### PR TITLE
[WiP] Adds bulk actions for motions, users and so on

### DIFF
--- a/client/src/app/core/actions/agenda-item-action.ts
+++ b/client/src/app/core/actions/agenda-item-action.ts
@@ -1,4 +1,4 @@
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { HasMeetingId } from 'app/shared/models/base/has-meeting-id';
 import { Identifiable } from 'app/shared/models/base/identifiable';
 import { BaseSortPayload } from './common/base-sort-payload';
@@ -10,12 +10,13 @@ export namespace AgendaItemAction {
     export const DELETE = 'agenda_item.delete';
     export const SORT = 'agenda_item.sort';
     export const NUMBERING = 'agenda_item.numbering';
+    export const ASSIGN = 'agenda_item.assign';
 
     interface OptionalPayload {
         item_number?: string;
         comment?: string;
         closed?: boolean;
-        type?: AgendaItemVisibility;
+        type?: AgendaItemType;
         duration?: number; // in seconds
         weight?: number;
         tag_ids?: Id[];
@@ -30,6 +31,8 @@ export namespace AgendaItemAction {
     }
 
     export interface UpdatePayload extends Identifiable, OptionalPayload {}
+    export interface DeletePayload extends Identifiable {}
+
     export interface AssignPayload extends HasMeetingId {
         ids: Id[];
         parent_id: Id;

--- a/client/src/app/core/actions/common/agenda-item-creation-payload.ts
+++ b/client/src/app/core/actions/common/agenda-item-creation-payload.ts
@@ -1,9 +1,9 @@
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 
 export interface AgendaItemCreationPayload {
     // Non-model fields for customizing the agenda item creation, optional
     agenda_create?: boolean;
-    agenda_type?: AgendaItemVisibility;
+    agenda_type?: AgendaItemType;
     agenda_parent_id?: number;
     agenda_comment?: string;
     agenda_duration?: number;

--- a/client/src/app/core/actions/meeting-action.ts
+++ b/client/src/app/core/actions/meeting-action.ts
@@ -1,4 +1,4 @@
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { Identifiable } from 'app/shared/models/base/identifiable';
 import { Id, UnsafeHtml } from '../definitions/key-types';
 
@@ -77,7 +77,7 @@ export namespace MeetingAction {
         agenda_number_prefix?: string;
         agenda_numeral_system?: string;
         agenda_item_creation?: string;
-        agenda_new_items_default_visibility?: AgendaItemVisibility;
+        agenda_new_items_default_visibility?: AgendaItemType;
         agenda_show_internal_items_on_projector?: boolean;
 
         // List of speakers

--- a/client/src/app/core/repositories/agenda/agenda-item-repository.service.ts
+++ b/client/src/app/core/repositories/agenda/agenda-item-repository.service.ts
@@ -4,7 +4,7 @@ import { AgendaItemAction } from 'app/core/actions/agenda-item-action';
 import { DEFAULT_FIELDSET, Fieldsets } from 'app/core/core-services/model-request-builder.service';
 import { MeetingSettingsService } from 'app/core/ui-services/meeting-settings.service';
 import { TreeIdNode } from 'app/core/ui-services/tree.service';
-import { AgendaItem } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItem, AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { Identifiable } from 'app/shared/models/base/identifiable';
 import { HasAgendaItem, ViewAgendaItem } from 'app/site/agenda/models/view-agenda-item';
 import { BaseViewModel } from 'app/site/base/base-view-model';
@@ -177,5 +177,25 @@ export class AgendaItemRepositoryService extends BaseRepositoryWithActiveMeeting
             }
         });
         return duration;
+    }
+
+    public bulkOpenItems(items: ViewAgendaItem[]): Promise<void> {
+        const payload: AgendaItemAction.UpdatePayload[] = items.map(item => ({ closed: false, id: item.id }));
+        return this.sendBulkActionToBackend(AgendaItemAction.UPDATE, payload);
+    }
+
+    public bulkCloseItems(items: ViewAgendaItem[]): Promise<void> {
+        const payload: AgendaItemAction.UpdatePayload[] = items.map(item => ({ closed: true, id: item.id }));
+        return this.sendBulkActionToBackend(AgendaItemAction.UPDATE, payload);
+    }
+
+    public bulkSetAgendaType(items: ViewAgendaItem[], agendaType: AgendaItemType): Promise<void> {
+        const payload: AgendaItemAction.UpdatePayload[] = items.map(item => ({ id: item.id, type: agendaType }));
+        return this.sendBulkActionToBackend(AgendaItemAction.UPDATE, payload);
+    }
+
+    public bulkRemoveItemsFromAgenda(items: ViewAgendaItem[]): Promise<void> {
+        const payload: AgendaItemAction.DeletePayload[] = items.map(item => ({ id: item.id }));
+        return this.sendBulkActionToBackend(AgendaItemAction.DELETE, payload);
     }
 }

--- a/client/src/app/core/repositories/base-repository.ts
+++ b/client/src/app/core/repositories/base-repository.ts
@@ -336,8 +336,9 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         });
     }
 
-    protected raiseError = (errorMessage: string | Error) => {
-        this.repositoryServiceCollector.errorService.showError(errorMessage);
+    protected raiseError = (error: string | Error) => {
+        this.repositoryServiceCollector.errorService.showError(error);
+        throw error;
     };
 
     protected async sendActionToBackend(action: string, payload: any): Promise<any> {

--- a/client/src/app/core/repositories/event-management/meeting-settings-definition.ts
+++ b/client/src/app/core/repositories/event-management/meeting-settings-definition.ts
@@ -2,7 +2,7 @@ import { ValidatorFn, Validators } from '@angular/forms';
 
 import dedent from 'ts-dedent';
 
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { AssignmentPollMethod } from 'app/shared/models/assignments/assignment-poll';
 import { Settings } from 'app/shared/models/event-management/meeting';
 import { MotionWorkflow } from 'app/shared/models/motions/motion-workflow';
@@ -280,12 +280,12 @@ export const meetingSettings: SettingsGroup[] = [
                     {
                         key: 'agenda_new_items_default_visibility',
                         label: 'Default visibility for new agenda items (except topics)',
-                        default: AgendaItemVisibility.internal,
+                        default: AgendaItemType.internal,
                         type: 'choice',
                         choices: {
-                            'Public item': AgendaItemVisibility.common,
-                            'Internal item': AgendaItemVisibility.internal,
-                            'Hidden item': AgendaItemVisibility.hidden
+                            'Public item': AgendaItemType.common,
+                            'Internal item': AgendaItemType.internal,
+                            'Hidden item': AgendaItemType.hidden
                         }
                     },
                     {

--- a/client/src/app/core/repositories/motions/motion-block-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-block-repository.service.ts
@@ -33,13 +33,13 @@ export class MotionBlockRepositoryService extends BaseIsAgendaItemAndListOfSpeak
     }
 
     public create(partialModel: Partial<MotionBlockAction.CreatePayload>): Promise<Identifiable> {
-        const payload: MotionBlockAction.CreatePayload = {
-            meeting_id: this.activeMeetingIdService.meetingId,
-            title: partialModel.title,
-            internal: partialModel.internal,
-            ...createAgendaItem(partialModel)
-        };
+        const payload: MotionBlockAction.CreatePayload = this.getCreatePayload(partialModel);
         return this.sendActionToBackend(MotionBlockAction.CREATE, payload);
+    }
+
+    public bulkCreate(motionBlocks: Partial<MotionBlock>[]): Promise<Identifiable[]> {
+        const payload: MotionBlockAction.CreatePayload[] = motionBlocks.map(block => this.getCreatePayload(block));
+        return this.sendBulkActionToBackend(MotionBlockAction.CREATE, payload);
     }
 
     public update(update: Partial<MotionBlock>, viewModel: ViewMotionBlock): Promise<void> {
@@ -115,5 +115,14 @@ export class MotionBlockRepositoryService extends BaseIsAgendaItemAndListOfSpeak
         this.setSortFunction((a: ViewMotionBlock, b: ViewMotionBlock) => {
             return this.languageCollator.compare(a.title, b.title);
         });
+    }
+
+    private getCreatePayload(partialModel: Partial<MotionBlockAction.CreatePayload>): MotionBlockAction.CreatePayload {
+        return {
+            meeting_id: this.activeMeetingIdService.meetingId,
+            title: partialModel.title,
+            internal: partialModel.internal,
+            ...createAgendaItem(partialModel)
+        };
     }
 }

--- a/client/src/app/core/repositories/motions/motion-category-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-category-repository.service.ts
@@ -38,13 +38,15 @@ export class MotionCategoryRepositoryService
     }
 
     public create(partialCategory: Partial<MotionCategory>): Promise<Identifiable> {
-        const payload: MotionCategoryAction.CreatePayload = {
-            meeting_id: this.activeMeetingIdService.meetingId,
-            name: partialCategory.name,
-            prefix: !!partialCategory.prefix ? partialCategory.prefix : null, // "" -> null
-            parent_id: partialCategory.parent_id
-        };
+        const payload: MotionCategoryAction.CreatePayload = this.getCreatePayload(partialCategory);
         return this.sendActionToBackend(MotionCategoryAction.CREATE, payload);
+    }
+
+    public bulkCreate(categories: Partial<MotionCategoryAction.CreatePayload>[]): Promise<Identifiable[]> {
+        const payload: MotionCategoryAction.CreatePayload[] = categories.map(category =>
+            this.getCreatePayload(category)
+        );
+        return this.sendBulkActionToBackend(MotionCategoryAction.CREATE, payload);
     }
 
     public update(update: Partial<MotionCategory>, viewModel: ViewMotionCategory): Promise<void> {
@@ -120,6 +122,15 @@ export class MotionCategoryRepositoryService
             tree: data
         };
         return this.actions.sendRequest(MotionCategoryAction.SORT, payload);
+    }
+
+    private getCreatePayload(partialCategory: Partial<MotionCategory>): MotionCategoryAction.CreatePayload {
+        return {
+            meeting_id: this.activeMeetingIdService.meetingId,
+            name: partialCategory.name,
+            prefix: partialCategory.prefix,
+            parent_id: partialCategory.parent_id
+        };
     }
 
     public getRequestToGetAllModels(): SimplifiedModelRequest {

--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -132,7 +132,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
         return this.sendActionToBackend(MotionAction.CREATE, payload);
     }
 
