### PR TITLE
Improve prod dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY client/package.json .
 COPY client/package-lock.json .
 RUN npm ci
+RUN npm run postinstall
 
 COPY client /app/
 


### PR DESCRIPTION
Move postinstall before copying static files: This reduces the time to
build the client since the typescript modules must not be compiled every
time.