### PR TITLE
Realign Orga and Meeting settings

### DIFF
--- a/client/src/app/core/repositories/event-management/meeting-repository.service.ts
+++ b/client/src/app/core/repositories/event-management/meeting-repository.service.ts
@@ -44,13 +44,15 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
             'is_template'
         ]);
         const dashboardFields: (keyof Meeting)[] = listFields.concat('location');
+        const startPageFields: (keyof Meeting)[] = ['welcome_title', 'welcome_text'];
 
         return {
             [DEFAULT_FIELDSET]: nameFields,
             list: listFields,
             edit: editFields,
             dashboard: dashboardFields,
-            settings: this.meetingSettingsDefinitionProvider.getSettingsKeys()
+            settings: this.meetingSettingsDefinitionProvider.getSettingsKeys(),
+            startPage: startPageFields
         };
     }
 

--- a/client/src/app/core/repositories/event-management/meeting-settings-definition.ts
+++ b/client/src/app/core/repositories/event-management/meeting-settings-definition.ts
@@ -21,6 +21,7 @@ export type SettingsType =
     | 'integer'
     | 'boolean'
     | 'choice'
+    | 'date'
     | 'datetime'
     | 'translations'
     | 'groups';
@@ -97,14 +98,6 @@ export const meetingSettings: SettingsGroup[] = [
                         validators: [Validators.maxLength(100)]
                     },
                     {
-                        key: 'start_time',
-                        label: 'Event start date'
-                    },
-                    {
-                        key: 'end_time',
-                        label: 'Event end date'
-                    },
-                    {
                         key: 'location',
                         label: 'Event location'
                     }
