### PR TITLE
Repairs routing and improves committees and dashboard

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -17,6 +17,7 @@ import { OperatorService } from './core/core-services/operator.service';
 import { OrganisationService } from './core/core-services/organisation.service';
 import { OverlayService } from './core/ui-services/overlay.service';
 import { overloadJsFunctions } from './shared/overload-js-functions';
+import { RouteGuard } from './core/core-services/route.guard';
 import { RoutingStateService } from './core/ui-services/routing-state.service';
 import { ServertimeService } from './core/core-services/servertime.service';
 import { ThemeService } from './core/ui-services/theme.service';
@@ -47,7 +48,7 @@ export class AppComponent implements OnInit {
         private activeMeetingIdService: ActiveMeetingIdService,
         private activeMeetingService: ActiveMeetingService,
         private lifecycleService: LifecycleService,
-        organisationService: OrganisationService,
+        routeGuard: RouteGuard,
         router: Router,
         offlineService: OfflineService,
         servertimeService: ServertimeService,

--- a/client/src/app/core/core-services/auth-guard.service.ts
+++ b/client/src/app/core/core-services/auth-guard.service.ts
@@ -46,8 +46,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
         if ((this.operator.isAnonymous && this.activeMeeting.guestsEnabled) || this.operator.isAuthenticated) {
             return this.hasPerms(basePerm);
         } else {
-            this.router.navigate(['login']);
-            return false;
+            return this.router.createUrlTree(['login']);
         }
     }
 

--- a/client/src/app/core/core-services/route.guard.ts
+++ b/client/src/app/core/core-services/route.guard.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { NavigationStart, Router } from '@angular/router';
+
+import { ActiveMeetingIdService } from './active-meeting-id.service';
+import { Id } from '../definitions/key-types';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class RouteGuard {
+    private get activeMeetingId(): Id {
+        return this.activeMeetingIdService.meetingId;
+    }
+
+    private readonly excludedRoutes = ['login', 'download', 'projector', 'committees', 'members'];
+
+    public constructor(private router: Router, private activeMeetingIdService: ActiveMeetingIdService) {
+        this.listenToNavigation();
+    }
+
+    private listenToNavigation(): void {
+        this.router.events.subscribe(event => {
+            if (event instanceof NavigationStart) {
+                const paths = event.url.split('/').filter(path => !!path);
+                if (!!Number(paths[0]) && !this.excludedRoutes.includes(paths[0])) {
+                    console.warn(`Route "${event.url}" is misleading. Please change.`);
+                    this.router.navigate([this.activeMeetingId, ...paths]);
+                }
+            }
+        });
+    }
+}

--- a/client/src/app/core/repositories/base-repository-with-active-meeting.ts
+++ b/client/src/app/core/repositories/base-repository-with-active-meeting.ts
@@ -7,7 +7,7 @@ import { RepositoryServiceCollector } from './repository-service-collector';
 
 /**
  * Extension of the base repository for all meeting specific models. Provides access
- * to the active meeting service and automatically inserts the id on creates.
+ * to the active meeting service and automatically inserts the id on viewmodel creates.
  */
 export abstract class BaseRepositoryWithActiveMeeting<
     V extends BaseViewModel,
@@ -26,5 +26,12 @@ export abstract class BaseRepositoryWithActiveMeeting<
         protected baseModelCtor: ModelConstructor<M>
     ) {
         super(fullRepositoryServiceCollector, baseModelCtor);
+        this.activeMeetingIdService.meetingHasChangedObservable.subscribe(() => this.clear());
+    }
+
+    protected createViewModel(model: M): V {
+        const viewModel = super.createViewModel(model);
+        viewModel.getActiveMeetingId = () => this.fullRepositoryServiceCollector.activeMeetingIdService.meetingId;
+        return viewModel;
     }
 }

--- a/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
+++ b/client/src/app/core/repositories/mediafiles/mediafile-repository.service.ts
@@ -137,7 +137,7 @@ export class MediafileRepositoryService extends BaseIsListOfSpeakersContentObjec
         const payload: MediafileAction.CreateDirectoryPayload = {
             meeting_id: this.activeMeetingIdService.meetingId,
             title: partialMediafile.title,
-            access_group_ids: partialMediafile.access_group_ids,
+            access_group_ids: partialMediafile.access_group_ids || [],
             parent_id: partialMediafile.parent_id
         };
         return this.sendActionToBackend(MediafileAction.CREATE_DIRECTORY, payload);

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -221,6 +221,12 @@ export const RELATIONS: Relation[] = [
         AField: 'default_meeting',
         BField: 'default_meeting_for_committee'
     }),
+    ...makeO2O({
+        AViewModel: ViewCommittee,
+        BViewModel: ViewMeeting,
+        AField: 'template_meeting_id',
+        BField: 'template_meeting_for_committee_id'
+    }),
     ...makeM2M({
         AViewModel: ViewCommittee,
         BViewModel: ViewUser,

--- a/client/src/app/core/repositories/repository-service-collector-without-active-meeting-service.ts
+++ b/client/src/app/core/repositories/repository-service-collector-without-active-meeting-service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { ActionService } from '../core-services/action.service';
+import { AuthService } from '../core-services/auth.service';
 import { CollectionMapperService } from '../core-services/collection-mapper.service';
 import { DataStoreService } from '../core-services/data-store.service';
 import { ErrorService } from '../ui-services/error.service';
@@ -20,6 +21,7 @@ export class RepositoryServiceCollectorWithoutActiveMeetingService {
         public viewModelStoreService: ViewModelStoreService,
         public translate: TranslateService,
         public relationManager: RelationManagerService,
-        public errorService: ErrorService
+        public errorService: ErrorService,
+        public authService: AuthService
     ) {}
 }

--- a/client/src/app/core/repositories/repository-service-collector.ts
+++ b/client/src/app/core/repositories/repository-service-collector.ts
@@ -4,6 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { ActionService } from '../core-services/action.service';
 import { ActiveMeetingIdService } from '../core-services/active-meeting-id.service';
+import { AuthService } from '../core-services/auth.service';
 import { CollectionMapperService } from '../core-services/collection-mapper.service';
 import { DataStoreService } from '../core-services/data-store.service';
 import { ErrorService } from '../ui-services/error.service';
@@ -23,6 +24,7 @@ export class RepositoryServiceCollector extends RepositoryServiceCollectorWithou
         translate: TranslateService,
         relationManager: RelationManagerService,
         errorService: ErrorService,
+        authService: AuthService,
         public activeMeetingIdService: ActiveMeetingIdService
     ) {
         super(
@@ -32,7 +34,8 @@ export class RepositoryServiceCollector extends RepositoryServiceCollectorWithou
             viewModelStoreService,
             translate,
             relationManager,
-            errorService
+            errorService,
+            authService
         );
     }
 }

--- a/client/src/app/core/ui-services/component-service-collector.ts
+++ b/client/src/app/core/ui-services/component-service-collector.ts
@@ -4,6 +4,7 @@ import { Title } from '@angular/platform-browser';
 
 import { TranslateService } from '@ngx-translate/core';
 
+import { ActiveMeetingIdService } from '../core-services/active-meeting-id.service';
 import { MeetingSettingsService } from './meeting-settings.service';
 import { ModelRequestService } from '../core-services/model-request.service';
 import { StorageService } from '../core-services/storage.service';
@@ -18,6 +19,7 @@ export class ComponentServiceCollector {
         public matSnackBar: MatSnackBar,
         public storage: StorageService,
         public modelRequestService: ModelRequestService,
-        public meetingSettingService: MeetingSettingsService
+        public meetingSettingService: MeetingSettingsService,
+        public activeMeetingId: ActiveMeetingIdService
     ) {}
 }

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -35,8 +35,49 @@
         </mat-form-field>
 
         <mat-form-field>
+            <mat-label> {{ 'Committee members' | translate }}</mat-label>
+            <os-search-value-selector
+                formControlName="member_ids"
+                [multiple]="true"
+                placeholder="{{ 'Committee members' | translate }}"
+                [inputListValues]="members"
+            ></os-search-value-selector>
+        </mat-form-field>
+
+        <mat-form-field>
             <mat-label>{{ 'Description' | translate }}</mat-label>
             <input matInput formControlName="description" />
         </mat-form-field>
