### PR TITLE
Some cleanup and tracking model requests

### DIFF
--- a/client/src/app/core/core-services/action.service.ts
+++ b/client/src/app/core/core-services/action.service.ts
@@ -42,7 +42,7 @@ export class ActionService {
             return null;
         }
         if (results.length !== 1) {
-            throw new Error('Inner resultlength is not 1 from the action service');
+            throw new Error('The action service did not respond with exactly one response for one request.');
         }
         return results[0];
     }
@@ -65,8 +65,8 @@ export class ActionService {
             if (!results) {
                 return null;
             }
-            if (results.length !== 1) {
-                throw new Error('Resultlength is not 1 from the action service');
+            if (results.length !== requests.length) {
+                throw new Error('The action service did not return responses for each request.');
             }
             return results[0];
         }

--- a/client/src/app/core/core-services/active-meeting.service.ts
+++ b/client/src/app/core/core-services/active-meeting.service.ts
@@ -59,7 +59,10 @@ export class ActiveMeetingService {
         }
 
         if (id) {
-            this.modelAutoupdateSubscription = await this.autoupdateService.simpleRequest(this.getModelRequest());
+            this.modelAutoupdateSubscription = await this.autoupdateService.simpleRequest(
+                this.getModelRequest(),
+                'ActiveMeetingService'
+            );
 
             if (this.meetingSubcription) {
                 this.meetingSubcription.unsubscribe();

--- a/client/src/app/core/core-services/auth.service.ts
+++ b/client/src/app/core/core-services/auth.service.ts
@@ -120,12 +120,16 @@ export class AuthService {
      * @returns true, if the request was successful (=online)
      */
     public async doWhoAmIRequest(): Promise<boolean> {
+        console.log('auth: Do WhoAmI');
+        let online;
         try {
             await this.http.post<LoginResponse>(`${environment.authUrlPrefix}/who-am-i/`);
-            return true;
+            online = true;
         } catch (e) {
-            return false;
+            online = false;
         }
+        console.log('auth: WhoAmI done, online:', online);
+        return online;
     }
 
     private resumeTokenSubscription(): void {

--- a/client/src/app/core/core-services/http-stream.service.ts
+++ b/client/src/app/core/core-services/http-stream.service.ts
@@ -21,14 +21,18 @@ export class StreamContainer {
     public hasErroredAmount = 0;
     public errorHandler: (error: any) => void = null;
 
+    public messageHandler: (message: any) => void;
     public stream?: Stream<any>;
 
     public constructor(
         public endpoint: EndpointConfiguration,
-        public messageHandler: (message: any) => void,
+        messageHandler: (message: any, streamId: number) => void,
         public params: () => Params,
-        public body: () => any
-    ) {}
+        public body: () => any,
+        public description: string
+    ) {
+        this.messageHandler = (message: any) => messageHandler(message, this.id);
+    }
 }
 
 @Injectable({

--- a/client/src/app/core/core-services/lifecycle.service.ts
+++ b/client/src/app/core/core-services/lifecycle.service.ts
@@ -35,7 +35,8 @@ export class LifecycleService {
     public constructor() {}
 
     public bootup(): void {
-        this._isBooted = false;
+        this._isBooted = true;
+        console.debug('Lifecycle: booted.');
         this.openslidesBooted.next();
     }
 
@@ -44,6 +45,7 @@ export class LifecycleService {
      */
     public shutdown(): void {
         this._isBooted = false;
+        console.debug('Lifecycle: shutdown.');
         this.openslidesShutdowned.next();
     }
 

--- a/client/src/app/core/core-services/model-request.service.ts
+++ b/client/src/app/core/core-services/model-request.service.ts
@@ -14,7 +14,10 @@ import { SimplifiedModelRequest } from './model-request-builder.service';
 export class ModelRequestService {
     public constructor(private autoupdateService: AutoupdateService) {}
 
-    public async requestModels(simplifiedModelRequest: SimplifiedModelRequest): Promise<ModelSubscription> {
-        return this.autoupdateService.simpleRequest(simplifiedModelRequest);
+    public async requestModels(
+        simplifiedModelRequest: SimplifiedModelRequest,
+        description: string
+    ): Promise<ModelSubscription> {
+        return this.autoupdateService.simpleRequest(simplifiedModelRequest, description);
     }
 }

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -30,14 +30,6 @@ export interface NewUser {
     name: string;
 }
 
-export function AllUsersInMeetingRequest(meetingId: Id): SimplifiedModelRequest {
-    return {
-        viewModelCtor: ViewMeeting,
-        ids: [meetingId],
-        follow: [{ idField: 'user_ids', fieldset: 'shortName' }]
-    };
-}
-
 interface CreateTemporaryPayloadWithPresent extends UserAction.CreateTemporaryPayload {
     is_present: boolean;
 }
@@ -270,7 +262,11 @@ export class UserRepositoryService
     };
 
     public getRequestToGetAllModels(): SimplifiedModelRequest {
-        return AllUsersInMeetingRequest(this.activeMeetingIdService.meetingId);
+        return {
+            viewModelCtor: ViewMeeting,
+            ids: [this.activeMeetingIdService.meetingId],
+            follow: [{ idField: 'user_ids', fieldset: 'shortName' }]
+        };
     }
 
     /**

--- a/client/src/app/core/ui-services/base-filter-list.service.ts
+++ b/client/src/app/core/ui-services/base-filter-list.service.ts
@@ -461,7 +461,6 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
      * @returns true if the item is to be displayed according to the filter
      */
     private checkIncluded(item: V, filter: OsFilter): boolean {
-        console.log('checkIncluded', item, filter);
         const nullFilter = filter.options.find(
             option => typeof option !== 'string' && option.isActive && option.condition === null
         );
@@ -486,10 +485,7 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
                 passesNullFilter = false;
             }
         }
-        if (nullFilter && passesNullFilter) {
-            return true;
-        }
-        return false;
+        return nullFilter && passesNullFilter;
     }
 
     /**

--- a/client/src/app/shared/components/media-upload-content/media-upload-content.component.ts
+++ b/client/src/app/shared/components/media-upload-content/media-upload-content.component.ts
@@ -141,7 +141,7 @@ export class MediaUploadContentComponent implements OnInit, OnDestroy {
             follow: [{ idField: 'mediafile_ids', fieldset: 'fileCreation' }],
             fieldset: []
         };
-        this.modelSubscription = await this.modelRequestService.requestModels(modelRequest);
+        this.modelSubscription = await this.modelRequestService.requestModels(modelRequest, this.constructor.name);
     }
 
     public ngOnDestroy(): void {

--- a/client/src/app/shared/components/search-repo-selector/search-repo-selector.component.ts
+++ b/client/src/app/shared/components/search-repo-selector/search-repo-selector.component.ts
@@ -4,9 +4,11 @@ import { FormBuilder, NgControl } from '@angular/forms';
 import { MatFormFieldControl } from '@angular/material/form-field';
 
 import { ModelSubscription } from 'app/core/core-services/autoupdate.service';
+import { ModelRequestService } from 'app/core/core-services/model-request.service';
 import { BaseRepository } from 'app/core/repositories/base-repository';
 import { ModelRequestRepository } from 'app/core/repositories/model-request-repository';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { MeetingSettingsService } from 'app/core/ui-services/meeting-settings.service';
 import { Settings } from 'app/shared/models/event-management/meeting';
 import { BaseSearchValueSelectorComponent } from '../base-search-value-selector';
 import { Selectable } from '../selectable';
@@ -41,7 +43,8 @@ export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponen
         @Optional() @Self() public ngControl: NgControl,
         focusMonitor: FocusMonitor,
         element: ElementRef<HTMLElement>,
-        private componentServiceCollector: ComponentServiceCollector
+        private modelRequestService: ModelRequestService,
+        private meetingSettingService: MeetingSettingsService
     ) {
         super(formBuilder, focusMonitor, element, ngControl);
     }
@@ -81,7 +84,7 @@ export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponen
         }
         if (this.defaultDataConfigKey) {
             this.subscriptions.push(
-                this.componentServiceCollector.meetingSettingService.get(this.defaultDataConfigKey).subscribe(value => {
+                this.meetingSettingService.get(this.defaultDataConfigKey).subscribe(value => {
                     if (!this.value) {
                         this.value = value as any;
                     }
@@ -92,8 +95,9 @@ export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponen
 
     private async doModelRequest(): Promise<void> {
         this.cleanModelSubscription();
-        this.modelSubscription = await this.componentServiceCollector.modelRequestService.requestModels(
-            this.repo.getRequestToGetAllModels()
+        this.modelSubscription = await this.modelRequestService.requestModels(
+            this.repo.getRequestToGetAllModels(),
+            this.constructor.name
         );
     }
 

--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.html
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.html
@@ -107,12 +107,8 @@
             <mat-icon>picture_as_pdf</mat-icon>
             <span>{{ 'Ballot papers' | translate }}</span>
         </button>
+
         <mat-divider></mat-divider>
-        <!-- Refresh Button -->
-        <button mat-menu-item (click)="refreshPoll()">
-            <mat-icon>refresh</mat-icon>
-            <span>{{ 'Refresh' | translate }}</span>
-        </button>
 
         <!-- Reset Button -->
         <button mat-menu-item (click)="resetState()">

--- a/client/src/app/site/base/components/base-model-context.component.ts
+++ b/client/src/app/site/base/components/base-model-context.component.ts
@@ -2,7 +2,6 @@ import { Directive, OnDestroy, OnInit } from '@angular/core';
 
 import { ModelSubscription } from 'app/core/core-services/autoupdate.service';
 import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
-import { ModelRequestService } from 'app/core/core-services/model-request.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { BaseComponent } from './base.component';
 
@@ -14,10 +13,12 @@ import { BaseComponent } from './base.component';
  */
 @Directive()
 export abstract class BaseModelContextComponent extends BaseComponent implements OnInit, OnDestroy {
-    protected localModelSub: ModelSubscription | null = null;
+    protected localModelSubscriptions: { [name: string]: ModelSubscription };
+    private destroyed = false;
 
     public constructor(protected componentServiceCollector: ComponentServiceCollector) {
         super(componentServiceCollector);
+        this.localModelSubscriptions = {};
     }
 
     public ngOnInit(): void {
@@ -27,23 +28,39 @@ export abstract class BaseModelContextComponent extends BaseComponent implements
         }
     }
 
-    protected async requestModels(simplifiedModelRequest: SimplifiedModelRequest): Promise<void> {
-        this.cleanCurrentModelSub();
-        this.localModelSub = await this.componentServiceCollector.modelRequestService.requestModels(
-            simplifiedModelRequest
+    protected async requestModels(
+        simplifiedModelRequest: SimplifiedModelRequest,
+        subscriptionName: string = 'default'
+    ): Promise<void> {
+        if (this.destroyed) {
+            throw new Error('You have requested models for a component that was destroyed!');
+        }
+
+        this.cleanCurrentModelSub(subscriptionName);
+        this.localModelSubscriptions[subscriptionName] = await this.modelRequestService.requestModels(
+            simplifiedModelRequest,
+            this.constructor.name + ' ' + subscriptionName // Note: This does not work for
+            // productive (minified) code, but it is just a dev thing.
         );
     }
 
     public ngOnDestroy(): void {
         super.ngOnDestroy();
-        this.cleanCurrentModelSub();
+        this.destroyed = true;
+        for (const name of Object.keys(this.localModelSubscriptions)) {
+            this.cleanCurrentModelSub(name);
+        }
     }
 
-    private cleanCurrentModelSub(): void {
-        if (this.localModelSub) {
-            this.localModelSub.close();
-            this.localModelSub = null;
+    private cleanCurrentModelSub(subscriptionName: string): void {
+        if (this.localModelSubscriptions[subscriptionName]) {
+            this.localModelSubscriptions[subscriptionName].close();
+            delete this.localModelSubscriptions[subscriptionName];
         }
+    }
+
+    protected hasSubscription(subscriptionName: string): boolean {
+        return !!this.localModelSubscriptions[subscriptionName];
     }
 
     protected getModelRequest(): SimplifiedModelRequest | null {

--- a/client/src/app/site/base/components/base.component.ts
+++ b/client/src/app/site/base/components/base.component.ts
@@ -5,6 +5,7 @@ import { Title } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 
+import { ModelRequestService } from 'app/core/core-services/model-request.service';
 import { Permission } from 'app/core/core-services/permission';
 import { Id } from 'app/core/definitions/key-types';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
@@ -98,6 +99,10 @@ export abstract class BaseComponent implements OnDestroy {
 
     protected get meetingSettingService(): MeetingSettingsService {
         return this.componentServiceCollector.meetingSettingService;
+    }
+
+    protected get modelRequestService(): ModelRequestService {
+        return this.componentServiceCollector.modelRequestService;
     }
 
     public constructor(protected componentServiceCollector: ComponentServiceCollector) {

--- a/client/src/app/site/users/components/user-detail/user-detail.component.ts
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.ts
@@ -84,8 +84,6 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
         return this.pollService.isElectronicVotingEnabled && this.voteWeightEnabled;
     }
 
-    private editModelsSubscription: ModelSubscription;
-
     private isTemporaryUser = true;
 
     /**
@@ -123,7 +121,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
         this.getUserByUrl();
 
         this.operatorService.operatorUpdatedEvent.subscribe(() => {
-            this.updateFormControlsAccesibility();
+            this.updateFormControlsAccessibility();
         });
 
         this.meetingSettingsService
@@ -132,13 +130,6 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
 
         this.groupRepo.getViewModelListObservableWithoutDefaultGroup().subscribe(this.groups);
         this.users = this.repo.getViewModelListBehaviorSubject();
-    }
-
-    public ngOnDestroy(): void {
-        super.ngOnDestroy();
-        if (this.editModelsSubscription) {
-            this.editModelsSubscription.close();
-        }
     }
 
     private getUserByUrl(): void {
@@ -273,7 +264,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
     /**
      * Makes the form editable
      */
-    public updateFormControlsAccesibility(): void {
+    public updateFormControlsAccessibility(): void {
         const formControlNames = Object.keys(this.personalInfoForm.controls);
 
         // Enable all controls.
@@ -352,16 +343,19 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
             this.isTemporaryUser = false;
         }
 
-        if (!this.editModelsSubscription) {
-            this.editModelsSubscription = await this.componentServiceCollector.modelRequestService.requestModels({
-                viewModelCtor: ViewMeeting,
-                ids: [this.activeMeetingIdService.meetingId],
-                follow: ['group_ids', { idField: 'user_ids', fieldset: 'shortName' }]
-            });
+        if (!this.hasSubscription('edit subscription')) {
+            await this.requestModels(
+                {
+                    viewModelCtor: ViewMeeting,
+                    ids: [this.activeMeetingIdService.meetingId],
+                    follow: ['group_ids', { idField: 'user_ids', fieldset: 'shortName' }]
+                },
+                'edit subscription'
+            );
         }
 
         this.editUser = edit;
-        this.updateFormControlsAccesibility();
+        this.updateFormControlsAccessibility();
 
         if (!this.newUser && edit) {
             this.patchFormValues();


### PR DESCRIPTION
@GabrielInTheWorld Two things:
- I've updated the base model context component. The `requestModels` now takes a second parameter: the name of the request. It has a default, so all other code still works. There were places on the old code with two calls to `requestModels` next to each other. The *old* behavior was like a singleton: when you do a second `requestModels`, the subscription from the first call is canceled (See the old assignment detail as an example).

  Since there are places where multiple requests are needed (E.g. motion detail: One request to the motion and one to the meeting getting all other needed models like all categories), the `modelRequestService` was often used, but the subscription must be cleaned up manually. Now, with the new `subscriptionName` the subscription is still singleton-like, but with respect to the name. You can make two subscriptions with different names - ok. But still: The second subscriptions with the same name will close the first one. The nice part is, that on `ngOnDestroy` the subscriptions will be cleaned automatically.

  On further development: We should switch wherever possible (I think all components) to the new format and do not use the `ModelRequestService`  for additional requests.

- I've added debugging prints on each open and close of a request. This helps identifying connection leaks (Navigate away from a component and the request is still open) and keep track on autoupdates: It is now printed on which stream an autoupdate was received. Also remember: opening streams is a heavy task. This should help optimizing the usage of requests later on. It might be a bit much output - we'll see how long it stays in the code.