### PR TITLE
Rename "Guests" to "Participants" in Meetings

### DIFF
--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.html
@@ -54,11 +54,11 @@
         </mat-form-field>
 
         <mat-form-field>
-            <mat-label> {{ 'Guests' | translate }}</mat-label>
+            <mat-label> {{ 'Participants' | translate }}</mat-label>
             <os-search-value-selector
                 formControlName="guest_ids"
                 [multiple]="true"
-                placeholder="{{ 'Guests' | translate }}"
+                placeholder="{{ 'Participants' | translate }}"
                 [inputListValues]="members"
             ></os-search-value-selector>
         </mat-form-field>


### PR DESCRIPTION
This is just frontend since the word "Guests" was misleading in this
scope. Internally they are still named guests. This is probably
in the whole stack.

fixes #158 