+
+        <ng-container *ngIf="!isCreateView">
+            <mat-form-field>
+                <mat-label>{{ 'Meeting as template' | translate }}</mat-label>
+                <os-search-value-selector
+                    formControlName="template_meeting_id"
+                    [multiple]="false"
+                    [inputListValues]="meetingsObservable"
+                ></os-search-value-selector>
+            </mat-form-field>
+
+            <mat-form-field>
+                <mat-label>{{ 'Default meeting' | translate }}</mat-label>
+                <os-search-value-selector
+                    formControlName="default_meeting_id"
+                    [multiple]="false"
+                    [inputListValues]="meetingsObservable"
+                ></os-search-value-selector>
+            </mat-form-field>
+
+            <mat-form-field>
+                <mat-label>{{ 'Forward to committees' | translate }}</mat-label>
+                <os-search-repo-selector
+                    formControlName="forward_to_committee_ids"
+                    [multiple]="true"
+                    [repo]="committeeRepo"
+                    [pipeFn]="getPipeFilterFn()"
+                    [showChips]="false"
+                ></os-search-repo-selector>
+            </mat-form-field>
+        </ng-container>
     </form>
 </mat-card>

--- a/client/src/app/management/components/dashboard/dashboard.component.html
+++ b/client/src/app/management/components/dashboard/dashboard.component.html
@@ -1,4 +1,4 @@
-<os-head-bar [customMenu]="true">
+<os-head-bar [customMenu]="true" [isSearchEnabled]="false">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Dashboard' | translate }}</h2>
@@ -16,41 +16,74 @@
 </mat-card>
 
 <ng-container *ngIf="!noMeetingsToShow">
-    <mat-card class="os-card">
-        <!-- active meetings -->
-        <div>
-            <h2>{{ 'Active meetings' | translate }}</h2>
-            <p *ngFor="let meeting of currentMeetings">
-                <ng-container [ngTemplateOutlet]="meetingTemplate" [ngTemplateOutletContext]="{ meeting: meeting }">
-                </ng-container>
-            </p>
+    <!-- active meetings -->
+    <div id="active-meetings" class="meeting-list-container">
+        <div class="meeting-icon-wrapper">
+            <mat-icon color="warn">access_alarm</mat-icon>
+            <span>{{ 'active' | translate }}</span>
         </div>
+        <div class="meeting-list">
+            <mat-card *ngIf="!currentMeetings.length">{{ 'Currently, no meeting available' | translate }}</mat-card>
+            <ng-container *ngFor="let meeting of currentMeetings; let last = last">
+                <ng-container
+                    [ngTemplateOutlet]="meetingTemplate"
+                    [ngTemplateOutletContext]="{ meeting: meeting }"
+                ></ng-container>
+                <mat-divider *ngIf="!last"></mat-divider>
+            </ng-container>
+        </div>
+    </div>
 
-        <!-- future meetings -->
-        <div>
-            <h2>{{ 'Future meetings' | translate }}</h2>
-            <p *ngFor="let meeting of futureMeetings">
-                <ng-container [ngTemplateOutlet]="meetingTemplate" [ngTemplateOutletContext]="{ meeting: meeting }">
-                </ng-container>
-            </p>
+    <!-- future meetings -->
+    <div id="future-meetings" class="meeting-list-container">
+        <div class="meeting-icon-wrapper">
+            <mat-icon color="primary">update</mat-icon>
+            <span>{{ 'future' | translate }}</span>
         </div>
+        <ng-container
+            [ngTemplateOutlet]="meetingListTemplate"
+            [ngTemplateOutletContext]="{ meetingList: futureMeetings }"
+        ></ng-container>
+    </div>
 
-        <!-- prev meetings -->
-        <div>
-            <h2>{{ 'Previous meetings' | translate }}</h2>
-            <p *ngFor="let meeting of previousMeetings">
-                <ng-container [ngTemplateOutlet]="meetingTemplate" [ngTemplateOutletContext]="{ meeting: meeting }">
-                </ng-container>
-            </p>
+    <!-- previous meetings -->
+    <div id="previous-meetings" class="meeting-list-container">
+        <div class="meeting-icon-wrapper">
+            <mat-icon aria-hidden="true">history</mat-icon>
+            <span>{{ 'ended' | translate }}</span>
         </div>
-    </mat-card>
+        <ng-container
+            [ngTemplateOutlet]="meetingListTemplate"
+            [ngTemplateOutletContext]="{ meetingList: previousMeetings }"
+        ></ng-container>
+    </div>
 </ng-container>
 
+<ng-template let-meetingList="meetingList" #meetingListTemplate>
+    <div class="meeting-list" [ngClass]="{ 'no-meeting': !meetingList.length }">
+        <mat-card *ngIf="!meetingList.length">{{ 'Currently, no meeting available' | translate }}</mat-card>
+        <cdk-virtual-scroll-viewport [itemSize]="60" *ngIf="!!meetingList.length">
+            <ng-container *cdkVirtualFor="let meeting of meetingList; let odd = odd; let last = last">
+                <div [ngClass]="{ alternate: odd }">
+                    <ng-container
+                        [ngTemplateOutlet]="meetingTemplate"
+                        [ngTemplateOutletContext]="{ meeting: meeting }"
+                    ></ng-container>
+                </div>
+                <mat-divider *ngIf="last"></mat-divider>
+            </ng-container>
+        </cdk-virtual-scroll-viewport>
+    </div>
+</ng-template>
+
 <ng-template let-meeting="meeting" #meetingTemplate>
-    <a [routerLink]="[meeting.id]">
-        <span>{{ meeting.start_time | localizedDate: 'll' }}</span>
-        <span> - </span>
-        <span>{{ meeting.end_time | localizedDate: 'll' }}</span>
-        <span>&nbsp;{{ meeting.name }}</span>
-    </a>
+    <div matRipple class="meeting-box" [routerLink]="meeting.id">
+        <div class="meeting-box--left">
+            <span>{{ meeting.start_time | localizedDate: 'll' }}</span>
+            <span *ngIf="meeting.start_time && meeting.end_time"> - </span>
+            <span>{{ meeting.end_time | localizedDate: 'll' }}</span>
+        </div>
+        <div class="meeting-box--mid">{{ meeting.name }}</div>
+        <div class="meeting-box--right">{{ meeting.location }}</div>
+    </div>
 </ng-template>

--- a/client/src/app/management/components/dashboard/dashboard.component.scss
+++ b/client/src/app/management/components/dashboard/dashboard.component.scss
@@ -7,3 +7,77 @@
     max-width: 400px;
     margin: 1em auto;
 }
+
+.meeting-list-container {
+    display: flex;
+    width: 1000px;
+    margin: 20px auto;
+}
+
+.meeting-icon-wrapper {
+    width: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+
+    mat-icon {
+        $size: 40px;
+        width: $size;
+        height: $size;
+        font-size: $size;
+    }
+}
+
+.meeting-list {
+    width: 100%;
+    box-shadow: 0 8px 10px 1px rgb(0 0 0 / 14%), 0 3px 14px 2px rgb(0 0 0 / 12%), 0 5px 5px -3px rgb(0 0 0 / 40%);
+    height: 250px;
+    display: block;
+    background: white;
+    overflow: hidden;
+
+    &.no-meeting {
+        height: fit-content;
+    }
+
+    cdk-virtual-scroll-viewport {
+        height: 100%;
+    }
+
+    div.alternate {
+        background: rgba(192, 192, 192, 0.1);
+    }
+}
+
+.meeting-box {
+    outline: none;
+    cursor: pointer;
+    padding: 10px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    box-sizing: border-box;
+    height: 60px;
+
+    &--mid {
+        font-size: 18px;
+        flex: 3;
+    }
+
+    &--left,
+    &--right {
+        flex: 1;
+    }
+}
+
+#previous-meetings {
+    .meeting-box {
+        color: rgba(0, 0, 0, 0.4);
+    }
+
+    .meeting-icon-wrapper {
+        color: rgba(0, 0, 0, 0.4);
+    }
+}

--- a/client/src/app/management/components/dashboard/dashboard.component.scss-theme.scss
+++ b/client/src/app/management/components/dashboard/dashboard.component.scss-theme.scss
@@ -1,0 +1,39 @@
+@import '~@angular/material/theming';
+
+@mixin os-dashboard-style($theme) {
+    $primary: map-get($theme, primary);
+    $warn: map-get($theme, warn);
+    $foreground: map-get($theme, foreground);
+    $background: map-get($theme, background);
+    $active-meetings-text-color: mat-color($background, card);
+
+    #active-meetings {
+        .meeting-list {
+            height: fit-content;
+            background: mat-color($background, card);
+
+            .meeting-box {
+                background: mat-color($primary);
+                color: $active-meetings-text-color;
+
+                &--mid {
+                    font-size: 22px;
+                }
+
+                &:last-child {
+                    border: none;
+                }
+            }
+        }
+
+        .meeting-icon-wrapper {
+            color: mat-color($warn);
+        }
+    }
+
+    #future-meetings {
+        .meeting-icon-wrapper {
+            color: mat-color($primary);
+        }
+    }
+}