-    public update(update: Partial<Motion>, viewModel: ViewMotion): Promise<void> {
+    public update(update: Partial<MotionAction.UpdatePayload>, viewModel: ViewMotion): Promise<void> {
         const payload: MotionAction.UpdatePayload = {
             id: viewModel.id,
             number: update.number,
@@ -144,7 +144,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
         return this.sendActionToBackend(MotionAction.UPDATE, payload);
     }
 
-    private updateMetadata(update: Partial<MotionAction.UpdateMetadataPayload>, viewMotion: ViewMotion): Promise<void> {
+    public updateMetadata(update: Partial<MotionAction.UpdateMetadataPayload>, viewMotion: ViewMotion): Promise<void> {
         const payload: MotionAction.UpdateMetadataPayload = {
             id: viewMotion.id,
             attachment_ids: update.attachment_ids,
@@ -222,7 +222,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
     public getAgendaListTitle = (viewMotion: ViewMotion) => {
         const numberPrefix = this.agendaItemRepo.getItemNumberPrefix(viewMotion);
         // Append the verbose name only, if not the special format 'Motion <number>' is used.
-        let title;
+        let title: string;
         if (viewMotion.number) {
             title = `${numberPrefix}${this.translate.instant('Motion')} ${viewMotion.number} · ${viewMotion.title}`;
         } else {
@@ -306,45 +306,6 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
     }
 
     /**
-     * Set the state of motions in bulk
-     *
-     * @param viewMotions target motions
-     * @param stateId the number that indicates the state
-     */
-    public async setMultiState(viewMotions: ViewMotion[], stateId: number): Promise<void> {
-        const payload: MotionAction.SetStatePayload[] = viewMotions.map(motion => {
-            return { id: motion.id, state_id: stateId };
-        });
-        await this.sendBulkActionToBackend(MotionAction.UPDATE_METADATA, payload);
-    }
-
-    /**
-     * Set the motion blocks of motions in bulk
-     *
-     * @param viewMotions target motions
-     * @param motionblockId the number that indicates the motion block
-     */
-    public async setMultiMotionBlock(viewMotions: ViewMotion[], motionblockId: number): Promise<void> {
-        const payload: MotionAction.UpdateMetadataPayload[] = viewMotions.map(motion => {
-            return { id: motion.id, block_id: motionblockId };
-        });
-        await this.sendBulkActionToBackend(MotionAction.UPDATE_METADATA, payload);
-    }
-
-    /**
-     * Set the category of motions in bulk
-     *
-     * @param viewMotions target motions
-     * @param categoryId the number that indicates the category
-     */
-    public async setMultiCategory(viewMotions: ViewMotion[], categoryId: number): Promise<void> {
-        const payload: MotionAction.UpdateMetadataPayload[] = viewMotions.map(motion => {
-            return { id: motion.id, category_id: categoryId };
-        });
-        await this.sendBulkActionToBackend(MotionAction.UPDATE_METADATA, payload);
-    }
-
-    /**
      * Set the category of a motion
      *
      * @param viewMotion target motion
@@ -382,16 +343,6 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
             tag_ids.splice(tagIndex, 1);
         }
         return this.updateMetadata({ tag_ids: tag_ids }, viewMotion);
-    }
-
-    /**
-     * Sets the submitters by sending a request to the server,
-     *
-     * @param viewMotion The motion to change the submitters from
-     * @param submitterUserIds The submitters to set
-     */
-    public async setSubmitters(viewMotion: ViewMotion, submitterUserIds: number[]): Promise<void> {
-        return this.update({ submitter_ids: submitterUserIds }, viewMotion);
     }
 
     /**

--- a/client/src/app/core/repositories/motions/motion-workflow-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-workflow-repository.service.ts
@@ -6,6 +6,7 @@ import {
     Fieldsets,
     SimplifiedModelRequest
 } from 'app/core/core-services/model-request-builder.service';
+import { Id } from 'app/core/definitions/key-types';
 import { Identifiable } from 'app/shared/models/base/identifiable';
 import { MotionWorkflow } from 'app/shared/models/motions/motion-workflow';
 import { ViewMeeting } from 'app/site/event-management/models/view-meeting';
@@ -36,6 +37,16 @@ export class MotionWorkflowRepositoryService
         super(repositoryServiceCollector, MotionWorkflow);
     }
 
+    public getFieldsets(): Fieldsets<MotionWorkflow> {
+        const nameFields: (keyof MotionWorkflow)[] = ['name'];
+        const listFields: (keyof MotionWorkflow)[] = nameFields;
+        return {
+            [DEFAULT_FIELDSET]: listFields,
+            name: nameFields,
+            list: listFields
+        };
+    }
+
     public getTitle = (viewMotionWorkflow: ViewMotionWorkflow) => {
         return viewMotionWorkflow.name;
     };
@@ -48,6 +59,7 @@ export class MotionWorkflowRepositoryService
      * Returns all workflowStates that cover the list of viewMotions given
      *
      * @param motions The motions to get the workflows from
+     *
      * @returns The workflow states to the given motion
      */
     public getWorkflowStatesForMotions(motions: ViewMotion[]): ViewMotionState[] {
@@ -62,14 +74,8 @@ export class MotionWorkflowRepositoryService
         return states;
     }
 
-    public getFieldsets(): Fieldsets<MotionWorkflow> {
-        const nameFields: (keyof MotionWorkflow)[] = ['name'];
-        const listFields: (keyof MotionWorkflow)[] = nameFields;
-        return {
-            [DEFAULT_FIELDSET]: listFields,
-            name: nameFields,
-            list: listFields
-        };
+    public getWorkflowByStateId(stateId: Id): ViewMotionWorkflow {
+        return this.getViewModelList().find(workflow => workflow.state_ids.includes(stateId));
     }
 
     public create(partialModel: Partial<MotionWorkflow>): Promise<Identifiable> {

--- a/client/src/app/core/repositories/tags/tag-repository.service.ts
+++ b/client/src/app/core/repositories/tags/tag-repository.service.ts
@@ -28,11 +28,13 @@ export class TagRepositoryService extends BaseRepositoryWithActiveMeeting<ViewTa
     }
 
     public async create(partialTag: Partial<Tag>): Promise<Identifiable> {
-        const payload: TagAction.CreatePayload = {
-            name: partialTag.name,
-            meeting_id: this.activeMeetingIdService.meetingId
-        };
+        const payload: TagAction.CreatePayload = this.getCreatePayload(partialTag);
         return this.sendActionToBackend(TagAction.CREATE, payload);
+    }
+
+    public bulkCreate(tags: Partial<Tag>[]): Promise<Identifiable[]> {
+        const payload: TagAction.CreatePayload[] = tags.map(tag => this.getCreatePayload(tag));
+        return this.sendBulkActionToBackend(TagAction.CREATE, payload);
     }
 
     public async update(update: Partial<Tag>, viewModel: ViewTag): Promise<void> {
@@ -68,5 +70,12 @@ export class TagRepositoryService extends BaseRepositoryWithActiveMeeting<ViewTa
         this.setSortFunction((a: ViewTag, b: ViewTag) => {
             return this.languageCollator.compare(a.name, b.name);
         });
+    }
+
+    private getCreatePayload(partialTag: Partial<Tag>): TagAction.CreatePayload {
+        return {
+            name: partialTag.name,
+            meeting_id: this.activeMeetingIdService.meetingId
+        };
     }
 }

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -485,21 +485,46 @@ export class UserRepositoryService
         return this.sendBulkActionToBackend(UserAction.UPDATE_TEMPORARY, payload);
     }
 
-    /**
-     * Alters groups of all given users. Either adds or removes the given groups.
-     *
-     * @param users Affected users
-     * @param action add or remove the groups
-     * @param groupIds All group ids to add or remove
-     */
-    public async bulkAlterGroups(users: ViewUser[], action: 'add' | 'remove', groupIds: Id[]): Promise<void> {
+    public bulkAddGroupsToUsers(users: ViewUser[], groupIds: Id[]): Promise<void> {
         this.preventAlterationOnDemoUsers(users);
-        /* await this.httpService.post('/rest/users/user/bulk_alter_groups/', {
-            user_ids: users.map(user => user.id),
-            action: action,
-            group_ids: groupIds
-        }); */
-        throw new Error('TODO');
+        const payload: UserAction.UpdatePayload[] = users.map(user => {
+            groupIds = groupIds.concat(user.group_ids());
+            return {
+                id: user.id,
+                group_ids: groupIds.filter((groupId, index, self) => self.indexOf(groupId) === index)
+            };
+        });
+        return this.sendBulkActionToBackend(UserAction.UPDATE, payload);
+    }
+
+    public bulkRemoveGroupsFromUsers(users: ViewUser[], groupIds: Id[]): Promise<void> {
+        this.preventAlterationOnDemoUsers(users);
+        const payload: UserAction.UpdatePayload[] = users.map(user => ({
+            id: user.id,
+            group_ids: user.group_ids().filter(groupId => !groupIds.includes(groupId))
+        }));
+        return this.sendBulkActionToBackend(UserAction.UPDATE, payload);
+    }
+
+    public bulkAddGroupsToTemporaryUsers(users: ViewUser[], groupIds: Id[]): Promise<void> {
+        this.preventAlterationOnDemoUsers(users);
+        const payload: UserAction.UpdateTemporaryPayload[] = users.map(user => {
+            groupIds = groupIds.concat(user.group_ids());
+            return {
+                id: user.id,
+                group_ids: groupIds.filter((groupId, index, self) => self.indexOf(groupId) === index)
+            };
+        });
+        return this.sendBulkActionToBackend(UserAction.UPDATE_TEMPORARY, payload);
+    }
+
+    public bulkRemoveGroupsFromTemporaryUsers(users: ViewUser[], groupIds: Id[]): Promise<void> {
+        this.preventAlterationOnDemoUsers(users);
+        const payload: UserAction.UpdateTemporaryPayload[] = users.map(user => ({
+            id: user.id,
+            group_ids: user.group_ids().filter(groupId => !groupIds.includes(groupId))
+        }));
+        return this.sendBulkActionToBackend(UserAction.UPDATE_TEMPORARY, payload);
     }
 
     /**

--- a/client/src/app/core/ui-services/base-filter-list.service.ts
+++ b/client/src/app/core/ui-services/base-filter-list.service.ts
@@ -454,13 +454,14 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
     }
 
     /**
-     * Checks if a given ViewBaseModel passes the filter.
+     * Checks if a given ViewBaseModel passes a filter.
      *
      * @param item Usually a view model
      * @param filter The filter to check
      * @returns true if the item is to be displayed according to the filter
      */
     private checkIncluded(item: V, filter: OsFilter): boolean {
+        console.log('checkIncluded', item, filter);
         const nullFilter = filter.options.find(
             option => typeof option !== 'string' && option.isActive && option.condition === null
         );

--- a/client/src/app/core/ui-services/choice.service.ts
+++ b/client/src/app/core/ui-services/choice.service.ts
@@ -29,7 +29,7 @@ export class ChoiceService {
      *  The answer.items will then be an array.
      * @param actions optional strings for buttons replacing the regular confirmation.
      * The answer.action will reflect the button selected
-     * @param clearChoice A string for an extra, visually slightly separated
+     * @param clearChoiceOption A string for an extra, visually slightly separated
      * choice for 'explicitly set an empty selection'. The answer's action may
      * have this string's value
      * @returns an answer {@link ChoiceAnswer}
@@ -39,7 +39,7 @@ export class ChoiceService {
         choices?: Observable<Displayable[]> | Displayable[],
         multiSelect: boolean = false,
         actions?: string[],
-        clearChoice?: string
+        clearChoiceOption?: string
     ): Promise<ChoiceAnswer> {
         const dialogRef = this.dialog.open(ChoiceDialogComponent, {
             ...infoDialogSettings,
@@ -48,7 +48,7 @@ export class ChoiceService {
                 choices: choices,
                 multiSelect: multiSelect,
                 actionButtons: actions,
-                clearChoice: clearChoice
+                clearChoiceOption: clearChoiceOption
             }
         });
         return dialogRef.afterClosed().toPromise();

--- a/client/src/app/shared/components/agenda-content-object-form/agenda-content-object-form.component.ts
+++ b/client/src/app/shared/components/agenda-content-object-form/agenda-content-object-form.component.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject } from 'rxjs';
 import { Permission } from 'app/core/core-services/permission';
 import { AgendaItemRepositoryService } from 'app/core/repositories/agenda/agenda-item-repository.service';
 import { MeetingSettingsService } from 'app/core/ui-services/meeting-settings.service';
-import { ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
 import { ViewAgendaItem } from 'app/site/agenda/models/view-agenda-item';
 
 @Component({
@@ -27,7 +27,7 @@ export class AgendaContentObjectFormComponent implements OnInit {
     /**
      * Determine visibility states for the agenda that will be created implicitly
      */
-    public ItemVisibilityChoices = ItemVisibilityChoices;
+    public ItemVisibilityChoices = ItemTypeChoices;
 
     /**
      * Subject for agenda items

--- a/client/src/app/shared/components/charts/charts.component.ts
+++ b/client/src/app/shared/components/charts/charts.component.ts
@@ -68,7 +68,7 @@ export class ChartsComponent extends BaseComponent {
      * The general data for the chart.
      * This is only needed for `type == 'bar' || 'line'`
      */
-    public chartData: ChartData;
+    public chartData: ChartData | number[];
 
     @Input()
     public set data(inputData: ChartData) {

--- a/client/src/app/shared/components/choice-dialog/choice-dialog.component.html
+++ b/client/src/app/shared/components/choice-dialog/choice-dialog.component.html
@@ -40,8 +40,8 @@
         </div>
 
         <!-- Clear choice button -->
-        <button mat-button *ngIf="data.clearChoice" (click)="closeDialog(true, data.clearChoice)">
-            <span>{{ data.clearChoice }}</span>
+        <button mat-button *ngIf="data.clearChoiceOption" (click)="closeDialog(true, data.clearChoiceOption)">
+            <span>{{ data.clearChoiceOption }}</span>
         </button>
 
         <!-- Cancel -->

--- a/client/src/app/shared/components/list-view-table/list-view-table.component.html
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.html
@@ -1,5 +1,5 @@
 <mat-drawer-container class="list-view-frame" *ngIf="columns && columnSet">
-    <div class="list-view-table-wrapper">
+    <div class="list-view-table-wrapper" (keydown)="onKeyDown($event)" (keyup)="onKeyUp($event)">
         <os-sort-filter-bar
             class="sort-filter-bar"
             *ngIf="showFilterBar"

--- a/client/src/app/shared/components/list-view-table/list-view-table.component.ts
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.ts
@@ -260,6 +260,10 @@ export class ListViewTableComponent<V extends BaseViewModel | BaseProjectableVie
 
     public readonly permission = Permission;
 
+    private isHoldingShiftKey = false;
+
+    private previousSelectedRow: V = null;
+
     /**
      * Collect subsciptions
      */
@@ -569,10 +573,14 @@ export class ListViewTableComponent<V extends BaseViewModel | BaseProjectableVie
         if (this.multiSelect) {
             const clickedModel: V = event.row;
             const alreadySelected = this.dataSource.selection.isSelected(clickedModel);
+            if (this.isHoldingShiftKey) {
+                this.selectMultipleRows(clickedModel, this.previousSelectedRow);
+            }
             if (alreadySelected) {
                 this.dataSource.selection.deselect(clickedModel);
             } else {
                 this.dataSource.selection.select(clickedModel);
+                this.previousSelectedRow = clickedModel;
             }
         }
     }
@@ -653,6 +661,18 @@ export class ListViewTableComponent<V extends BaseViewModel | BaseProjectableVie
         this.inputValue = await this.store.get<string>(`query_${this.listStorageKey}`);
     }
 
+    public onKeyDown(keyEvent: KeyboardEvent): void {
+        if (keyEvent.key === 'Shift') {
+            this.isHoldingShiftKey = true;
+        }
+    }
+
+    public onKeyUp(keyEvent: KeyboardEvent): void {
+        if (keyEvent.key === 'Shift') {
+            this.isHoldingShiftKey = false;
+        }
+    }
+
     /**
      * Automatically scrolls to a stored scroll position
      */
@@ -669,6 +689,28 @@ export class ListViewTableComponent<V extends BaseViewModel | BaseProjectableVie
     private changeRowHeight(): void {
         if (this.vScrollFixed > 0) {
             document.documentElement.style.setProperty('--pbl-height', this.vScrollFixed + 'px');
+        }
+    }
+
+    /**
+     * Selects multiple rows between `firstRow` and `secondRow`.
+     * The indices of the two rows are compared to each other to
+     * get a subarray beginning at the lower index up to the higher one.
+     *
+     * @param firstRow The first one of two selected rows.
+     * @param secondRow The second one of two selected rows.
+     */
+    private selectMultipleRows(firstRow: V, secondRow: V): void {
+        const sourceArray = this.dataSource.source;
+        const index = sourceArray.findIndex(row => row.id === firstRow.id);
+        const previousIndex = sourceArray.findIndex(row => row.id === secondRow.id);
+        if (index === previousIndex) {
+            return;
+        }
+        if (index > previousIndex) {
+            this.dataSource.selection.select(...sourceArray.slice(previousIndex, index));
+        } else {
+            this.dataSource.selection.select(...sourceArray.slice(index, previousIndex));
         }
     }
 

--- a/client/src/app/shared/directives/perms.directive.ts
+++ b/client/src/app/shared/directives/perms.directive.ts
@@ -25,7 +25,7 @@ export class PermsDirective implements OnInit, OnDestroy {
      * Holds the value of the last permission check. Therefore one can check, if the
      * permission has changes, to save unnecessary view updates, if not.
      */
-    private lastPermissionCheckResult = false;
+    private lastPermissionCheckResult: boolean | null = null; // take null to also catch a first "false" update
 
     /**
      * Alternative to the permissions. Used in special case where a combination

--- a/client/src/app/shared/models/agenda/agenda-item.ts
+++ b/client/src/app/shared/models/agenda/agenda-item.ts
@@ -4,20 +4,19 @@ import { HasMeetingId } from '../base/has-meeting-id';
 import { HasProjectableIds } from '../base/has-projectable-ids';
 import { HasTagIds } from '../base/has-tag-ids';
 
-export enum AgendaItemVisibility {
+export enum AgendaItemType {
     common = 'common',
     internal = 'internal',
     hidden = 'hidden'
 }
 
 /**
- * Determine visibility states for agenda items
- * Coming from "ConfigVariables" property "agenda_hide_internal_items_on_projector"
+ * Determine type for agenda items
  */
-export const ItemVisibilityChoices = [
-    { key: AgendaItemVisibility.common, name: 'public', csvName: '' },
-    { key: AgendaItemVisibility.internal, name: 'internal', csvName: 'internal' },
-    { key: AgendaItemVisibility.hidden, name: 'hidden', csvName: 'hidden' }
+export const ItemTypeChoices = [
+    { key: AgendaItemType.common, name: 'public', csvName: '' },
+    { key: AgendaItemType.internal, name: 'internal', csvName: 'internal' },
+    { key: AgendaItemType.hidden, name: 'hidden', csvName: 'hidden' }
 ];
 
 /**
@@ -31,7 +30,7 @@ export class AgendaItem extends BaseModel<AgendaItem> {
     public item_number: string;
     public comment: string;
     public closed: boolean;
-    public type: AgendaItemVisibility;
+    public type: AgendaItemType;
     public is_hidden: boolean;
     public is_internal: boolean;
     public duration: number; // in seconds

--- a/client/src/app/shared/models/event-management/meeting.ts
+++ b/client/src/app/shared/models/event-management/meeting.ts
@@ -1,4 +1,4 @@
-import { AgendaItemVisibility } from '../agenda/agenda-item';
+import { AgendaItemType } from '../agenda/agenda-item';
 import { Id } from 'app/core/definitions/key-types';
 import { ChangeRecoMode, LineNumberingMode } from 'app/site/motions/motions.constants';
 import { AssignmentPollMethod, AssignmentPollPercentBase } from '../assignments/assignment-poll';
@@ -61,7 +61,7 @@ export interface Settings {
     agenda_number_prefix: string;
     agenda_numeral_system: string;
     agenda_item_creation: AgendaItemCreation;
-    agenda_new_items_default_visibility: AgendaItemVisibility;
+    agenda_new_items_default_visibility: AgendaItemType;
     agenda_show_internal_items_on_projector: boolean;
 
     // List of speakers

--- a/client/src/app/shared/models/poll/base-poll.ts
+++ b/client/src/app/shared/models/poll/base-poll.ts
@@ -1,4 +1,5 @@
 import { Id } from 'app/core/definitions/key-types';
+import { BasePollData } from 'app/site/polls/services/poll.service';
 import { BaseDecimalModel } from '../base/base-decimal-model';
 import { BaseOption } from './base-option';
 import { HasMeetingId } from '../base/has-meeting-id';
@@ -135,4 +136,5 @@ export interface BasePoll<
     PM extends string = string,
     PB extends string = string
 > extends HasMeetingId,
-        HasProjectableIds {}
+        HasProjectableIds,
+        BasePollData<PM, PB> {}

--- a/client/src/app/shared/overload-js-functions.ts
+++ b/client/src/app/shared/overload-js-functions.ts
@@ -4,7 +4,7 @@ declare global {
      * TODO: Remove once flatMap made its way into official JS/TS (ES 2019?)
      */
     interface Array<T> {
-        flatMap(o: any): any[];
+        flatMap<U>(callbackFn: (currentValue: T, index: number, array: T[]) => U, thisArg?: any): U;
         intersect(a: T[]): T[];
         mapToObject(f: (item: T) => { [key: string]: any }): { [key: string]: any };
     }

--- a/client/src/app/site/agenda/components/agenda-item-info-dialog/agenda-item-info-dialog.component.ts
+++ b/client/src/app/site/agenda/components/agenda-item-info-dialog/agenda-item-info-dialog.component.ts
@@ -4,7 +4,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { TagRepositoryService } from 'app/core/repositories/tags/tag-repository.service';
 import { DurationService } from 'app/core/ui-services/duration.service';
-import { ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
 import { durationValidator } from 'app/shared/validators/custom-validators';
 import { ViewTag } from 'app/site/tags/models/view-tag';
 import { ViewAgendaItem } from '../../models/view-agenda-item';
@@ -26,7 +26,7 @@ export class AgendaItemInfoDialogComponent implements OnInit {
     /**
      * Hold item visibility
      */
-    public itemVisibility = ItemVisibilityChoices;
+    public itemVisibility = ItemTypeChoices;
 
     public tags: ViewTag[] = [];
 

--- a/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.html
@@ -189,13 +189,13 @@
         <mat-divider></mat-divider>
         <div *osPerms="permission.agendaItemCanManage">
             <!-- Close selected -->
-            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setClosedSelected(true)">
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="closeSelectedItems()">
                 <mat-icon>done</mat-icon>
                 <span>{{ 'Close' | translate }}</span>
             </button>
 
             <!-- Open selected -->
-            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setClosedSelected(false)">
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="openSelectedItems()">
                 <mat-icon>redo</mat-icon>
                 <span>{{ 'Open' | translate }}</span>
             </button>
@@ -203,19 +203,19 @@
             <mat-divider></mat-divider>
 
             <!-- Set multiple to public -->
-            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setAgendaType(1)">
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setAgendaType(AGENDA_TYPE_PUBLIC)">
                 <mat-icon>public</mat-icon>
                 <span>{{ 'Set public' | translate }}</span>
             </button>
 
             <!-- Set multiple to internal -->
-            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setAgendaType(2)">
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setAgendaType(AGENDA_TYPE_INTERNAL)">
                 <mat-icon>visibility</mat-icon>
                 <span>{{ 'Set internal' | translate }}</span>
             </button>
 
             <!-- Set multiple to hidden -->
-            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setAgendaType(3)">
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setAgendaType(AGENDA_TYPE_HIDDEN)">
                 <mat-icon>visibility_off</mat-icon>
                 <span>{{ 'Set hidden' | translate }}</span>
             </button>
@@ -259,13 +259,13 @@
             </button>
 
             <!-- Duplicate button -->
-            <button mat-menu-item (click)="duplicateTopic(item.contentObject)" *ngIf="isTopic(item.contentObject)">
+            <button mat-menu-item (click)="duplicateTopic(item)" *ngIf="isTopic(item.content_object)">
                 <mat-icon>file_copy</mat-icon>
                 <span>{{ 'Duplicate' | translate }}</span>
             </button>
 
             <!-- Delete Button -->
-            <button mat-menu-item (click)="removeFromAgenda(item)" *ngIf="!isTopic(item.contentObject)">
+            <button mat-menu-item (click)="removeFromAgenda(item)" *ngIf="!isTopic(item.content_object)">
                 <mat-icon>remove</mat-icon>
                 <span>{{ 'Remove from agenda' | translate }}</span>
             </button>
@@ -274,7 +274,7 @@
                 mat-menu-item
                 class="red-warning-text"
                 (click)="deleteTopic(item)"
-                *ngIf="isTopic(item.contentObject)"
+                *ngIf="isTopic(item.content_object)"
             >
                 <mat-icon>delete</mat-icon>
                 <span>{{ 'Delete' | translate }}</span>

--- a/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.ts
+++ b/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.ts
@@ -24,7 +24,7 @@ import { PromptService } from 'app/core/ui-services/prompt.service';
 import { ViewportService } from 'app/core/ui-services/viewport.service';
 import { ColumnRestriction } from 'app/shared/components/list-view-table/list-view-table.component';
 import { SPEAKER_BUTTON_FOLLOW } from 'app/shared/components/speaker-button/speaker-button.component';
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { infoDialogSettings } from 'app/shared/utils/dialog-settings';
 import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component.';
 import { isProjectable, ProjectorElementBuildDeskriptor } from 'app/site/base/projectable';
@@ -43,6 +43,10 @@ import { hasListOfSpeakers } from '../../models/view-list-of-speakers';
     styleUrls: ['./agenda-item-list.component.scss']
 })
 export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaItem> implements OnInit {
+    public readonly AGENDA_TYPE_PUBLIC = 1;
+    public readonly AGENDA_TYPE_INTERNAL = 2;
+    public readonly AGENDA_TYPE_HIDDEN = 3;
+
     /**
      * Show or hide the numbering button
      */
@@ -280,13 +284,7 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
         const content = this.translate.instant("All topics will be deleted and won't be accessible afterwards.");
         if (await this.promptService.open(title, content)) {
             try {
-                for (const item of this.selectedRows) {
-                    if (item.content_object instanceof ViewTopic) {
-                        await this.topicRepo.delete(item.content_object);
-                    } else {
-                        await this.repo.removeFromAgenda(item);
-                    }
-                }
+                await this.repo.bulkRemoveItemsFromAgenda(this.selectedRows);
             } catch (e) {
                 this.raiseError(e);
             }
@@ -294,16 +292,24 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
     }
 
     /**
-     * Sets multiple entries' open/closed state. Needs items in selectedRows, which
+     * Sets multiple entries' open state. Needs items in selectedRows, which
      * is only filled with any data in multiSelect mode
-     *
-     * @param closed true if the item is to be considered done
      */
-    public async setClosedSelected(closed: boolean): Promise<void> {
+    public async openSelectedItems(): Promise<void> {
         try {
-            for (const item of this.selectedRows) {
-                await this.repo.update({ closed: closed }, item);
-            }
+            await this.repo.bulkOpenItems(this.selectedRows);
+        } catch (e) {
+            this.raiseError(e);
+        }
+    }
+
+    /**
+     * Sets multiple entries' open state. Needs items in selectedRows, which
+     * is only filled with any data in multiSelect mode
+     */
+    public async closeSelectedItems(): Promise<void> {
+        try {
+            await this.repo.bulkCloseItems(this.selectedRows);
         } catch (e) {
             this.raiseError(e);
         }
@@ -312,14 +318,10 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
     /**
      * Sets multiple entries' agenda type. Needs items in selectedRows, which
      * is only filled with any data in multiSelect mode.
-     *
-     * @param visible true if the item is to be shown
      */
-    public async setAgendaType(agendaType: AgendaItemVisibility): Promise<void> {
+    public async setAgendaType(type: AgendaItemType): Promise<void> {
         try {
-            for (const item of this.selectedRows) {
-                await this.repo.update({ type: agendaType }, item).catch(this.raiseError);
-            }
+            await this.repo.bulkSetAgendaType(this.selectedRows, type);
         } catch (e) {
             this.raiseError(e);
         }
@@ -378,8 +380,8 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
      *
      * @param item The item to duplicte.
      */
-    public duplicateTopic(topic: ViewTopic): void {
-        this.topicRepo.duplicateTopic(topic);
+    public duplicateTopic(topicAgendaItem: ViewAgendaItem): void {
+        this.topicRepo.duplicateTopic(topicAgendaItem);
     }
 
     /**
@@ -388,11 +390,7 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
      * @param selectedItems All selected items.
      */
     public duplicateMultipleTopics(selectedItems: ViewAgendaItem[]): void {
-        for (const item of selectedItems) {
-            if (this.isTopic(item.content_object)) {
-                this.duplicateTopic(item.content_object);
-            }
-        }
+        this.topicRepo.duplicateMultipleTopics(selectedItems.filter(item => this.isTopic(item.content_object)));
     }
 
     /**

--- a/client/src/app/site/agenda/components/agenda-sort/agenda-sort.component.ts
+++ b/client/src/app/site/agenda/components/agenda-sort/agenda-sort.component.ts
@@ -6,7 +6,8 @@ import { SimplifiedModelRequest } from 'app/core/core-services/model-request-bui
 import { AgendaItemRepositoryService } from 'app/core/repositories/agenda/agenda-item-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { PromptService } from 'app/core/ui-services/prompt.service';
-import { AgendaItemVisibility, ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { BaseSortTreeComponent, SortTreeFilterOption } from 'app/site/base/components/base-sort-tree.component';
 import { ViewMeeting } from 'app/site/event-management/models/view-meeting';
 import { ViewAgendaItem } from '../../models/view-agenda-item';
@@ -30,8 +31,8 @@ export class AgendaSortComponent extends BaseSortTreeComponent<ViewAgendaItem> i
      * Adds the property `state` to identify if the option is marked as active.
      * When reset the filters, the option `state` will be set to `false`.
      */
-    public filterOptions: SortTreeFilterOption[] = ItemVisibilityChoices.map(item => {
-        return { label: item.name, id: this.getNumericValueForAgendaItemVisibility(item.key), state: false };
+    public filterOptions: SortTreeFilterOption[] = ItemTypeChoices.map(item => {
+        return { label: item.name, id: this.getNumericValueForAgendaItemType(item.key), state: false };
     });
 
     /**
@@ -104,7 +105,7 @@ export class AgendaSortComponent extends BaseSortTreeComponent<ViewAgendaItem> i
         const filter = this.activeFilters.subscribe((value: number[]) => {
             this.hasActiveFilter = value.length === 0 ? false : true;
             this.changeFilter.emit((item: ViewAgendaItem): boolean => {
-                return !(value.includes(this.getNumericValueForAgendaItemVisibility(item.type)) || value.length === 0);
+                return !(value.includes(this.getNumericValueForAgendaItemType(item.type)) || value.length === 0);
             });
         });
         this.subscriptions.push(filter);
@@ -156,13 +157,13 @@ export class AgendaSortComponent extends BaseSortTreeComponent<ViewAgendaItem> i
         }
     }
 
-    private getNumericValueForAgendaItemVisibility(visibility: AgendaItemVisibility): number {
-        switch (visibility) {
-            case AgendaItemVisibility.common:
+    private getNumericValueForAgendaItemType(type: AgendaItemType): number {
+        switch (type) {
+            case AgendaItemType.common:
                 return 1;
-            case AgendaItemVisibility.hidden:
+            case AgendaItemType.hidden:
                 return 3;
-            case AgendaItemVisibility.internal:
+            case AgendaItemType.internal:
                 return 2;
         }
     }

--- a/client/src/app/site/agenda/models/view-agenda-item.ts
+++ b/client/src/app/site/agenda/models/view-agenda-item.ts
@@ -1,5 +1,5 @@
 import { AgendaListTitle } from 'app/core/repositories/agenda/agenda-item-repository.service';
-import { AgendaItem, ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItem, ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
 import { HasAgendaItemId } from 'app/shared/models/base/has-agenda-item-id';
 import { BaseProjectableViewModel } from 'app/site/base/base-projectable-view-model';
 import { BaseViewModel } from 'app/site/base/base-view-model';
@@ -46,7 +46,7 @@ export class ViewAgendaItem extends BaseProjectableViewModel<AgendaItem> {
         if (!this.type) {
             return '';
         }
-        const type = ItemVisibilityChoices.find(choice => choice.key === this.type);
+        const type = ItemTypeChoices.find(choice => choice.key === this.type);
         return type ? type.name : '';
     }
 
@@ -67,7 +67,7 @@ export class ViewAgendaItem extends BaseProjectableViewModel<AgendaItem> {
         if (!this.type) {
             return '';
         }
-        const type = ItemVisibilityChoices.find(choice => choice.key === this.type);
+        const type = ItemTypeChoices.find(choice => choice.key === this.type);
         return type ? type.csvName : '';
     }
 }

--- a/client/src/app/site/agenda/services/agenda-filter-list.service.ts
+++ b/client/src/app/site/agenda/services/agenda-filter-list.service.ts
@@ -6,8 +6,11 @@ import { HistoryService } from 'app/core/core-services/history.service';
 import { StorageService } from 'app/core/core-services/storage.service';
 import { TagRepositoryService } from 'app/core/repositories/tags/tag-repository.service';
 import { BaseFilterListService, OsFilter, OsFilterOption } from 'app/core/ui-services/base-filter-list.service';
-import { ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
+import { Assignment } from 'app/shared/models/assignments/assignment';
 import { Motion } from 'app/shared/models/motions/motion';
+import { MotionBlock } from 'app/shared/models/motions/motion-block';
+import { Topic } from 'app/shared/models/topics/topic';
 import { ViewAgendaItem } from '../models/view-agenda-item';
 
 /**
@@ -69,9 +72,9 @@ export class AgendaFilterListService extends BaseFilterListService<ViewAgendaIte
                 property: 'collection',
                 options: [
                     { label: this.translate.instant('Motions'), condition: Motion.COLLECTION },
-                    { label: this.translate.instant('Topics'), condition: 'topics/topic' },
-                    { label: this.translate.instant('Motion blocks'), condition: 'motions/motion-block' },
-                    { label: this.translate.instant('Elections'), condition: 'assignments/assignment' }
+                    { label: this.translate.instant('Topics'), condition: Topic.COLLECTION },
+                    { label: this.translate.instant('Motion blocks'), condition: MotionBlock.COLLECTION },
+                    { label: this.translate.instant('Elections'), condition: Assignment.COLLECTION }
                 ]
             }
         ];
@@ -83,7 +86,7 @@ export class AgendaFilterListService extends BaseFilterListService<ViewAgendaIte
      * @returns a list of choices to filter from
      */
     private createVisibilityFilterOptions(): OsFilterOption[] {
-        return ItemVisibilityChoices.map(choice => ({
+        return ItemTypeChoices.map(choice => ({
             condition: choice.key,
             label: choice.name
         }));

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -229,16 +229,25 @@
 <!-- Menu for Mediafiles -->
 <mat-menu #mediafilesMenu="matMenu">
     <div *ngIf="!isMultiSelect">
-        <button mat-menu-item (click)="downloadMultiple()">
-            <mat-icon>cloud_download</mat-icon>
-            <span>{{ 'Download folder' | translate }}</span>
-        </button>
         <button mat-menu-item (click)="toggleMultiSelect()">
             <mat-icon>library_add</mat-icon>
             <span>{{ 'Multiselect' | translate }}</span>
         </button>
+        <button mat-menu-item (click)="downloadMultiple()">
+            <mat-icon>cloud_download</mat-icon>
+            <span>{{ 'Download folder' | translate }}</span>
+        </button>
     </div>
     <div *ngIf="isMultiSelect">
+        <button mat-menu-item (click)="selectAll()">
+            <mat-icon>done_all</mat-icon>
+            <span>{{ 'Select all' | translate }}</span>
+        </button>
+        <button mat-menu-item [disabled]="!selectedRows.length" (click)="deselectAll()">
+            <mat-icon>clear</mat-icon>
+            <span>{{ 'Deselect all' | translate }}</span>
+        </button>
+        <mat-divider *osPerms="permission.mediafilesCanManage"></mat-divider>
         <button mat-menu-item [disabled]="!selectedRows.length" (click)="downloadMultiple(selectedRows)">
             <mat-icon>cloud_download</mat-icon>
             <span>{{ 'Download' | translate }}</span>
@@ -253,15 +262,6 @@
             <span>{{ 'Move' | translate }}</span>
         </button>
         <mat-divider></mat-divider>
-        <button mat-menu-item (click)="selectAll()">
-            <mat-icon>done_all</mat-icon>
-            <span>{{ 'Select all' | translate }}</span>
-        </button>
-        <button mat-menu-item [disabled]="!selectedRows.length" (click)="deselectAll()">
-            <mat-icon>clear</mat-icon>
-            <span>{{ 'Deselect all' | translate }}</span>
-        </button>
-        <mat-divider *osPerms="permission.mediafilesCanManage"></mat-divider>
         <button
             mat-menu-item
             *osPerms="permission.mediafilesCanManage"

--- a/client/src/app/site/motions/models/import-create-motion.ts
+++ b/client/src/app/site/motions/models/import-create-motion.ts
@@ -1,3 +1,4 @@
+import { Id } from 'app/core/definitions/key-types';
 import { CreateMotion } from './create-motion';
 
 /**
@@ -124,7 +125,7 @@ export class ImportCreateMotion extends CreateMotion {
      */
     public solveTags(tags: CsvMapping[]): number {
         let open = 0;
-        const ids: number[] = [];
+        const ids: Id[] = [];
         for (const tag of this.csvTags) {
             if (tag.id) {
                 ids.push(tag.id);

--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -4,7 +4,7 @@ import { Id } from 'app/core/definitions/key-types';
 import { DiffLinesInParagraph } from 'app/core/ui-services/diff.service';
 import { MeetingSettingsService } from 'app/core/ui-services/meeting-settings.service';
 import { SearchProperty, SearchRepresentation } from 'app/core/ui-services/search.service';
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { HasReferencedMotionInRecommendationExtensionIds, Motion } from 'app/shared/models/motions/motion';
 import { HasAgendaItem } from 'app/site/agenda/models/view-agenda-item';
 import { HasListOfSpeakers } from 'app/site/agenda/models/view-list-of-speakers';
@@ -56,7 +56,7 @@ export class ViewMotion extends BaseProjectableViewModel<Motion> {
         return this.number ? this.number : this.title;
     }
 
-    public get agenda_type(): AgendaItemVisibility | null {
+    public get agenda_type(): AgendaItemType | null {
         return this.agenda_item ? this.agenda_item.type : null;
     }
 

--- a/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
+++ b/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
@@ -13,7 +13,7 @@ import { MotionRepositoryService } from 'app/core/repositories/motions/motion-re
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { LinenumberingService } from 'app/core/ui-services/linenumbering.service';
 import { OverlayService } from 'app/core/ui-services/overlay.service';
-import { ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
 import { largeDialogSettings } from 'app/shared/utils/dialog-settings';
 import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component.';
 import { ViewMeeting } from 'app/site/event-management/models/view-meeting';
@@ -48,7 +48,7 @@ export class AmendmentListComponent extends BaseListViewComponent<ViewMotion> im
     /**
      * Hold item visibility
      */
-    public itemVisibility = ItemVisibilityChoices;
+    public itemVisibility = ItemTypeChoices;
 
     public showSequentialNumber: boolean;
 

--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.ts
@@ -13,7 +13,7 @@ import { AgendaItemRepositoryService } from 'app/core/repositories/agenda/agenda
 import { MotionBlockRepositoryService } from 'app/core/repositories/motions/motion-block-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { SPEAKER_BUTTON_FOLLOW } from 'app/shared/components/speaker-button/speaker-button.component';
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { infoDialogSettings } from 'app/shared/utils/dialog-settings';
 import { ViewAgendaItem } from 'app/site/agenda/models/view-agenda-item';
 import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component.';
@@ -49,7 +49,7 @@ export class MotionBlockListComponent extends BaseListViewComponent<ViewMotionBl
     /**
      * Determine the default agenda visibility
      */
-    public defaultVisibility = AgendaItemVisibility.internal;
+    public defaultVisibility = AgendaItemType.internal;
 
     /**
      * Defines the properties the `sort-filter-bar` can search for.

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -641,6 +641,9 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
                 {
                     idField: 'personal_note_ids'
                 }
+                // {
+                //     idField: 'motion_workflow_ids'
+                // }
             ]
         });
     }
@@ -699,6 +702,7 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
                 'category_id',
                 'lead_motion_id',
                 'comment_ids',
+                // 'workflow_id',
                 {
                     idField: 'change_recommendation_ids'
                 },
@@ -732,6 +736,7 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
                         },
                         GET_POSSIBLE_RECOMMENDATIONS
                     ]
+                    // fieldset: 'list'
                 },
                 'recommendation_id',
                 'tag_ids',
@@ -806,6 +811,11 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
             // When saving the changes, notify other users if they edit the same motion.
             // this.unsubscribeEditNotifications(MotionEditNotificationType.TYPE_SAVING_EDITING_MOTION);
         }
+    }
+
+    public getPossibleRecommendations(): ViewMotionState[] {
+        const allStates = this.motion.state?.workflow.states || [];
+        return allStates.filter(state => state.recommendation_label);
     }
 
     /**

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -114,7 +114,7 @@
 
                 <!-- Recommendation -->
                 <div
-                    *ngIf="motion.recommendation && motion.state.next_state_ids.length > 0"
+                    *ngIf="motion.recommendation && motion.state.next_state_ids.length"
                     class="ellipsis-overflow white spacer-top-3"
                 >
                     <mat-basic-chip class="bluegrey" [disabled]="true">

--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-list/workflow-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-list/workflow-list.component.ts
@@ -80,8 +80,7 @@ export class WorkflowListComponent extends BaseListViewComponent<ViewMotionWorkf
                 {
                     idField: 'motion_workflow_ids'
                 }
-            ],
-            fieldset: []
+            ]
         };
     }
 

--- a/client/src/app/site/motions/services/motion-filter-list.service.ts
+++ b/client/src/app/site/motions/services/motion-filter-list.service.ts
@@ -281,11 +281,11 @@ export class MotionFilterListService extends BaseFilterListService<ViewMotion> {
 
                     for (const state of workflow.states) {
                         // get the restriction array, but remove the is_submitter condition, if present
-                        const restrictions = (state.restrictions.filter(
+                        const restrictions = (state.restrictions?.filter(
                             r => r !== Restriction.motionsIsSubmitter
                         ) as unknown) as Permission[];
 
-                        if (!restrictions.length || this.operator.hasPerms(...restrictions)) {
+                        if (!restrictions || !restrictions.length || this.operator.hasPerms(...restrictions)) {
                             // sort final and non final states
                             state.isFinalState ? finalStates.push(state.id) : nonFinalStates.push(state.id);
 

--- a/client/src/app/site/motions/services/motion-pdf.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf.service.ts
@@ -129,7 +129,7 @@ export class MotionPdfService {
         }
 
         if (!contentToExport || contentToExport.includes('reason')) {
-            const reason = this.createReason(motion, lnMode);
+            const reason = this.createReason(motion);
             motionPdfContent.push(reason);
         }
 
@@ -620,28 +620,32 @@ export class MotionPdfService {
      * @returns
      */
     private getUnifiedChanges(motion: ViewMotion, lineLength: number): ViewUnifiedChange[] {
-        const motionChangeRecos = this.changeRecoRepo.getChangeRecoOfMotion(motion.id);
+        throw new Error('Todo');
+        /*const motionChangeRecos = this.changeRecoRepo.getChangeRecoOfMotion(motion.id);
 
-        const motionAmendments = this.motionRepo.getAmendmentsInstantly(motion.id).flatMap((amendment: ViewMotion) => {
-            const changeRecos = this.changeRecoRepo
-                .getChangeRecoOfMotion(amendment.id)
-                .filter(reco => reco.showInFinalView());
-            return this.motionLineNumbering.getAmendmentAmendedParagraphs(amendment, lineLength, changeRecos);
-        });
+        const motionAmendments: any[] = this.motionRepo
+            .getAmendmentsInstantly(motion.id)
+            .flatMap((amendment: ViewMotion) => {
+                const changeRecos = this.changeRecoRepo
+                    .getChangeRecoOfMotion(amendment.id)
+                    .filter(reco => reco.showInFinalView());
+                return this.motionRepo.getAmendmentAmendedParagraphs(amendment, lineLength, changeRecos);
+            });
 
         return motionChangeRecos
             .concat(motionAmendments)
             .filter(change => !!change)
-            .sort((a, b) => a.getLineFrom() - b.getLineFrom()) as ViewUnifiedChange[];
+            .sort((a, b) => a.getLineFrom() - b.getLineFrom()) as ViewUnifiedChange[];*/
     }
 
     /**
      * Creates the motion reason - uses HTML to PDF
      *
      * @param motion the target motion
+     *
      * @returns doc def for the reason as array
      */
-    private createReason(motion: ViewMotion, lnMode: LineNumberingMode): object {
+    private createReason(motion: ViewMotion): object {
         if (motion.reason) {
             const reason = [];
 

--- a/client/src/app/site/motions/services/motion-poll.service.ts
+++ b/client/src/app/site/motions/services/motion-poll.service.ts
@@ -9,7 +9,7 @@ import { MotionPoll, MotionPollMethod } from 'app/shared/models/motions/motion-p
 import { MajorityMethod, PercentBase, PollType } from 'app/shared/models/poll/base-poll';
 import { ParsePollNumberPipe } from 'app/shared/pipes/parse-poll-number.pipe';
 import { PollKeyVerbosePipe } from 'app/shared/pipes/poll-key-verbose.pipe';
-import { PollData, PollService, PollTableData, VotingResult } from 'app/site/polls/services/poll.service';
+import { BasePollData, PollData, PollService, PollTableData, VotingResult } from 'app/site/polls/services/poll.service';
 import { ViewMotionOption } from '../models/view-motion-option';
 import { ViewMotionPoll } from '../models/view-motion-poll';
 
@@ -76,17 +76,21 @@ export class MotionPollService extends PollService {
     }
 
     public generateTableData(poll: PollData | ViewMotionPoll): PollTableData[] {
-        let tableData: PollTableData[] = poll.options.flatMap(vote =>
-            super.getVoteTableKeys(poll).map(key => this.createTableDataEntry(poll, key, vote))
-        );
-        tableData.push(...super.getSumTableKeys(poll).map(key => this.createTableDataEntry(poll, key)));
+        if (poll instanceof ViewMotionPoll) {
+            let tableData: PollTableData[] = poll.options.flatMap(vote =>
+                super.getVoteTableKeys(poll).map(key => this.createTableDataEntry(poll, key, vote))
+            );
+            tableData.push(...super.getSumTableKeys(poll).map(key => this.createTableDataEntry(poll, key)));
 
-        tableData = tableData.filter(localeTableData => !localeTableData.value.some(result => result.hide));
-        return tableData;
+            tableData = tableData.filter(localeTableData => !localeTableData.value.some(result => result.hide));
+            return tableData;
+        } else {
+            return [];
+        }
     }
 
     private createTableDataEntry(
-        poll: PollData | ViewMotionPoll,
+        poll: BasePollData<any, any>,
         result: VotingResult,
         vote?: ViewMotionOption
     ): PollTableData {

--- a/client/src/app/site/polls/services/poll.service.ts
+++ b/client/src/app/site/polls/services/poll.service.ts
@@ -101,16 +101,19 @@ export const PollMajorityMethod: CalculableMajorityMethod[] = [
     }
 ];
 
-export interface PollData {
-    pollmethod: string;
-    type: string;
-    onehundred_percent_base: string;
-    options: PollDataOption[];
+export interface BasePollData<PM, PB> {
+    pollmethod: PM;
+    onehundred_percent_base: PB;
     votesvalid: number;
     votesinvalid: number;
     votescast: number;
+}
+
+export interface PollData extends BasePollData<string, string> {
+    type: string;
     amount_global_no?: number;
     amount_global_abstain?: number;
+    options: PollDataOption[];
 }
 
 export interface PollDataOption {

--- a/client/src/app/site/topics/components/topic-detail/topic-detail.component.ts
+++ b/client/src/app/site/topics/components/topic-detail/topic-detail.component.ts
@@ -11,7 +11,7 @@ import { TopicRepositoryService } from 'app/core/repositories/topics/topic-repos
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { SPEAKER_BUTTON_FOLLOW } from 'app/shared/components/speaker-button/speaker-button.component';
-import { AgendaItemVisibility, ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType, ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
 import { Topic } from 'app/shared/models/topics/topic';
 import { ViewAgendaItem } from 'app/site/agenda/models/view-agenda-item';
 import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
@@ -54,7 +54,7 @@ export class TopicDetailComponent extends BaseModelContextComponent {
     /**
      * Determine visibility states for the agenda that will be created implicitly
      */
-    public itemVisibility = ItemVisibilityChoices;
+    public itemVisibility = ItemTypeChoices;
 
     /**
      * Constructor for the topic detail page.
@@ -133,7 +133,7 @@ export class TopicDetailComponent extends BaseModelContextComponent {
             title: ['', Validators.required]
         });
 
-        this.topicForm.get('agenda_type').setValue(AgendaItemVisibility.common);
+        this.topicForm.get('agenda_type').setValue(AgendaItemType.common);
     }
 
     /**

--- a/client/src/app/site/topics/components/topic-import-list/topic-import-list.component.ts
+++ b/client/src/app/site/topics/components/topic-import-list/topic-import-list.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { CsvExportService } from 'app/core/ui-services/csv-export.service';
 import { DurationService } from 'app/core/ui-services/duration.service';
-import { AgendaItemVisibility, ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType, ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
 import { BaseImportListComponent } from 'app/site/base/components/base-import-list.component';
 import { CreateTopic } from 'app/site/topics/models/create-topic';
 import { TopicImportService } from '../../../topics/services/topic-import.service';
@@ -67,8 +67,8 @@ export class TopicImportListComponent extends BaseImportListComponent<CreateTopi
      * @param type
      * @returns A string, which may be empty if the type is not found in the visibilityChoices
      */
-    public getTypeString(type: AgendaItemVisibility): string {
-        const visibility = ItemVisibilityChoices.find(choice => choice.key === type);
+    public getTypeString(type: AgendaItemType): string {
+        const visibility = ItemTypeChoices.find(choice => choice.key === type);
         return visibility ? visibility.name : '';
     }
 

--- a/client/src/app/site/topics/models/create-topic.ts
+++ b/client/src/app/site/topics/models/create-topic.ts
@@ -1,4 +1,4 @@
-import { AgendaItemVisibility } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { Topic } from 'app/shared/models/topics/topic';
 
 /**
@@ -6,7 +6,7 @@ import { Topic } from 'app/shared/models/topics/topic';
  */
 export class CreateTopic extends Topic {
     public attachment_ids: number[];
-    public agenda_type: AgendaItemVisibility;
+    public agenda_type: AgendaItemType;
     public agenda_parent_id: number;
     public agenda_comment: string;
     public agenda_duration: number;
@@ -22,6 +22,6 @@ export class CreateTopic extends Topic {
     }
 
     public constructor(input?: Partial<CreateTopic>) {
-        super(input);
+        super({ ...input, text: input?.text || '' });
     }
 }

--- a/client/src/app/site/topics/services/topic-import.service.ts
+++ b/client/src/app/site/topics/services/topic-import.service.ts
@@ -7,7 +7,7 @@ import { Papa } from 'ngx-papaparse';
 import { TopicRepositoryService } from 'app/core/repositories/topics/topic-repository.service';
 import { BaseImportService, NewEntry } from 'app/core/ui-services/base-import.service';
 import { DurationService } from 'app/core/ui-services/duration.service';
-import { AgendaItemVisibility, ItemVisibilityChoices } from 'app/shared/models/agenda/agenda-item';
+import { AgendaItemType, ItemTypeChoices } from 'app/shared/models/agenda/agenda-item';
 import { CreateTopic } from '../models/create-topic';
 
 @Injectable({
@@ -101,7 +101,7 @@ export class TopicImportService extends BaseImportService<CreateTopic> {
 
         // set type to 'public' if none is given in import
         if (!newEntry.agenda_type) {
-            newEntry.agenda_type = AgendaItemVisibility.common;
+            newEntry.agenda_type = AgendaItemType.common;
         }
         const mappedEntry: NewEntry<CreateTopic> = {
             newEntry: newEntry,
@@ -151,17 +151,17 @@ export class TopicImportService extends BaseImportService<CreateTopic> {
      * @param input
      * @returns a number as defined for the itemVisibilityChoices
      */
-    public parseType(input: string | number): AgendaItemVisibility {
+    public parseType(input: string | number): AgendaItemType {
         if (!input) {
-            return AgendaItemVisibility.common; // default, public item
+            return AgendaItemType.common; // default, public item
         } else if (typeof input === 'string') {
-            const visibility = ItemVisibilityChoices.find(choice => choice.csvName === input);
+            const visibility = ItemTypeChoices.find(choice => choice.csvName === input);
             if (visibility) {
                 return visibility.key;
             }
         } else if (input === 1) {
             // Compatibility with the old client's isInternal column
-            const visibility = ItemVisibilityChoices.find(choice => choice.name === 'Internal item');
+            const visibility = ItemTypeChoices.find(choice => choice.name === 'Internal item');
             if (visibility) {
                 return visibility.key;
             }
@@ -187,7 +187,7 @@ export class TopicImportService extends BaseImportService<CreateTopic> {
             const newTopic = new CreateTopic(
                 new CreateTopic({
                     title: line,
-                    agenda_type: AgendaItemVisibility.common // set type to 'public item' by default
+                    agenda_type: AgendaItemType.common // set type to 'public item' by default
                 })
             );
             const newEntry: NewEntry<CreateTopic> = {

--- a/client/src/app/site/users/components/user-list/user-list.component.ts
+++ b/client/src/app/site/users/components/user-list/user-list.component.ts
@@ -354,13 +354,16 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
         const content = this.translate.instant(
             'This will add or remove the following groups for all selected participants:'
         );
-        const choices = [_('add group(s)'), _('remove group(s)')];
+        const ADD = _('add group(s)');
+        const REMOVE = _('remove group(s)');
+        const choices = [ADD, REMOVE];
         const selectedChoice = await this.choiceService.open(content, this.groupRepo.getViewModelList(), true, choices);
         if (selectedChoice) {
-            const action = selectedChoice.action === choices[0] ? 'add' : 'remove';
-            this.repo
-                .bulkAlterGroups(this.selectedRows, action, selectedChoice.items as number[])
-                .catch(this.raiseError);
+            if (selectedChoice.action === ADD) {
+                this.repo.bulkAddGroupsToTemporaryUsers(this.selectedRows, selectedChoice.items as number[]);
+            } else {
+                this.repo.bulkRemoveGroupsFromTemporaryUsers(this.selectedRows, selectedChoice.items as number[]);
+            }
         }
     }
 


### PR DESCRIPTION
Currently implemented:

- Bulk actions for motions
- Bulk actions for users
- Bulk actions for agenda-items
- Bulk actions for assignments

TODO:
- Refactoring of `motion-import.service.ts`
- Maybe splitting user-repo into `user-repository` and `temporary-user-repository`?