### PR TITLE
Adds a dialog to manage orga-wide my account

### DIFF
--- a/client/src/app/core/core-services/route.guard.ts
+++ b/client/src/app/core/core-services/route.guard.ts
@@ -22,7 +22,7 @@ export class RouteGuard {
         this.router.events.subscribe(event => {
             if (event instanceof NavigationStart) {
                 const paths = event.url.split('/').filter(path => !!path);
-                if (!!Number(paths[0]) && !this.excludedRoutes.includes(paths[0])) {
+                if (!!paths[0] && !Number(paths[0]) && !this.excludedRoutes.includes(paths[0])) {
                     console.warn(`Route "${event.url}" is misleading. Please change.`);
                     this.router.navigate([this.activeMeetingId, ...paths]);
                 }

--- a/client/src/app/management/components/account-dialog/account-dialog.component.html
+++ b/client/src/app/management/components/account-dialog/account-dialog.component.html
@@ -1,0 +1,46 @@
+<h2 mat-dialog-title>{{ 'My account' | translate }}: self?.shortName</h2>
+<mat-divider></mat-divider>
+<div mat-dialog-content class="account-dialog-container">
+    <div class="account-dialog-menu-items">
+        <mat-selection-list [multiple]="false">
+            <ng-container *ngFor="let item of menuItems">
+                <mat-list-option
+                    [value]="item"
+                    [selected]="activeMenuItem === item.name"
+                    (click)="activeMenuItem = item.name"
+                >
+                    {{ item.name | translate }}
+                </mat-list-option>
+                <mat-divider></mat-divider>
+            </ng-container>
+        </mat-selection-list>
+    </div>
+    <mat-divider [vertical]="true"></mat-divider>
+    <div class="account-dialog-content">
+        <div class="content-wrapper">
+            <ng-container [ngSwitch]="activeMenuItem">
+                <ng-container
+                    *ngSwitchCase="menuItemsRef.CHANGE_PASSWORD"
+                    [ngTemplateOutlet]="changePasswordView"
+                ></ng-container>
+            </ng-container>
+        </div>
+    </div>
+</div>
+<mat-divider></mat-divider>
+<div mat-dialog-actions>
+    <button mat-button [mat-dialog-close]="null">{{ 'Close' | translate }}</button>
+</div>
+
+<ng-template #changePasswordView>
+    <h2>{{ 'Change password' | translate }}</h2>
+    <os-change-password
+        (validEvent)="isUserPasswordValid = $event"
+        (changeEvent)="userPasswordForm = $event"
+    ></os-change-password>
+    <div>
+        <button mat-button [disabled]="!isUserPasswordValid" (click)="changePassword()">
+            {{ 'Confirm' | translate }}
+        </button>
+    </div>
+</ng-template>

--- a/client/src/app/management/components/account-dialog/account-dialog.component.scss
+++ b/client/src/app/management/components/account-dialog/account-dialog.component.scss
@@ -1,0 +1,21 @@
+.account-dialog-container {
+    min-height: 400px;
+    display: flex;
+    flex-direction: row;
+
+    .account-dialog-menu-items {
+        flex: 1;
+
+        mat-list-item {
+            cursor: pointer;
+        }
+    }
+
+    .account-dialog-content {
+        flex: 3;
+
+        .content-wrapper {
+            padding: 24px;
+        }
+    }
+}

--- a/client/src/app/management/components/account-dialog/account-dialog.component.spec.ts
+++ b/client/src/app/management/components/account-dialog/account-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountDialogComponent } from './account-dialog.component';
+
+describe('AccountDialogComponent', () => {
+    let component: AccountDialogComponent;
+    let fixture: ComponentFixture<AccountDialogComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [AccountDialogComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AccountDialogComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/management/components/account-dialog/account-dialog.component.ts
+++ b/client/src/app/management/components/account-dialog/account-dialog.component.ts
@@ -1,0 +1,62 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+import { OperatorService } from 'app/core/core-services/operator.service';
+import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
+import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PasswordForm } from 'app/shared/components/change-password/change-password.component';
+import { BaseComponent } from 'app/site/base/components/base.component';
+import { ViewUser } from 'app/site/users/models/view-user';
+
+interface MenuItem {
+    name: string;
+}
+
+enum MenuItems {
+    CHANGE_PASSWORD = 'Change password'
+}
+
+@Component({
+    selector: 'os-account-dialog',
+    templateUrl: './account-dialog.component.html',
+    styleUrls: ['./account-dialog.component.scss']
+})
+export class AccountDialogComponent extends BaseComponent implements OnInit {
+    public readonly menuItems: MenuItem[] = [
+        {
+            name: MenuItems.CHANGE_PASSWORD
+        }
+    ];
+
+    public readonly menuItemsRef = MenuItems;
+
+    public get self(): ViewUser {
+        return this._self;
+    }
+
+    public activeMenuItem = this.menuItems[0].name;
+
+    public isUserPasswordValid = false;
+    public userPasswordForm: PasswordForm;
+
+    private _self: ViewUser;
+
+    public constructor(
+        serviceCollector: ComponentServiceCollector,
+        public dialogRef: MatDialogRef<AccountDialogComponent>,
+        private operator: OperatorService,
+        private userRepo: UserRepositoryService
+    ) {
+        super(serviceCollector);
+    }
+
+    public ngOnInit(): void {
+        this.subscriptions.push(this.operator.userObservable.subscribe(user => (this._self = user)));
+    }
+
+    public async changePassword(): Promise<void> {
+        const { oldPassword, newPassword }: PasswordForm = this.userPasswordForm;
+        await this.userRepo.setPasswordSelf(this.self, oldPassword, newPassword);
+        this.isUserPasswordValid = false;
+    }
+}

--- a/client/src/app/management/components/management-navigation/management-navigation.component.html
+++ b/client/src/app/management/components/management-navigation/management-navigation.component.html
@@ -1,9 +1,13 @@
 <span *ngFor="let entry of menuEntries">
-    <a *osPerms="entry.permission" mat-menu-item [routerLink]="entry.route">
+    <a *osPerms="entry.permission" mat-menu-item class="management-router-link" [routerLink]="entry.route">
         <mat-icon>{{ entry.icon }}</mat-icon>
         <span>{{ entry.displayName | translate }}</span>
     </a>
 </span>
+<div mat-menu-item (click)="openAccountDialog()">
+    <mat-icon>person</mat-icon>
+    <span>{{ 'My account' | translate }}</span>
+</div>
 <mat-divider></mat-divider>
 <button mat-menu-item (click)="logout()">
     <mat-icon>exit_to_app</mat-icon>

--- a/client/src/app/management/components/management-navigation/management-navigation.component.scss
+++ b/client/src/app/management/components/management-navigation/management-navigation.component.scss
@@ -1,0 +1,3 @@
+.management-router-link {
+    text-decoration: none;
+}

--- a/client/src/app/management/components/management-navigation/management-navigation.component.ts
+++ b/client/src/app/management/components/management-navigation/management-navigation.component.ts
@@ -1,8 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 
+import { AccountDialogComponent } from '../account-dialog/account-dialog.component';
 import { AuthService } from 'app/core/core-services/auth.service';
 import { MainMenuEntry } from 'app/core/core-services/main-menu.service';
 import { OverlayService } from 'app/core/ui-services/overlay.service';
+import { largeDialogSettings } from 'app/shared/utils/dialog-settings';
 
 @Component({
     selector: 'os-management-navigation',
@@ -41,7 +44,17 @@ export class ManagementNavigationComponent {
         }
     ];
 
-    public constructor(private authService: AuthService, private overlayService: OverlayService) {}
+    public constructor(
+        private authService: AuthService,
+        private overlayService: OverlayService,
+        private dialog: MatDialog
+    ) {}
+
+    public openAccountDialog(): void {
+        this.dialog.open(AccountDialogComponent, {
+            ...largeDialogSettings
+        });
+    }
 
     public logout(): void {
         this.authService.logout();

--- a/client/src/app/management/management.module.ts
+++ b/client/src/app/management/management.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { AccountDialogComponent } from './components/account-dialog/account-dialog.component';
 import { SharedModule } from 'app/shared/shared.module';
 import { CommitteeEditComponent } from './components/committee-edit/committee-edit.component';
 import { CommitteeListComponent } from './components/committee-list/committee-list.component';
@@ -26,7 +27,8 @@ import { OrgaSettingsComponent } from './components/orga-settings/orga-settings.
         CommitteeEditComponent,
         MemberEditComponent,
         ManagementNavigationComponent,
-        OrgaSettingsComponent
+        OrgaSettingsComponent,
+        AccountDialogComponent
     ]
 })
 export class ManagementModule {}

--- a/client/src/app/shared/components/change-password/change-password.component.html
+++ b/client/src/app/shared/components/change-password/change-password.component.html
@@ -1,0 +1,62 @@
+<form [formGroup]="changePasswordForm">
+    <mat-form-field>
+        <mat-label>{{ 'Old password' | translate }}</mat-label>
+        <input
+            [type]="hideOldPassword ? 'password' : 'text'"
+            matInput
+            required
+            formControlName="oldPassword"
+            #oldPassword
+        />
+        <button
+            matSuffix
+            mat-button
+            mat-icon-button
+            (click)="hideOldPassword = !hideOldPassword"
+            [disabled]="!oldPassword.value"
+        >
+            <mat-icon>{{ hideOldPassword ? 'visibility' : 'visibility_off' }}</mat-icon>
+        </button>
+    </mat-form-field>
+    <mat-form-field>
+        <mat-label>{{ 'New password' | translate }}</mat-label>
+        <input
+            [type]="hideNewPassword ? 'password' : 'text'"
+            matInput
+            required
+            formControlName="newPassword"
+            #newPassword
+        />
+        <button
+            matSuffix
+            mat-button
+            mat-icon-button
+            (click)="hideNewPassword = !hideNewPassword"
+            [disabled]="!newPassword.value"
+        >
+            <mat-icon>{{ hideNewPassword ? 'visibility' : 'visibility_off' }}</mat-icon>
+        </button>
+    </mat-form-field>
+    <mat-form-field>
+        <mat-label>{{ 'Confirm new password' | translate }}</mat-label>
+        <input
+            [type]="hideConfirmPassword ? 'password' : 'text'"
+            matInput
+            required
+            formControlName="confirmPassword"
+            #confirmPassword
+        />
+        <button
+            matSuffix
+            mat-button
+            mat-icon-button
+            (click)="hideConfirmPassword = !hideConfirmPassword"
+            [disabled]="!confirmPassword.value"
+        >
+            <mat-icon>{{ hideConfirmPassword ? 'visibility' : 'visibility_off' }}</mat-icon>
+        </button>
+        <mat-error *ngIf="changePasswordForm.get('confirmPassword').errors?.passwordMismatch">
+            {{ 'Passwords do not match' | translate }}
+        </mat-error>
+    </mat-form-field>
+</form>

--- a/client/src/app/shared/components/change-password/change-password.component.scss
+++ b/client/src/app/shared/components/change-password/change-password.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+    display: block;
+}

--- a/client/src/app/shared/components/change-password/change-password.component.spec.ts
+++ b/client/src/app/shared/components/change-password/change-password.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangePasswordComponent } from './change-password.component';
+
+describe('ChangePasswordComponent', () => {
+    let component: ChangePasswordComponent;
+    let fixture: ComponentFixture<ChangePasswordComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ChangePasswordComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ChangePasswordComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/shared/components/change-password/change-password.component.ts
+++ b/client/src/app/shared/components/change-password/change-password.component.ts
@@ -1,0 +1,51 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PasswordValidator } from 'app/shared/validators';
+import { BaseComponent } from 'app/site/base/components/base.component';
+
+export interface PasswordForm {
+    oldPassword: string;
+    newPassword: string;
+    confirmPassword: string;
+}
+
+@Component({
+    selector: 'os-change-password',
+    templateUrl: './change-password.component.html',
+    styleUrls: ['./change-password.component.scss']
+})
+export class ChangePasswordComponent extends BaseComponent implements OnInit {
+    @Output()
+    public changeEvent = new EventEmitter<PasswordForm>();
+
+    @Output()
+    public validEvent = new EventEmitter<boolean>();
+
+    public changePasswordForm: FormGroup;
+    public newPasswordForm: FormControl;
+
+    public hideOldPassword = true;
+    public hideNewPassword = true;
+    public hideConfirmPassword = true;
+
+    public constructor(serviceCollector: ComponentServiceCollector, private fb: FormBuilder) {
+        super(serviceCollector);
+    }
+
+    public ngOnInit(): void {
+        this.newPasswordForm = this.fb.control('', Validators.required);
+        this.changePasswordForm = this.fb.group({
+            oldPassword: ['', Validators.required],
+            newPassword: this.newPasswordForm,
+            confirmPassword: ['', [Validators.required, PasswordValidator.validation(this.newPasswordForm)]]
+        });
+        this.subscriptions.push(
+            this.changePasswordForm.valueChanges.subscribe(value => {
+                this.changeEvent.emit(value);
+                this.validEvent.emit(this.changePasswordForm.valid);
+            })
+        );
+    }
+}

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -102,6 +102,7 @@ import { SearchRepoSelectorComponent } from './components/search-selector/search
 import { MaterialDesignModule } from './libraries/material-design.module';
 import { SwipeDirective } from './directives/swipe.directive';
 import { ListenEditingDirective } from './directives/listen-editing.directive';
+import { ChangePasswordComponent } from './components/change-password/change-password.component';
 
 const declarations = [
     PermsDirective,
@@ -171,7 +172,8 @@ const declarations = [
     OnlyNumberDirective,
     SearchRepoSelectorComponent,
     SwipeDirective,
-    ListenEditingDirective
+    ListenEditingDirective,
+    ChangePasswordComponent
 ];
 
 const sharedModules = [

--- a/client/src/app/shared/validators/index.ts
+++ b/client/src/app/shared/validators/index.ts
@@ -1,0 +1,3 @@
+export * from './custom-validators';
+export * from './one-of-validator';
+export * from './password-validator';

--- a/client/src/app/shared/validators/password-validator.ts
+++ b/client/src/app/shared/validators/password-validator.ts
@@ -1,0 +1,10 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+
+export class PasswordValidator {
+    public static validation(referenceControl: AbstractControl): (control: AbstractControl) => ValidationErrors | null {
+        return (control: AbstractControl) => {
+            const isEqual = !control.value || !referenceControl.value || control.value === referenceControl.value;
+            return isEqual ? null : { passwordMismatch: true };
+        };
+    }
+}

--- a/client/src/app/site/users/components/password/password.component.html
+++ b/client/src/app/site/users/components/password/password.component.html
@@ -1,5 +1,11 @@
-<os-head-bar (mainEvent)="goBack()" [hasMainButton]="true" [nav]="false" [editMode]="true" (saveEvent)="save()"
-    >a
+<os-head-bar
+    (mainEvent)="goBack()"
+    [hasMainButton]="true"
+    [nav]="false"
+    [editMode]="true"
+    (saveEvent)="save()"
+    [isSaveButtonEnabled]="isValid"
+>
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Change password' | translate }}</h2>
@@ -58,42 +64,11 @@
         </div>
     </div>
 
-    <div *ngIf="this.ownPage">
+    <div *ngIf="this.ownPage" (keydown)="onKeyDown($event)">
         <!-- can not Manage, but own Page (a.k.a. User) -->
-        <form [formGroup]="userPasswordForm" (keydown)="onKeyDown($event)">
-            <mat-form-field>
-                <input
-                    [type]="hideOldPassword ? 'password' : 'text'"
-                    matInput
-                    formControlName="oldPassword"
-                    placeholder="{{ 'Old password' | translate }}"
-                    required
-                />
-                <mat-icon mat-button matSuffix mat-icon-button (click)="hideOldPassword = !hideOldPassword">
-                    {{ hideOldPassword ? 'visibility' : 'visibility_off' }}
-                </mat-icon> </mat-form-field
-            ><br />
-            <mat-form-field>
-                <input
-                    [type]="hidePassword ? 'password' : 'text'"
-                    matInput
-                    formControlName="newPassword1"
-                    placeholder="{{ 'New password' | translate }}"
-                    required
-                />
-                <mat-icon mat-button matSuffix mat-icon-button (click)="hidePassword = !hidePassword">
-                    {{ hidePassword ? 'visibility' : 'visibility_off' }}
-                </mat-icon> </mat-form-field
-            ><br />
-            <mat-form-field>
-                <input
-                    [type]="hidePassword ? 'password' : 'text'"
-                    matInput
-                    formControlName="newPassword2"
-                    placeholder="{{ 'Confirm new password' | translate }}"
-                    required
-                />
-            </mat-form-field>
-        </form>
+        <os-change-password
+            (validEvent)="isUserPasswordValid = $event"
+            (changeEvent)="userPasswordForm = $event"
+        ></os-change-password>
     </div>
 </mat-card>


### PR DESCRIPTION
Fixes #149 

- Adds a user-dialog to manage orga-wide user-related things for my account. Currently, I can only change my password.
- Separates the form to change a password into an own component to reuse it.