--- a/client/src/app/management/components/dashboard/dashboard.component.ts
+++ b/client/src/app/management/components/dashboard/dashboard.component.ts
@@ -46,15 +46,15 @@ export class DashboardComponent extends BaseModelContextComponent implements OnI
         this.meetingRepo.getViewModelListObservable().subscribe(meetings => {
             const currentDate = new Date();
             currentDate.setHours(0, 0, 0, 0);
-            this.previousMeetings = meetings.filter(meeting => {
-                return meeting.endDate < currentDate;
-            });
-            this.futureMeetings = meetings.filter(meeting => {
-                return meeting.startDate > currentDate;
-            });
-            this.currentMeetings = meetings.filter(meeting => {
-                return meeting.endDate >= currentDate && meeting.startDate <= currentDate;
-            });
+            this.previousMeetings = meetings
+                .filter(meeting => meeting.endDate < currentDate)
+                .sort((a, b) => b.end_time - a.end_time);
+            this.futureMeetings = meetings
+                .filter(meeting => meeting.startDate > currentDate)
+                .sort((a, b) => a.end_time - b.end_time);
+            this.currentMeetings = meetings.filter(
+                meeting => meeting.endDate >= currentDate && meeting.startDate <= currentDate
+            );
         });
     }
 }

--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.ts
@@ -12,6 +12,7 @@ import { UserRepositoryService } from 'app/core/repositories/users/user-reposito
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
 import { ViewMeeting } from 'app/site/event-management/models/view-meeting';
+import { ViewOrganisation } from 'app/site/event-management/models/view-organisation';
 import { ViewUser } from 'app/site/users/models/view-user';
 
 const AddMeetingLabel = _('Create Meeting');
@@ -75,7 +76,9 @@ export class MeetingEditComponent extends BaseModelContextComponent implements O
                 this.committeeId = Number(params.committeeId);
                 this.meetingId = Number(params.meetingId);
 
-                this.loadMeeting(this.meetingId);
+                if (this.meetingId) {
+                    this.loadMeeting(this.meetingId);
+                }
             })
         );
     }
@@ -124,19 +127,25 @@ export class MeetingEditComponent extends BaseModelContextComponent implements O
     }
 
     private requestUpdates(): void {
+        /**
+         * TODO: Requires orga members
+         */
         this.requestModels({
-            // viewModelCtor: ViewOrganization,
-            viewModelCtor: ViewMeeting,
-            /**
-             * TODO: Requires orga users
-             */
+            viewModelCtor: ViewOrganisation,
             ids: [1],
             follow: [
                 {
-                    // idField: 'member_ids',
-                    idField: 'user_ids'
+                    idField: 'committee_ids',
+                    fieldset: 'list',
+                    follow: [
+                        {
+                            idField: 'meeting_ids',
+                            follow: [{ idField: 'user_ids', fieldset: 'list' }]
+                        }
+                    ]
                 }
-            ]
+            ],
+            fieldset: []
         });
     }
 

--- a/client/src/app/management/components/meeting-list/meeting-list.component.html
+++ b/client/src/app/management/components/meeting-list/meeting-list.component.html
@@ -28,7 +28,7 @@
 </os-head-bar>
 
 <os-list-view-table
-    [listObservableProvider]="meetingRepo"
+    [listObservable]="meetingsObservable"
     [columns]="tableColumnDefinition"
     [alwaysShowMenu]="true"
     [allowProjector]="false"

--- a/client/src/app/management/components/member-edit/member-edit.component.html
+++ b/client/src/app/management/components/member-edit/member-edit.component.html
@@ -1,7 +1,12 @@
 <os-head-bar
     [customMenu]="true"
+    [hasMainButton]="true"
+    mainButtonIcon="edit"
+    (mainEvent)="setEditMode(!isEditingUser)"
+    [goBack]="true"
     [nav]="false"
-    [editMode]="false"
+    [editMode]="isEditingUser"
+    [isSaveButtonEnabled]="personalInfoForm?.valid"
     (cancelEditEvent)="onCancel()"
     (saveEvent)="onSubmit()"
 >
@@ -15,4 +20,205 @@
     </ng-container>
 </os-head-bar>
 
-<p>member-edit works!</p>
+<div class="member-container">
+    <mat-card
+        class="spacer-bottom-60"
+        (keydown)="onKeyDown($event)"
+        [ngClass]="isEditingUser ? 'os-form-card' : 'os-card'"
+        *ngIf="isAllowed('seeName')"
+    >
+        <ng-container *ngIf="isEditingUser; then editView; else showView"></ng-container>
+    </mat-card>
+</div>
+
+<ng-template #editView>
+    <form [formGroup]="personalInfoForm">
+        <div *ngIf="isAllowed('seeName')">
+            <!-- Title -->
+            <mat-form-field class="form16 distance force-min-with">
+                <input
+                    type="text"
+                    matInput
+                    osAutofocus
+                    placeholder="{{ 'Title' | translate }}"
+                    formControlName="title"
+                />
+            </mat-form-field>
+            <!-- First name -->
+            <mat-form-field class="form37 distance force-min-with">
+                <input type="text" matInput placeholder="{{ 'Given name' | translate }}" formControlName="first_name" />
+            </mat-form-field>
+
+            <!-- Last name -->
+            <mat-form-field class="form37 force-min-with">
+                <input type="text" matInput placeholder="{{ 'Surname' | translate }}" formControlName="last_name" />
+            </mat-form-field>
+        </div>
+
+        <div *ngIf="isAllowed('seePersonal')">
+            <!-- E-Mail -->
+            <mat-form-field class="form70 distance">
+                <input
+                    type="email"
+                    matInput
+                    autocomplete="off"
+                    placeholder="{{ 'Email' | translate }}"
+                    name="email"
+                    formControlName="email"
+                />
+                <mat-error *ngIf="personalInfoForm.get('email').hasError('email')">
+                    {{ 'Please enter a valid email address' | translate }}
+                </mat-error>
+            </mat-form-field>
+
+            <!-- Gender -->
+            <mat-form-field class="form25 force-min-with">
+                <mat-select placeholder="{{ 'Gender' | translate }}" formControlName="gender">
+                    <mat-option value="">-</mat-option>
+                    <mat-option *ngFor="let gender of genders" [value]="gender">{{ gender | translate }}</mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+
+        <ng-container *ngIf="!user || (user && !user.isTemporary)">
+            <div>
+                <!-- Strucuture Level -->
+                <mat-form-field
+                    class="distance"
+                    [ngClass]="{
+                        form37: true
+                    }"
+                >
+                    <input
+                        type="text"
+                        matInput
+                        placeholder="{{ 'Default structure level' | translate }}"
+                        formControlName="default_structure_level"
+                    />
+                </mat-form-field>
+
+                <!-- Participant Number -->
+                <mat-form-field
+                    [ngClass]="{
+                        distance: true,
+                        form37: true
+                    }"
+                >
+                    <input
+                        type="text"
+                        matInput
+                        placeholder="{{ 'Default number' | translate }}"
+                        formControlName="default_number"
+                    />
+                </mat-form-field>
+
+                <!-- Vote weight -->
+                <mat-form-field class="form16 force-min-with">
+                    <!-- TODO Input type should be number with limited decimal spaces -->
+                    <input
+                        type="number"
+                        matInput
+                        placeholder="{{ 'Default vote weight' | translate }}"
+                        formControlName="default_vote_weight"
+                    />
+                </mat-form-field>
+            </div>
+
+            <div>
+                <mat-form-field>
+                    <os-search-repo-selector
+                        formControlName="committee_as_member_ids"
+                        [multiple]="true"
+                        placeholder="{{ 'Member in committees' | translate }}"
+                        [repo]="committeeRepo"
+                    ></os-search-repo-selector>
+                </mat-form-field>
+            </div>
+        </ng-container>
+
+        <div *ngIf="isAllowed('manage')">
+            <!-- Initial Password -->
+            <mat-form-field>
+                <input
+                    matInput
+                    autocomplete="off"
+                    placeholder="{{ 'Initial password' | translate }}"
+                    formControlName="default_password"
+                />
+                <mat-hint align="end">Generate</mat-hint>
+                <button
+                    type="button"
+                    mat-button
+                    matSuffix
+                    mat-icon-button
+                    [disabled]="!isNewUser"
+                    (click)="setRandomPassword()"
+                >
+                    <mat-icon>sync_problem</mat-icon>
+                </button>
+            </mat-form-field>
+        </div>
+
+        <div *ngIf="isAllowed('seePersonal')">
+            <!-- username -->
+            <mat-form-field>
+                <input type="text" matInput placeholder="{{ 'Username' | translate }}" formControlName="username" />
+            </mat-form-field>
+        </div>
+
+        <div>
+            <mat-checkbox formControlName="is_active">{{ 'Is active' | translate }}</mat-checkbox>
+            <mat-checkbox formControlName="is_physical_person">{{ 'Is a physical person' | translate }}</mat-checkbox>
+        </div>
+    </form>
+</ng-template>
+
+<ng-template #showView>
+    <ng-container *ngIf="user">
+        <!-- User name -->
+        <div *ngIf="isAllowed('seeName')">
+            <h4>{{ 'Name' | translate }}</h4>
+            <span class="state-icons">
+                <span>{{ user.short_name }}</span>
+                <mat-icon *ngIf="!user.is_active && isAllowed('seeExtra')" matTooltip="{{ 'Inactive' | translate }}">
+                    block
+                </mat-icon>
+            </span>
+        </div>
+
+        <!-- Mail -->
+        <div *ngIf="isAllowed('seePersonal')">
+            <div *ngIf="user.email">
+                <h4>{{ 'Email' | translate }}</h4>
+                <span>{{ user.email }}</span>
+            </div>
+        </div>
+
+        <!-- Gender -->
+        <div *ngIf="user.gender">
+            <h4>{{ 'Gender' | translate }}</h4>
+            <span>{{ user.gender | translate }}</span>
+        </div>
+
+        <div *ngIf="isAllowed('manage')">
+            <!-- Username -->
+            <div *ngIf="user.username">
+                <h4>{{ 'Username' | translate }}</h4>
+                <span>{{ user.username }}</span>
+            </div>
+
+            <!-- Initial Password -->
+            <div *ngIf="user.default_password">
+                <h4>{{ 'Initial password' | translate }}</h4>
+                <span>{{ user.default_password }}</span>
+            </div>
+        </div>
+
+        <div *ngIf="isAllowed('seePersonal') && user.isLastEmailSend">
+            <div>
+                <h4>{{ 'Last email sent' | translate }}</h4>
+                <span>{{ getEmailSentTime() }}</span>
+            </div>
+        </div>
+    </ng-container>
+</ng-template>