@@ -159,15 +152,6 @@ export const meetingSettings: SettingsGroup[] = [
             {
                 label: 'System',
                 settings: [
-                    {
-                        key: 'url_name',
-                        label: 'URL name'
-                    },
-                    {
-                        key: 'is_template',
-                        label: 'Use this as a template for other meetings',
-                        type: 'boolean'
-                    },
                     {
                         key: 'enable_anonymous',
                         label: 'Allow access for anonymous guest users',
@@ -240,14 +224,14 @@ export const meetingSettings: SettingsGroup[] = [
                     {
                         key: 'start_time',
                         label: 'Begin of event',
-                        type: 'datetime',
-                        helpText: 'Input format: DD.MM.YYYY HH:MM'
+                        type: 'date',
+                        helpText: 'Input format: DD.MM.YYYY'
                     },
                     {
                         key: 'end_time', // not in code anymore
                         label: 'End of event',
-                        type: 'datetime',
-                        helpText: 'Input format: DD.MM.YYYY HH:MM'
+                        type: 'date',
+                        helpText: 'Input format: DD.MM.YYYY'
                     },
                     {
                         key: 'agenda_show_subtitles',

--- a/client/src/app/shared/components/legal-notice-content/legal-notice-content.component.html
+++ b/client/src/app/shared/components/legal-notice-content/legal-notice-content.component.html
@@ -13,7 +13,7 @@
                 </form>
             </div>
         </ng-container>
-        <mat-divider></mat-divider>
+        <mat-divider *ngIf="versionInfo"></mat-divider>
         <div *ngIf="versionInfo" class="version-text">
             <a [attr.href]="versionInfo.openslides_url" target="_blank">
                 OpenSlides {{ versionInfo.openslides_version }}

--- a/client/src/app/site/common/components/legal-notice/legal-notice.component.html
+++ b/client/src/app/site/common/components/legal-notice/legal-notice.component.html
@@ -1,58 +1,10 @@
-<os-head-bar
-    [nav]="false"
-    [goBack]="true"
-    [editMode]="isEditing"
-    [hasMainButton]="canManage()"
-    [mainButtonIcon]="'edit'"
-    [mainActionTooltip]="'Edit' | translate"
-    (cancelEditEvent)="isEditing = !isEditing"
-    (mainEvent)="isEditing = !isEditing"
-    (saveEvent)="saveChanges()"
->
+<os-head-bar [nav]="false" [goBack]="true">
     <div class="title-slot">
         <h2>{{ 'Legal notice' | translate }}</h2>
     </div>
 </os-head-bar>
 
-<os-legal-notice-content
-    [canBeEdited]="true"
-    [isEditing]="isEditing"
-    (update)="legalNotice = $event"
-></os-legal-notice-content>
-
-<mat-card class="os-card">
-    <div>
-        <button type="button" mat-button (click)="resetCache()">
-            <span>{{ 'Reset cache' | translate }}</span>
-        </button>
-    </div>
-
-    <div>
-        <button type="button" mat-button (click)="checkForUpdate()">
-            <span>{{ 'Check for updates' | translate }}</span>
-        </button>
-    </div>
-
-    <div>
-        <button type="button" mat-button (click)="showDevTools = !showDevTools">
-            <span>{{ 'Show devtools' | translate }}</span>
-        </button>
-    </div>
-
-    <mat-card class="os-card" *ngIf="showDevTools">
-        <div>
-            <button type="button" mat-button (click)="printDS()">
-                <span>Print DS</span>
-            </button>
-        </div>
-
-        <div>
-            <button type="button" mat-button (click)="getThisComponent()">
-                <span>Get this component</span>
-            </button>
-        </div>
-    </mat-card>
-</mat-card>
+<os-legal-notice-content></os-legal-notice-content>
 
 <mat-card class="os-card" *osPerms="permission.usersCanManage">
     <h2>{{ 'Statistics' | translate }}</h2>
@@ -64,14 +16,4 @@
         <h3>{{ 'Requests to speak' | translate }}</h3>
         <os-user-statistics></os-user-statistics>
     </div>
-</mat-card>
-
-<mat-card class="os-card spacer-bottom-60">
-    <button mat-button (click)="doAuthenticate()">Authenticate</button>
-    <button mat-button (click)="testCreateTopic()">Test: create topic</button>
-    <button mat-button (click)="testCreateTopicWithExpiredToken()">Test: create topic with expired token</button>
-    <button mat-button (click)="apiAuthRequestWithTokenCookie()">API Hello World</button>
-    <button mat-button (click)="apiAuthRequestWithCookie()">API Request Only Cookie</button>
-    <button mat-button (click)="apiAuthRequestWithExpiredToken()">API Request with expired Token</button>
-    <button mat-button (click)="apiAuthRequestWithInvalidToken()">API Request with invalid Token</button>
 </mat-card>

--- a/client/src/app/site/common/components/legal-notice/legal-notice.component.ts
+++ b/client/src/app/site/common/components/legal-notice/legal-notice.component.ts
@@ -1,16 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { environment } from 'environments/environment';
-
-import { AuthTokenService } from 'app/core/core-services/auth-token.service';
-import { DataStoreService } from 'app/core/core-services/data-store.service';
-import { HttpService } from 'app/core/core-services/http.service';
-import { LifecycleService } from 'app/core/core-services/lifecycle.service';
-import { OperatorService } from 'app/core/core-services/operator.service';
-import { Permission } from 'app/core/core-services/permission';
-import { TopicRepositoryService } from 'app/core/repositories/topics/topic-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
-import { UpdateService } from 'app/core/ui-services/update.service';
 import { BaseComponent } from 'app/site/base/components/base.component';
 
 @Component({
@@ -18,123 +8,11 @@ import { BaseComponent } from 'app/site/base/components/base.component';
     templateUrl: './legal-notice.component.html'
 })
 export class LegalNoticeComponent extends BaseComponent implements OnInit {
-    /**
-     * Whether this component is in editing-mode.
-     */
-    public isEditing = false;
-
-    /**
-     * Holds the current legal-notice.
-     */
-    public legalNotice = '';
-
-    public showDevTools = false;
-
-    /**
-     * Constructor.
-     */
-    public constructor(
-        componentServiceCollector: ComponentServiceCollector,
-        private lifecycleService: LifecycleService,
-        private update: UpdateService,
-        private operator: OperatorService,
-        private DS: DataStoreService,
-        private http: HttpService,
-        private authTokenService: AuthTokenService,
-        private topicRepo: TopicRepositoryService
-    ) {
+    public constructor(componentServiceCollector: ComponentServiceCollector) {
         super(componentServiceCollector);
     }
 
     public ngOnInit(): void {
-        super.setTitle(this.translate.instant('Legal notice'));
+        super.setTitle('Legal notice');
     }
-
-    public resetCache(): void {
-        this.lifecycleService.reboot();
-    }
-
-    public checkForUpdate(): void {
-        this.update.checkForUpdate();
-    }
-
-    /**
-     * Saves changes.
-     */
-    public saveChanges(): void {
-        /*this.configRepo
-            .bulkUpdate([{ key: 'general_event_legal_notice', value: this.legalNotice }])
-            .then(() => (this.isEditing = !this.isEditing), this.raiseError);
-        */
-        throw new Error('TODO');
-    }
-
-    /**
-     * Returns, if the current user has the necessary permissions.
-     */
-    public canManage(): boolean {
-        return this.operator.hasPerms(Permission.meetingCanManageSettings);
-    }
-
-    public printDS(): void {
-        this.DS.print();
-    }
-
-    public getThisComponent(): void {
-        console.log(this);
-    }
-
-    /**
-     * Only testing purposes
-     */
-    private async createTopic(): Promise<any> {
-        return await this.topicRepo.create({ text: 'Ich mag Kuchen', title: 'Hallo Kekse' });
-    }
-
-    public async testCreateTopic(): Promise<any> {
-        return await this.createTopic();
-    }
-
-    public async testCreateTopicWithExpiredToken(): Promise<any> {
-        this.authTokenService.resetAccessTokenToExpired();
-        return await this.createTopic();
-    }
-
-    public apiAuthRequestWithTokenCookie(): void {
-        this.http.get(`${environment.authUrlPrefix}/api/hello`).then(response => console.log('response', response));
-    }
-
-    public apiAuthRequestWithCookie(): void {
-        this.authTokenService.resetAccessTokenToNull();
-        this.apiAuthRequestWithTokenCookie();
-    }
-
-    public apiAuthRequestWithInvalidToken(): void {
-        this.authTokenService.resetAccessTokenToInvalid();
-        this.apiAuthRequestWithTokenCookie();
-    }
-
-    public apiAuthRequestWithExpiredToken(): void {
-        this.authTokenService.resetAccessTokenToExpired();
-        this.apiAuthRequestWithTokenCookie();
-    }
-
-    public async doAuthenticate(): Promise<void> {
-        // try {
-        //     await this.http.post(`https://auth:9004/internal/auth/api/authenticate`);
-        // } catch (e) {
-        //     console.log('Error while authenticating', e);
-        // }
-        const payload = [
-            {
-                presenter: 'server_time'
-            }
-        ];
-        const servertimeResponse = await this.http.post<any[]>('/system/presenter/handle_request', payload);
-        console.log('servertimeResponse', servertimeResponse);
-    }
-
-    /**
-     * End of testing purposes
-     */
 }

--- a/client/src/app/site/common/components/privacy-policy/privacy-policy.component.html
+++ b/client/src/app/site/common/components/privacy-policy/privacy-policy.component.html
@@ -1,21 +1,7 @@
-<os-head-bar
-    [nav]="false"
-    [goBack]="true"
-    [editMode]="isEditing"
-    [hasMainButton]="canManage()"
-    [mainButtonIcon]="'edit'"
-    [mainActionTooltip]="'Edit' | translate"
-    (cancelEditEvent)="isEditing = !isEditing"
-    (mainEvent)="isEditing = !isEditing"
-    (saveEvent)="saveChanges()"
->
+<os-head-bar [nav]="false" [goBack]="true">
     <div class="title-slot">
         <h2>{{ 'Privacy Policy' | translate }}</h2>
     </div>
 </os-head-bar>
 
-<os-privacy-policy-content
-    [canBeEdited]="true"
-    [isEditing]="isEditing"
-    (update)="privacyProlicy = $event"
-></os-privacy-policy-content>
+<os-privacy-policy-content></os-privacy-policy-content>

--- a/client/src/app/site/common/components/privacy-policy/privacy-policy.component.ts
+++ b/client/src/app/site/common/components/privacy-policy/privacy-policy.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { OperatorService } from 'app/core/core-services/operator.service';
-import { Permission } from 'app/core/core-services/permission';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { BaseComponent } from 'app/site/base/components/base.component';
 
@@ -11,45 +9,11 @@ import { BaseComponent } from 'app/site/base/components/base.component';
     styleUrls: ['./privacy-policy.component.scss']
 })
 export class PrivacyPolicyComponent extends BaseComponent implements OnInit {
-    /**
-     * Whether the component is in editing-mode.
-     */
-    public isEditing = false;
-
-    /**
-     * Holds the current privacy-policy.
-     */
-    public privacyProlicy = '';
-
-    /**
-     * Constructor.
-     *
-     * @param titleService
-     * @param translate
-     * @param configRepo
-     */
-    public constructor(componentServiceCollector: ComponentServiceCollector, private operator: OperatorService) {
+    public constructor(componentServiceCollector: ComponentServiceCollector) {
         super(componentServiceCollector);
     }
 
     public ngOnInit(): void {
-        super.setTitle(this.translate.instant('Privacy policy'));
-    }
-
-    /**
-     * Saves changes.
-     */
-    public saveChanges(): void {
-        /*this.configRepo
-            .bulkUpdate([{ key: 'general_event_privacy_policy', value: this.privacyProlicy }])
-            .then(() => (this.isEditing = !this.isEditing), this.raiseError);*/
-        throw new Error('TODO');
-    }
-
-    /**
-     * Returns, if the current user has the necessary permissions.
-     */
-    public canManage(): boolean {
-        return this.operator.hasPerms(Permission.meetingCanManageSettings);
+        super.setTitle('Privacy policy');
     }
 }

--- a/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.html
+++ b/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.html
@@ -27,7 +27,10 @@
                 <ng-template #select ngProjectAs="mat-select">
                     <mat-select formControlName="value" [errorStateMatcher]="matcher">
                         <ng-container *ngIf="setting.choices">
-                            <mat-option *ngFor="let choice of setting.choices | keyvalue: keepEntryOrder" [value]="choice.value">
+                            <mat-option
+                                *ngFor="let choice of setting.choices | keyvalue: keepEntryOrder"
+                                [value]="choice.value"
+                            >
                                 {{ choice.key | translate }}
                             </mat-option>
                         </ng-container>
@@ -83,8 +86,8 @@
                     </mat-form-field>
                 </div>
 
-                <!-- datetime -->
-                <div *ngIf="setting.type === 'datetime'">
+                <!-- date / datetime -->
+                <div *ngIf="setting.type === 'datetime' || setting.type === 'date'">
                     <div class="datetimepicker-container">
                         <mat-form-field>
                             <mat-label>{{ setting.label | translate }}</mat-label>
@@ -105,7 +108,7 @@
                             <mat-error *ngIf="error"> {{ error }} </mat-error>
                             <mat-datepicker #datepicker></mat-datepicker>
                         </mat-form-field>
-                        <mat-form-field>
+                        <mat-form-field *ngIf="setting.type === 'datetime'">
                             <input matInput [format]="24" formControlName="time" [ngxTimepicker]="timepicker" />
                             <div class="suffix-wrapper" matSuffix>
                                 <mat-icon class="red-warning-text" *ngIf="updateSuccessIcon">error</mat-icon>

--- a/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.ts
+++ b/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.ts
@@ -17,7 +17,6 @@ import { Observable } from 'rxjs';
 import { distinctUntilChanged, filter } from 'rxjs/operators';
 
 import { CollectionMapperService } from 'app/core/core-services/collection-mapper.service';
-import { MotionWorkflowRepositoryService } from 'app/core/repositories/motions/motion-workflow-repository.service';
 import { GroupRepositoryService } from 'app/core/repositories/users/group-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { MeetingSettingsDefinitionProvider } from 'app/core/ui-services/meeting-settings-definition-provider.service';
@@ -153,7 +152,7 @@ export class MeetingSettingsFieldComponent extends BaseComponent implements OnIn
                 this.translatedValue = this.translate.instant(this.value);
             }
         }
-        if (this.setting.type === 'datetime' && this.value) {
+        if ((this.setting.type === 'datetime' || this.setting.type === 'date') && this.value) {
             const datetimeObj = this.unixToDateAndTime(this.value as number);
             this.form.patchValue(datetimeObj);
         }
@@ -220,6 +219,7 @@ export class MeetingSettingsFieldComponent extends BaseComponent implements OnIn
             case 'markupText':
                 // tinyMCE markuptext does not autoupdate on change, only when entering or leaving
                 return;
+            case 'date':
             case 'datetime':
                 // datetime has to be converted
                 const date = this.form.get('date').value;
@@ -285,7 +285,7 @@ export class MeetingSettingsFieldComponent extends BaseComponent implements OnIn
      * @returns wheather it should be excluded or not
      */
     public isExcludedType(type: string): boolean {
-        const excluded = ['boolean', 'markupText', 'text', 'translations', 'datetime'];
+        const excluded = ['boolean', 'markupText', 'text', 'translations', 'datetime', 'date'];
         return excluded.includes(type);
     }
 

--- a/client/src/app/site/meeting-settings/components/meeting-settings-list/meeting-settings-list.component.ts
+++ b/client/src/app/site/meeting-settings/components/meeting-settings-list/meeting-settings-list.component.ts
@@ -66,17 +66,20 @@ export class MeetingSettingsListComponent
     public ngOnInit(): void {
         super.ngOnInit();
         const settings = this.translate.instant('Settings');
-        this.route.params.subscribe(params => {
-            if (params.group) {
-                this.settingsGroup = this.meetingSettingsDefinitionProvider.getSettingsGroup(params.group);
-                const groupName = this.translate.instant(this.settingsGroup.label);
-                super.setTitle(`${settings} - ${groupName}`);
-                this.cd.markForCheck();
-            }
-        });
-        this.activeMeetingService.meetingObservable.subscribe(meeting => {
-            this.meeting = meeting;
-        });
+
+        this.subscriptions.push(
+            this.route.params.subscribe(params => {
+                if (params.group) {
+                    this.settingsGroup = this.meetingSettingsDefinitionProvider.getSettingsGroup(params.group);
+                    const groupName = this.translate.instant(this.settingsGroup.label);
+                    super.setTitle(`${settings} - ${groupName}`);
+                    this.cd.markForCheck();
+                }
+            }),
+            this.activeMeetingService.meetingObservable.subscribe(meeting => {
+                this.meeting = meeting;
+            })
+        );
     }
 
     /**


### PR DESCRIPTION
Certain settings are only available in the organisation, some settings
can be found in both orga view and meeting view

- altered meeting date/time picker to (optionally perhaps temporarily)
support date only
- fix the start page. Allows To set and show welcome title and welcome
text
- deactivate privacy policy edit inside of meetings
- deactivate legal notice edit inside of meetings
- removes some test functions inside legal notice
- removes manual update check inside legal notice
- remove start time and end time from meeting setting general tab since
it was duplicated from agenda
- remove url-name and template since it should only be used by orga
managers and not inside a meeting

fixes #162