--- a/client/src/app/management/components/member-edit/member-edit.component.scss
+++ b/client/src/app/management/components/member-edit/member-edit.component.scss
@@ -1,0 +1,44 @@
+@import '~assets/styles/media-queries.scss';
+
+@include set-breakpoint-upper(xs) {
+    .form70 {
+        width: 70%;
+    }
+
+    .form37 {
+        width: 37%;
+    }
+
+    .form25 {
+        width: 25%;
+    }
+
+    .form16 {
+        width: 16%;
+    }
+}
+
+.force-min-width {
+    min-width: 110px;
+}
+
+.distance {
+    padding-right: 5%;
+}
+
+mat-checkbox {
+    margin-right: 10px;
+}
+
+.state-icons {
+    display: flex;
+
+    mat-icon {
+        margin-left: 5px;
+    }
+}
+
+.member-container {
+    height: calc(100vh - 64px);
+    overflow-y: scroll;
+}

--- a/client/src/app/management/components/member-edit/member-edit.component.ts
+++ b/client/src/app/management/components/member-edit/member-edit.component.ts
@@ -1,16 +1,278 @@
 import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { CommitteeRepositoryService } from 'app/core/repositories/event-management/committee-repository.service';
+import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
+import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PromptService } from 'app/core/ui-services/prompt.service';
+import { genders } from 'app/shared/models/users/user';
+import { OneOfValidator } from 'app/shared/validators/one-of-validator';
+import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
+import { ViewUser } from 'app/site/users/models/view-user';
 
 @Component({
     selector: 'os-member-edit',
     templateUrl: './member-edit.component.html',
     styleUrls: ['./member-edit.component.scss']
 })
-export class MemberEditComponent implements OnInit {
-    public constructor() {}
+export class MemberEditComponent extends BaseModelContextComponent implements OnInit {
+    public personalInfoForm: FormGroup;
 
-    public ngOnInit(): void {}
+    public genders = genders;
 
-    public onSubmit(): void {}
+    public isEditingUser = false;
+    public user: ViewUser;
+    public isNewUser = false;
 
-    public onCancel(): void {}
+    public constructor(
+        componentServiceCollector: ComponentServiceCollector,
+        public committeeRepo: CommitteeRepositoryService,
+        private fb: FormBuilder,
+        private repo: UserRepositoryService,
+        private route: ActivatedRoute,
+        private router: Router,
+        private promptService: PromptService
+    ) {
+        super(componentServiceCollector);
+    }
+
+    public ngOnInit(): void {
+        this.getUserByUrl();
+    }
+
+    public async onSubmit(): Promise<void> {
+        if (this.personalInfoForm.invalid) {
+            this.checkFormForErrors();
+            return;
+        }
+
+        try {
+            await this.createOrUpdateUser();
+        } catch (e) {
+            this.raiseError(e);
+        }
+    }
+
+    public onCancel(): void {
+        this.router.navigate(['..'], { relativeTo: this.route });
+    }
+
+    /**
+     * Should determine if the user (Operator) has the
+     * correct permission to perform the given action.
+     *
+     * actions might be:
+     * - delete         (deleting the user) (users.can_manage and not ownPage)
+     * - seeName        (title, first, last, gender, about) (user.can_see_name or ownPage)
+     * - seeOtherUsers  (title, first, last, gender, about) (user.can_see_name)
+     * - seeExtra       (email, comment, is_active, last_email_send) (user.can_see_extra_data)
+     * - seePersonal    (mail, username, structure level) (user.can_see_extra_data or ownPage)
+     * - manage         (everything) (user.can_manage)
+     * - changePersonal (mail, username, about) (user.can_manage or ownPage)
+     * - changePassword (user.can_change_password)
+     *
+     * @param action the action the user tries to perform
+     */
+    public isAllowed(action: string): boolean {
+        switch (action) {
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Handler for the generate Password button.
+     */
+    public setRandomPassword(): void {
+        this.personalInfoForm.patchValue({
+            default_password: this.repo.getRandomPassword()
+        });
+    }
+
+    /**
+     * clicking Shift and Enter will save automatically
+     *
+     * @param event has the code
+     */
+    public onKeyDown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' && event.shiftKey) {
+            this.onSubmit();
+        }
+    }
+
+    /**
+     * click on the delete user button
+     */
+    public async deleteUserButton(): Promise<void> {
+        const title = this.translate.instant('Are you sure you want to delete this member?');
+        const content = this.user.full_name;
+        if (await this.promptService.open(title, content)) {
+            await this.repo.delete(this.user);
+            this.router.navigate(['./members/']);
+        }
+    }
+
+    /**
+     * sets editUser variable and editable form
+     * @param edit
+     */
+    public async setEditMode(edit: boolean): Promise<void> {
+        this.isEditingUser = edit;
+
+        if (edit) {
+            this.enterEditMode();
+        }
+
+        // case: abort creation of a new user
+        if (this.isNewUser && !edit) {
+            this.router.navigate(['./members/']);
+        }
+    }
+
+    private enterEditMode(): void {
+        this.createForm();
+        this.updateFormControlsAccessibility();
+        if (this.user) {
+            this.patchFormValues();
+        }
+    }
+
+    /**
+     * Updates the formcontrols of the `personalInfoForm` with the values from a given user.
+     */
+    private patchFormValues(): void {
+        const personalInfoPatch = {};
+        Object.keys(this.personalInfoForm.controls).forEach(ctrl => {
+            if (typeof this.user[ctrl] === 'function') {
+                personalInfoPatch[ctrl] = this.user[ctrl]();
+            } else {
+                personalInfoPatch[ctrl] = this.user[ctrl];
+            }
+        });
+        this.personalInfoForm.patchValue(personalInfoPatch);
+    }
+
+    /**
+     * Makes the form editable
+     */
+    private updateFormControlsAccessibility(): void {
+        const formControlNames = Object.keys(this.personalInfoForm.controls);
+
+        // Enable all controls.
+        formControlNames.forEach(formControlName => {
+            this.personalInfoForm.get(formControlName).enable();
+        });
+
+        // Disable not permitted controls
+        if (!this.isAllowed('manage')) {
+            formControlNames.forEach(formControlName => {
+                if (!['username', 'email', 'about_me'].includes(formControlName)) {
+                    this.personalInfoForm.get(formControlName).disable();
+                }
+            });
+        }
+    }
+
+    /**
+     * initialize the form with default values
+     */
+    private createForm(): void {
+        if (this.personalInfoForm) {
+            return;
+        }
+        this.personalInfoForm = this.fb.group(
+            {
+                username: [undefined],
+                title: [undefined],
+                first_name: [undefined],
+                last_name: [undefined],
+                gender: [undefined],
+                email: [undefined, Validators.email],
+                committee_as_member_ids: [[]],
+                last_email_send: [undefined],
+                default_password: [undefined],
+                default_structure_level: [undefined],
+                default_number: [undefined],
+                default_vote_weight: [undefined],
+                is_active: [true],
+                is_physical_person: [true]
+            },
+            {
+                validators: OneOfValidator.validation('username', 'first_name', 'last_name')
+            }
+        );
+    }
+
+    private getUserByUrl(): void {
+        if (this.route.snapshot.url[0] && this.route.snapshot.url[0].path === 'create') {
+            super.setTitle('New member');
+            this.isNewUser = true;
+            this.setEditMode(true);
+        } else {
+            this.route.params.subscribe(params => {
+                this.loadUserById(Number(params.id));
+            });
+        }
+    }
+
+    private loadUserById(userId: number): void {
+        if (userId) {
+            this.requestModels({
+                viewModelCtor: ViewUser,
+                ids: [userId],
+                follow: [],
+                fieldset: 'orga'
+            });
+
+            this.subscriptions.push(
+                this.repo.getViewModelObservable(userId).subscribe(user => {
+                    if (user) {
+                        const title = user.getTitle();
+                        super.setTitle(title);
+                        this.user = user;
+                    }
+                })
+            );
+        }
+    }
+
+    private async createOrUpdateUser(): Promise<void> {
+        if (this.isNewUser) {
+            await this.createRealUser();
+        } else {
+            await this.updateRealUser();
+        }
+    }
+
+    private async createRealUser(): Promise<void> {
+        const payload = {
+            ...this.personalInfoForm.value
+        };
+        const identifiable = await this.repo.create(payload);
+        this.router.navigate(['..', identifiable.id], { relativeTo: this.route });
+    }
+
+    private async updateRealUser(): Promise<void> {
+        const payload = {
+            ...this.personalInfoForm.value
+        };
+        await this.repo.update(payload, this.user);
+        this.setEditMode(false);
+    }
+
+    private checkFormForErrors(): void {
+        let hint = '';
+        const personalInfoForm = this.personalInfoForm;
+        if (personalInfoForm.errors) {
+            hint = 'At least one of username, first name or last name has to be set.';
+        } else {
+            for (const formControl in personalInfoForm.controls) {
+                if (personalInfoForm.get(formControl).errors) {
+                    hint = formControl + ' is incorrect.';
+                }
+            }
+        }
+        this.raiseError(this.translate.instant(hint));
+    }
 }

--- a/client/src/app/management/components/member-list/member-list.component.html
+++ b/client/src/app/management/components/member-list/member-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar [customMenu]="true" [hasMainButton]="false" (mainEvent)="createNewMember()">
+<os-head-bar [customMenu]="true" [hasMainButton]="true" (mainEvent)="createNewMember()">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Members' | translate }}</h2>
@@ -10,7 +10,7 @@
 </os-head-bar>
 
 <os-list-view-table
-    [listObservableProvider]="repo"
+    [listObservable]="repo.getViewModelListObservable()"
     [columns]="tableColumnDefinition"
     [showListOfSpeakers]="false"
     [showListOfSpeakers]="false"
@@ -20,11 +20,35 @@
 >
     <!-- Name column -->
     <div *pblNgridCellDef="'short_name'; row as user; rowContext as rowContext" class="cell-slot fill">
-        <!-- <a class="detail-link" [routerLink]="user.id" *ngIf="!isMultiSelect"></a> -->
+        <a class="detail-link" [routerLink]="user.id" *ngIf="!isMultiSelect"></a>
         <div class="nameCell">
             <div>
-                <div>{{ user.short_name }}</div>
+                <os-icon-container
+                    icon="error_outline"
+                    [swap]="true"
+                    [showIcon]="user.isTemporary"
+                    iconTooltip="{{ 'This user is temporary' | translate }}"
+                >
+                    {{ user.short_name }}
+                </os-icon-container>
             </div>
+        </div>
+    </div>
+    <!-- Info column -->
+    <div *pblNgridCellDef="'info'; row as user">
+        <div class="flex-center">
+            <mat-icon
+                *ngIf="!user.isTemporary && user.committee_as_member_ids?.length"
+                matTooltip="{{ 'Member in committees' | translate }}"
+            >
+                account_balance
+            </mat-icon>
+            <ng-container *ngFor="let committee of user.committees_as_member; last as last">
+                <os-icon-container [showIcon]="false" [noWrap]="true" [inline]="true">
+                    {{ committee.name | translate }}
+                    <span *ngIf="!last">,</span>
+                </os-icon-container>
+            </ng-container>
         </div>
     </div>
 </os-list-view-table>

--- a/client/src/app/management/components/member-list/member-list.component.ts
+++ b/client/src/app/management/components/member-list/member-list.component.ts
@@ -3,13 +3,18 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { PblColumnDefinition } from '@pebula/ngrid';
 
+import { HttpService } from 'app/core/core-services/http.service';
 import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
+import { Id } from 'app/core/definitions/key-types';
 import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component';
-import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
-import { ViewMeeting } from 'app/site/event-management/models/view-meeting';
+import { ViewCommittee } from 'app/site/event-management/models/view-committee';
 import { ViewUser } from 'app/site/users/models/view-user';
+
+interface GetUsersRequest {
+    users: Id[];
+}
 
 @Component({
     selector: 'os-members',
@@ -21,12 +26,17 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
         {
             prop: 'short_name',
             width: 'auto'
+        },
+        {
+            prop: 'info',
+            width: '65%'
         }
     ];
 
     public constructor(
         public repo: UserRepositoryService,
         protected componentServiceCollector: ComponentServiceCollector,
+        private http: HttpService,
         private router: Router,
         private route: ActivatedRoute
     ) {
@@ -36,26 +46,39 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
 
     public ngOnInit(): void {
         super.ngOnInit();
-    }
-
-    protected getModelRequest(): SimplifiedModelRequest {
-        return {
-            // viewModelCtor: ViewOrganization,
-            viewModelCtor: ViewMeeting,
-            /**
-             * TODO: Requires orga users
-             */
-            ids: [1],
-            follow: [
-                {
-                    idField: 'user_ids'
-                }
-            ],
-            fieldset: []
-        };
+        this.loadUsers();
     }
 
     public createNewMember(): void {
         this.router.navigate(['create'], { relativeTo: this.route });
+    }
+
+    public isCommitteeManager(user: ViewUser, committee: ViewCommittee): boolean {
+        return user.committees_as_manager.includes(committee);
+    }
+
+    private async loadUsers(start_index: number = 0, entries: number = 10000): Promise<void> {
+        const payload = [
+            {
+                presenter: 'get_users',
+                data: {
+                    start_index,
+                    entries,
+                    include_temporary: true
+                }
+            }
+        ];
+        try {
+            const response = await this.http.post<GetUsersRequest[]>('/system/presenter/handle_request', payload);
+            const request: SimplifiedModelRequest = {
+                viewModelCtor: ViewUser,
+                ids: response[0].users,
+                fieldset: 'orga',
+                follow: [{ idField: 'committee_as_manager_ids' }, { idField: 'committee_as_member_ids' }]
+            };
+            this.requestModels(request, 'load_users');
+        } catch (e) {
+            console.log('Error:', e);
+        }
     }
 }

--- a/client/src/app/shared/components/head-bar/head-bar.component.ts
+++ b/client/src/app/shared/components/head-bar/head-bar.component.ts
@@ -126,7 +126,7 @@ export class HeadBarComponent implements OnInit {
      * Has only an effect if goBack is set to false
      */
     @Input()
-    public prevUrl = '../';
+    public prevUrl = '..';
 
     /**
      * Optional tooltip for the main action
@@ -232,7 +232,8 @@ export class HeadBarComponent implements OnInit {
         } else if (this.routingState.customOrigin && this.routingState.customOrigin !== this.router.url) {
             this.router.navigate([this.routingState.customOrigin], { relativeTo: this.route });
         } else {
-            this.router.navigate([this.prevUrl], { relativeTo: this.route });
+            const relativeToRoute = !!this.route.snapshot.url.length ? this.route : this.route.parent;
+            this.router.navigate([this.prevUrl], { relativeTo: relativeToRoute });
         }
     }
 }

--- a/client/src/app/shared/components/icon-container/icon-container.component.html
+++ b/client/src/app/shared/components/icon-container/icon-container.component.html
@@ -8,6 +8,7 @@
 >
 <span class="content-node" [ngClass]="noWrap ? 'single-line' : 'break-lines'">
     <ng-content></ng-content>
+    <ng-content select="[afterContent]"></ng-content>
 </span>
 <mat-icon
     *ngIf="swap && showIcon"

--- a/client/src/app/shared/components/icon-container/icon-container.component.scss
+++ b/client/src/app/shared/components/icon-container/icon-container.component.scss
@@ -1,7 +1,7 @@
 @mixin icon-container($iconSize, $contentSize, $fontWeight) {
     line-height: $iconSize;
 
-    & > mat-icon {
+    & mat-icon {
         font-size: $iconSize;
         width: $iconSize;
         height: $iconSize;
@@ -38,7 +38,13 @@ os-icon-container {
         @include icon-container(34px, 22px, 400);
     }
 
+    &.inline {
+        display: inline-flex;
+        margin-top: 0;
+    }
+
     .content-node {
+        display: inline-flex;
         margin: auto 5px;
         text-overflow: ellipsis;
         overflow: hidden;

--- a/client/src/app/shared/components/icon-container/icon-container.component.ts
+++ b/client/src/app/shared/components/icon-container/icon-container.component.ts
@@ -11,7 +11,7 @@ export class IconContainerComponent {
      */
     @HostBinding('class')
     public get classes(): string {
-        return `${this.size}-container`;
+        return `${this.size}-container ${this.inline ? 'inline' : ''}`;
     }
 
     /**
@@ -25,6 +25,9 @@ export class IconContainerComponent {
      */
     @Input()
     public size: 'small' | 'medium' | 'large' | 'gigantic' = 'medium';
+
+    @Input()
+    public inline = false;
 
     /**
      * Reverse text and icon.

--- a/client/src/app/shared/components/media-upload-content/media-upload-content.component.ts
+++ b/client/src/app/shared/components/media-upload-content/media-upload-content.component.ts
@@ -6,11 +6,7 @@ import { Router } from '@angular/router';
 import { FileSystemFileEntry, NgxFileDropEntry } from 'ngx-file-drop';
 import { BehaviorSubject } from 'rxjs';
 
-import { ActiveMeetingIdService } from 'app/core/core-services/active-meeting-id.service';
-import { ActiveMeetingService } from 'app/core/core-services/active-meeting.service';
 import { ModelSubscription } from 'app/core/core-services/autoupdate.service';
-import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
-import { ModelRequestService } from 'app/core/core-services/model-request.service';
 import { MediafileRepositoryService } from 'app/core/repositories/mediafiles/mediafile-repository.service';
 import { GroupRepositoryService } from 'app/core/repositories/users/group-repository.service';
 import { toBase64 } from 'app/core/to-base64';
@@ -107,8 +103,7 @@ export class MediaUploadContentComponent extends BaseModelContextComponent imple
         private repo: MediafileRepositoryService,
         private formBuilder: FormBuilder,
         private groupRepo: GroupRepositoryService,
-        private router: Router,
-        private activeMeetingIdService: ActiveMeetingIdService
+        private router: Router
     ) {
         super(componentServiceCollector);
         this.directoryBehaviorSubject = this.repo.getDirectoryBehaviorSubject();
@@ -143,7 +138,7 @@ export class MediaUploadContentComponent extends BaseModelContextComponent imple
 
         this.requestModels({
             viewModelCtor: ViewMeeting,
-            ids: [this.activeMeetingIdService.meetingId],
+            ids: [this.activeMeetingId],
             follow: [{ idField: 'mediafile_ids', fieldset: 'fileCreation' }],
             fieldset: []
         });

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.html
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.html
@@ -10,7 +10,7 @@
     </mat-option>
     <ng-container *ngIf="multiple && showChips">
         <div #chipPlaceholder>
-            <div class="os-search-selector--chip-container" [style.width]="width">
+            <div class="os-search-selector--chip-container">
                 <mat-chip-list class="chip-list" [selectable]="false">
                     <mat-chip
                         *ngFor="let item of selectedItems"

--- a/client/src/app/shared/components/search-selector/search-repo-selector/search-repo-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/search-repo-selector/search-repo-selector.component.ts
@@ -1,5 +1,5 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { Component, ElementRef, Input, OnInit, Optional, Self, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, Optional, Self, ViewEncapsulation } from '@angular/core';
 import { FormBuilder, NgControl } from '@angular/forms';
 import { MatFormFieldControl } from '@angular/material/form-field';
 
@@ -25,7 +25,7 @@ import { Selectable } from '../../selectable';
     providers: [{ provide: MatFormFieldControl, useExisting: SearchRepoSelectorComponent }],
     encapsulation: ViewEncapsulation.None
 })
-export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponent implements OnInit {
+export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponent implements OnInit, OnDestroy {
     @Input()
     public repo: BaseRepository<any, any> & ModelRequestRepository;
 
@@ -60,6 +60,11 @@ export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponen
 
     public ngOnInit(): void {
         this.init();
+    }
+
+    public ngOnDestroy(): void {
+        super.ngOnDestroy();
+        this.cleanModelSubscription();
     }
 
     public onContainerClick(event: MouseEvent): void {

--- a/client/src/app/shared/models/event-management/committee.ts
+++ b/client/src/app/shared/models/event-management/committee.ts
@@ -10,6 +10,7 @@ export class Committee extends BaseModel<Committee> {
 
     public meeting_ids: Id[]; // (meeting/committee_id)[];
     public default_meeting_id: Id; // meeting/default_meeting_for_committee_id;
+    public template_meeting_id: Id; // meeting/template_meeting_for_committee_id;
     public member_ids: Id[]; // (user/committee_as_memeber_ids)[];
     public manager_ids: Id[]; // (user/committee_as_manager_ids)[];
     public forward_to_committee_ids: Id[]; // (committee/receive_forwardings_from_committee_ids)[];

--- a/client/src/app/shared/models/event-management/meeting.ts
+++ b/client/src/app/shared/models/event-management/meeting.ts
@@ -185,6 +185,7 @@ export class Meeting extends BaseModel<Meeting> {
 
     // Other relations
     public committee_id: Id; // committee/meeting_ids;
+    public template_meeting_for_committee_id: Id; // committee/template_meeting_id;
     public default_meeting_for_committee_id: Id; // committee/default_meeting_id;
     public present_user_ids: Id[]; // (user/is_present_in_meeting_ids)[];
     public temporary_user_ids: Id[]; // (user/meeting_id)[];

--- a/client/src/app/shared/validators/one-of-validator.ts
+++ b/client/src/app/shared/validators/one-of-validator.ts
@@ -17,9 +17,7 @@ export class OneOfValidator {
         return (control: AbstractControl): ValidationErrors | null => {
             const formControls = keys.map(key => control.get(key));
 
-            const noOneSet = formControls.every(
-                formControl => (formControl && formControl.value === '') || !formControl
-            );
+            const noOneSet = formControls.every(formControl => (formControl && !formControl.value) || !formControl);
 
             return noOneSet ? { noOneSet: true } : null;
         };

--- a/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.ts
+++ b/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.ts
@@ -200,7 +200,7 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
      */
     public getDetailUrl(item: ViewAgendaItem): string {
         if (item.content_object && !this.isMultiSelect) {
-            return item.content_object.getDetailStateURL();
+            return `/${item.content_object.getDetailStateURL()}`;
         }
     }
 

--- a/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.ts
+++ b/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
 import { BehaviorSubject, Subscription } from 'rxjs';
 
-import { ActiveMeetingIdService } from 'app/core/core-services/active-meeting-id.service';
 import { OperatorService } from 'app/core/core-services/operator.service';
 import { Permission } from 'app/core/core-services/permission';
 import { Id } from 'app/core/definitions/key-types';
@@ -196,8 +195,7 @@ export class AssignmentDetailComponent extends BaseModelContextComponent impleme
         private pdfService: AssignmentPdfExportService,
         private mediafileRepo: MediafileRepositoryService,
         private pollDialog: AssignmentPollDialogService,
-        private assignmentPollService: AssignmentPollService,
-        private activeMeetingIdService: ActiveMeetingIdService
+        private assignmentPollService: AssignmentPollService
     ) {
         super(componentServiceCollector);
         this.subscriptions.push(
@@ -240,7 +238,7 @@ export class AssignmentDetailComponent extends BaseModelContextComponent impleme
             {
                 // Get all available groups in an active meeting.
                 viewModelCtor: ViewMeeting,
-                ids: [this.activeMeetingIdService.meetingId],
+                ids: [this.activeMeetingId],
                 follow: [{ idField: 'group_ids' }]
             },
             'groups'

--- a/client/src/app/site/base/base-view-model.ts
+++ b/client/src/app/site/base/base-view-model.ts
@@ -1,4 +1,4 @@
-import { Fqid } from 'app/core/definitions/key-types';
+import { Fqid, Id } from 'app/core/definitions/key-types';
 import { BaseModel } from 'app/shared/models/base/base-model';
 import { Collection } from 'app/shared/models/base/collection';
 import { Displayable } from './displayable';
@@ -50,4 +50,5 @@ export interface BaseViewModel<M extends BaseModel = any> extends Displayable, I
      * @returns the verbose name of the model
      */
     getVerboseName: (plural?: boolean) => string;
+    getActiveMeetingId: () => Id;
 }

--- a/client/src/app/site/base/components/base.component.ts
+++ b/client/src/app/site/base/components/base.component.ts
@@ -105,6 +105,10 @@ export abstract class BaseComponent implements OnDestroy {
         return this.componentServiceCollector.modelRequestService;
     }
 
+    protected get activeMeetingId(): Id {
+        return this.componentServiceCollector.activeMeetingId.meetingId;
+    }
+
     public constructor(protected componentServiceCollector: ComponentServiceCollector) {
         this.tinyMceSettings.language_url = '/assets/tinymce/langs/' + this.translate.currentLang + '.js';
         this.tinyMceSettings.language = this.translate.currentLang;

--- a/client/src/app/site/common/components/super-search/super-search.component.ts
+++ b/client/src/app/site/common/components/super-search/super-search.component.ts
@@ -339,7 +339,7 @@ export class SuperSearchComponent implements OnInit {
         if (model.collection === 'mediafiles/mediafile' && !(<ViewMediafile>model).is_directory) {
             window.open(model.getDetailStateURL(), '_blank');
         } else {
-            this.router.navigateByUrl(model.getDetailStateURL());
+            this.router.navigate([model.getDetailStateURL()]);
         }
         this.hideOverlay();
         this.saveQueryToStorage(this.searchForm.value);

--- a/client/src/app/site/event-management/models/view-committee.ts
+++ b/client/src/app/site/event-management/models/view-committee.ts
@@ -28,5 +28,6 @@ interface ICommitteeRelations {
     forward_to_committees: ViewCommittee[];
     receive_forwardings_from_committees: ViewCommittee[];
     organisation: ViewOrganisation;
+    template_meeting: ViewMeeting;
 }
 export interface ViewCommittee extends Committee, ICommitteeRelations {}

--- a/client/src/app/site/event-management/models/view-meeting.ts
+++ b/client/src/app/site/event-management/models/view-meeting.ts
@@ -97,6 +97,7 @@ interface IMeetingRelations {
     logo: StructuredRelation<string, ViewMediafile | null>;
     font: StructuredRelation<string, ViewMediafile | null>;
     committee: ViewCommittee;
+    template_meeting_for_committee?: ViewCommittee;
     default_meeting_for_committee?: ViewCommittee;
     present_users: ViewUser[];
     temporary_users: ViewUser[];

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
@@ -36,7 +36,6 @@ import {
 import { MeetingSettingsService } from 'app/core/ui-services/meeting-settings.service';
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { ViewportService } from 'app/core/ui-services/viewport.service';
-import { CreateMediafile } from 'app/shared/models/mediafiles/create-mediafile';
 import { Mediafile } from 'app/shared/models/mediafiles/mediafile';
 import { infoDialogSettings } from 'app/shared/utils/dialog-settings';
 import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component';
@@ -219,10 +218,8 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
         super.setTitle('Files');
         this.createDataSource();
 
-        // const directoryId = this.route.snapshot.url.length > 0 ? +this.route.snapshot.url[0].path : null;
-        // console.log('this.route.snapshot: ', this.route.snapshot);
-        // const directoryId =
-        // this.changeDirectory(directoryId);
+        const directoryId = this.route.snapshot.url.length > 0 ? +this.route.snapshot.url[0].path : null;
+        this.changeDirectory(directoryId);
     }
 
     public ngOnDestroy(): void {
@@ -296,7 +293,7 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
                     console.log('has newDirectory: ');
                     this.directoryChain = newDirectory.getDirectoryChain();
                     // Update the URL.
-                    this.router.navigate(['mediafiles/' + newDirectory.id]);
+                    this.router.navigate([this.activeMeetingId, 'mediafiles', newDirectory.id]);
                 } else {
                     console.log('directoryId No newDirectory');
                     this.directoryChain = [];
@@ -312,7 +309,7 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
 
     public onMainEvent(): void {
         const path = 'mediafiles/upload/' + (this.directory ? this.directory.id : '');
-        this.router.navigate([path]);
+        this.router.navigate([this.activeMeetingId, 'mediafiles', 'upload', this.directory ? this.directory.id : '']);
     }
 
     /**
@@ -402,11 +399,11 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
 
         dialogRef.afterClosed().subscribe(result => {
             if (result) {
-                const mediafile = new CreateMediafile({
+                const mediafile = {
                     ...this.newDirectoryForm.value,
                     parent_id: this.directory ? this.directory.id : null,
                     is_directory: true
-                });
+                };
                 this.repo.createDirectory(mediafile).catch(this.raiseError);
             }
         });

--- a/client/src/app/site/motions/models/view-motion-category.ts
+++ b/client/src/app/site/motions/models/view-motion-category.ts
@@ -77,7 +77,7 @@ export class ViewMotionCategory extends BaseViewModel<MotionCategory> implements
     }
 
     public getDetailStateURL(): string {
-        return `motions/category/${this.id}`;
+        return `/${this.getActiveMeetingId()}/motions/category/${this.id}`;
     }
 
     /**

--- a/client/src/app/site/motions/modules/amendment-list/amendment-list.component.html
+++ b/client/src/app/site/motions/modules/amendment-list/amendment-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false" [multiSelectMode]="isMultiSelect">
+<os-head-bar [nav]="false" [multiSelectMode]="isMultiSelect">
     <!-- Title -->
     <div class="title-slot" *ngIf="!parentMotion">
         <h2>{{ 'Amendments' | translate }}</h2>
@@ -60,9 +60,7 @@
                 </span>
 
                 <span *ngIf="showSequentialNumber">
-                    <span *ngIf="motion.submitters.length">
-                        &middot;
-                    </span>
+                    <span *ngIf="motion.submitters.length"> &middot; </span>
                     <span>{{ 'Sequential number' | translate }}</span>
                     {{ motion.id }}
                 </span>

--- a/client/src/app/site/motions/modules/call-list/call-list.component.html
+++ b/client/src/app/site/motions/modules/call-list/call-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false" [editMode]="hasChanged" (mainEvent)="onCancel()" (saveEvent)="onSave()">
+<os-head-bar [nav]="false" [editMode]="hasChanged" (mainEvent)="onCancel()" (saveEvent)="onSave()">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Call list' | translate }}</h2>

--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.html
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-list/motion-block-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false" [hasMainButton]="canEdit" (mainEvent)="onPlusButton()">
+<os-head-bar [nav]="false" [hasMainButton]="canEdit" (mainEvent)="onPlusButton()">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Motion blocks' | translate }}</h2>

--- a/client/src/app/site/motions/modules/motion-category/components/category-list/category-list.component.html
+++ b/client/src/app/site/motions/modules/motion-category/components/category-list/category-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false" [hasMainButton]="canEdit" (mainEvent)="onPlusButton()">
+<os-head-bar [nav]="false" [hasMainButton]="canEdit" (mainEvent)="onPlusButton()">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Categories' | translate }}</h2>

--- a/client/src/app/site/motions/modules/motion-comment-section/components/motion-comment-section-list/motion-comment-section-list.component.html
+++ b/client/src/app/site/motions/modules/motion-comment-section/components/motion-comment-section-list/motion-comment-section-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false" [hasMainButton]="true" (mainEvent)="openDialog()">
+<os-head-bar [nav]="false" [hasMainButton]="true" (mainEvent)="openDialog()">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Comment fields' | translate }}</h2>
@@ -24,17 +24,13 @@
                     <div class="read">
                         <os-icon-container icon="visibility">
                             {{ section.read_groups }}
-                            <ng-container *ngIf="section.read_groups.length === 0">
-                                &ndash;
-                            </ng-container>
+                            <ng-container *ngIf="section.read_groups.length === 0"> &ndash; </ng-container>
                         </os-icon-container>
                     </div>
                     <div class="write">
                         <os-icon-container icon="edit">
                             {{ section.write_groups }}
-                            <ng-container *ngIf="section.write_groups.length === 0">
-                                &ndash;
-                            </ng-container>
+                            <ng-container *ngIf="section.write_groups.length === 0"> &ndash; </ng-container>
                         </os-icon-container>
                     </div>
                 </div>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -1,7 +1,6 @@
 <os-head-bar
     [hasMainButton]="perms.isAllowed('can_create_amendments', motion)"
     mainActionTooltip="New amendment"
-    prevUrl="../.."
     [nav]="false"
     [editMode]="editMotion"
     [isSaveButtonEnabled]="canSave"

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -14,7 +14,6 @@ import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 
 import { MotionAction } from 'app/core/actions/motion-action';
-import { ActiveMeetingIdService } from 'app/core/core-services/active-meeting-id.service';
 import { OperatorService } from 'app/core/core-services/operator.service';
 import { Id } from 'app/core/definitions/key-types';
 import { AgendaItemRepositoryService } from 'app/core/repositories/agenda/agenda-item-repository.service';
@@ -209,8 +208,7 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
         private motionFilterService: MotionFilterListService,
         private amendmentFilterService: AmendmentFilterListService,
         private cd: ChangeDetectorRef,
-        private meetingSettingsService: MeetingSettingsService,
-        private activeMeetingIdService: ActiveMeetingIdService
+        private meetingSettingsService: MeetingSettingsService
     ) {
         super(componentServiceCollector);
     }
@@ -298,7 +296,7 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
         this.requestModels(
             {
                 viewModelCtor: ViewMeeting,
-                ids: [this.activeMeetingIdService.meetingId],
+                ids: [this.activeMeetingId],
                 follow: [
                     {
                         idField: 'user_ids',

--- a/client/src/app/site/motions/modules/motion-import/motion-import-list.component.html
+++ b/client/src/app/site/motions/modules/motion-import/motion-import-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false">
+<os-head-bar [nav]="false">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Import motions' | translate }}</h2>

--- a/client/src/app/site/motions/modules/motion-workflow/components/workflow-list/workflow-list.component.html
+++ b/client/src/app/site/motions/modules/motion-workflow/components/workflow-list/workflow-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false" [hasMainButton]="true" (mainEvent)="onNewButton(newWorkflowDialog)">
+<os-head-bar [nav]="false" [hasMainButton]="true" (mainEvent)="onNewButton(newWorkflowDialog)">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Workflows' | translate }}</h2>

--- a/client/src/app/site/motions/modules/statute-paragraph/components/statute-paragraph-list/statute-paragraph-list.component.html
+++ b/client/src/app/site/motions/modules/statute-paragraph/components/statute-paragraph-list/statute-paragraph-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar prevUrl="../.." [nav]="false" [hasMainButton]="true" (mainEvent)="openDialog()">
+<os-head-bar [nav]="false" [hasMainButton]="true" (mainEvent)="openDialog()">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Statute' | translate }}</h2>

--- a/client/src/app/site/projector/components/projector-detail/projector-detail.component.ts
+++ b/client/src/app/site/projector/components/projector-detail/projector-detail.component.ts
@@ -97,22 +97,24 @@ export class ProjectorDetailComponent extends BaseModelContextComponent implemen
     ) {
         super(componentServiceCollector);
 
-        this.countdownRepo.getViewModelListObservable().subscribe(countdowns => (this.countdowns = countdowns));
-        this.messageRepo.getViewModelListObservable().subscribe(messages => (this.messages = messages));
-        this.projectorRepo
-            .getViewModelListObservable()
-            .subscribe(projectors => (this.projectorCount = projectors.length));
-        // TODO: remove.
-        // This is just for testing the new autoupdate/projector service mechanism
-        this.projectorRepo.getViewModelListObservable().subscribe(p => {
-            p.forEach(x => {
-                console.log(
-                    x,
-                    x.current_projections,
-                    x.current_projections.map((y: any) => y.content)
-                );
-            });
-        });
+        this.subscriptions.push(
+            this.countdownRepo.getViewModelListObservable().subscribe(countdowns => (this.countdowns = countdowns)),
+            this.messageRepo.getViewModelListObservable().subscribe(messages => (this.messages = messages)),
+            this.projectorRepo
+                .getViewModelListObservable()
+                .subscribe(projectors => (this.projectorCount = projectors.length)),
+            // TODO: remove.
+            // This is just for testing the new autoupdate/projector service mechanism
+            this.projectorRepo.getViewModelListObservable().subscribe(p => {
+                p.forEach(x => {
+                    console.log(
+                        x,
+                        x.current_projections,
+                        x.current_projections.map((y: any) => y.content)
+                    );
+                });
+            })
+        );
     }
 
     /**
@@ -152,7 +154,7 @@ export class ProjectorDetailComponent extends BaseModelContextComponent implemen
         this.requestModels(
             {
                 viewModelCtor: ViewMeeting,
-                ids: [this.activeMeetingService.meetingId],
+                ids: [this.activeMeetingId],
                 follow: ['projector_countdown_ids', 'projector_message_ids']
             },
             'messages and countdowns'
@@ -278,7 +280,7 @@ export class ProjectorDetailComponent extends BaseModelContextComponent implemen
             if (result) {
                 const defaultTime = this.durationService.stringToDuration(result.duration, 'm');
                 const countdown = {
-                    meeting_id: this.activeMeetingService.meetingId,
+                    meeting_id: this.activeMeetingId,
                     title: result.title,
                     description: result.description,
                     default_time: defaultTime
@@ -301,7 +303,7 @@ export class ProjectorDetailComponent extends BaseModelContextComponent implemen
         dialogRef.afterClosed().subscribe(result => {
             if (result) {
                 const message: ProjectorMessageAction.CreatePayload = {
-                    meeting_id: this.activeMeetingService.meetingId,
+                    meeting_id: this.activeMeetingId,
                     message: result.message
                 };
                 this.messageRepo.create(message);

--- a/client/src/app/site/topics/models/view-topic.ts
+++ b/client/src/app/site/topics/models/view-topic.ts
@@ -35,7 +35,7 @@ export class ViewTopic extends BaseProjectableViewModel<Topic> {
     }
 
     public getDetailStateURL(): string {
-        return `topics/${this.id}`;
+        return `/${this.getActiveMeetingId()}/topics/${this.id}`;
     }
 
     /**

--- a/client/src/app/site/users/components/user-detail/user-detail.component.ts
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.ts
@@ -369,7 +369,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
 
         // case: abort creation of a new user
         if (this.newUser && !edit) {
-            this.router.navigate(['./users/']);
+            this.goToAllUsers();
         }
     }
 
@@ -381,7 +381,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
         const content = this.user.full_name;
         if (await this.promptService.open(title, content)) {
             await this.repo.delete(this.user);
-            this.router.navigate(['./users/']);
+            this.goToAllUsers();
         }
     }
 
@@ -389,7 +389,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
      * navigate to the change Password site
      */
     public changePassword(): void {
-        this.router.navigate([`./users/password/${this.user.id}`]);
+        this.router.navigate([this.activeMeetingId, 'users', 'password', this.user.id]);
     }
 
     /**
@@ -428,7 +428,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
             ...this.createVoteDelegationObject(this.personalInfoForm.value)
         };
         await this.repo.create(payload);
-        this.router.navigate(['./users/']);
+        this.goToAllUsers();
     }
 
     private async updateRealUser(): Promise<void> {
@@ -442,7 +442,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
 
     private async createTemporaryUser(): Promise<void> {
         await this.repo.createTemporary(this.personalInfoForm.value);
-        this.router.navigate([`./users/`]);
+        this.goToAllUsers();
     }
 
     private async updateTemporaryUser(): Promise<void> {
@@ -470,5 +470,9 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
                 [this.activeMeetingIdService.meetingId]: payload.vote_delegations_from_ids
             }
         };
+    }
+
+    private goToAllUsers(): void {
+        this.router.navigate([this.activeMeetingId, 'users']);
     }
 }

--- a/client/src/app/site/users/components/user-list/user-list.component.ts
+++ b/client/src/app/site/users/components/user-list/user-list.component.ts
@@ -225,7 +225,7 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
     protected getModelRequest(): SimplifiedModelRequest {
         return {
             viewModelCtor: ViewMeeting,
-            ids: [this.activeMeetingIdService.meetingId], // TODO
+            ids: [this.activeMeetingId],
             follow: [
                 {
                     idField: 'user_ids',

--- a/client/src/assets/styles/component-themes.scss
+++ b/client/src/assets/styles/component-themes.scss
@@ -46,6 +46,7 @@ $narrow-spacing: (
 @import './app/shared/components/list-view-table/list-view-table.component.scss-theme.scss';
 @import './app/site/common/components/user-statistics/user-statistics.component.scss-theme.scss';
 @import './app/site/login/components/login-wrapper/login-wrapper.component.scss-theme.scss';
+@import './app/management/components/dashboard/dashboard.component.scss-theme.scss';
 
 /** Mix the component-related style-rules. Every single custom style goes here */
 @mixin openslides-components-theme($theme) {
@@ -72,6 +73,7 @@ $narrow-spacing: (
     @include os-list-view-table-theme($theme);
     @include os-user-statistics-style($theme);
     @include os-login-wrapper-theme($theme);
+    @include os-dashboard-style($theme);
 }
 
 .openslides-default-light-theme {


### PR DESCRIPTION
Fixes #138 

- Enhances the UI of the dashboard.
- Gets all users of an organization.
- Injects the id of a currently active meeting to view-models.
- Ensures, that routing inside of a meeting happens in this meeting (misleading urls will be corrected).
- Some urls are corrected:
  - Urls depending on Motions and motion-related modules
  - Navigation of mediafiles
  - `getDetailStateUrl` of view-models