### PR TITLE
Adds organization tags client-side

### DIFF
--- a/client/src/app/core/actions/organisation-tag-action.ts
+++ b/client/src/app/core/actions/organisation-tag-action.ts
@@ -1,0 +1,21 @@
+import { Identifiable } from 'app/shared/models/base/identifiable';
+import { HtmlColor, Id } from '../definitions/key-types';
+
+export namespace OrganisationTagAction {
+    export const CREATE = 'organisation_tag.create';
+    export const UPDATE = 'organisation_tag.update';
+    export const DELETE = 'organisation_tag.delete';
+
+    export interface OrganisationTagPayload {
+        name: string;
+        color: HtmlColor;
+    }
+
+    export interface CreatePayload extends OrganisationTagPayload {
+        organisation_id: Id;
+    }
+
+    export interface UpdatePayload extends Identifiable, Partial<OrganisationTagPayload> {}
+
+    export interface DeletePayload extends Identifiable {}
+}

--- a/client/src/app/core/actions/organization-action.ts
+++ b/client/src/app/core/actions/organization-action.ts
@@ -1,6 +1,5 @@
 import { Identifiable } from 'app/shared/models/base/identifiable';
 import { OrganisationSetting } from 'app/shared/models/event-management/organisation';
-import { Id, UnsafeHtml } from '../definitions/key-types';
 
 export namespace OrganizationAction {
     export const UPDATE = 'organisation.update';

--- a/client/src/app/core/core-services/organisation.service.ts
+++ b/client/src/app/core/core-services/organisation.service.ts
@@ -15,7 +15,7 @@ export const WEB_HEADER_TOKEN = 'web_header';
 /**
  * The organisation_id is always the 1.
  */
-const ORGANISATION_ID = 1;
+export const ORGANISATION_ID = 1;
 
 @Injectable({
     providedIn: 'root'

--- a/client/src/app/core/core-services/route.guard.ts
+++ b/client/src/app/core/core-services/route.guard.ts
@@ -12,7 +12,15 @@ export class RouteGuard {
         return this.activeMeetingIdService.meetingId;
     }
 
-    private readonly excludedRoutes = ['login', 'download', 'projector', 'committees', 'members'];
+    private readonly excludedRoutes = [
+        'login',
+        'download',
+        'projector',
+        'committees',
+        'members',
+        'organization-tags',
+        'settings'
+    ];
 
     public constructor(private router: Router, private activeMeetingIdService: ActiveMeetingIdService) {
         this.listenToNavigation();

--- a/client/src/app/core/definitions/key-types.ts
+++ b/client/src/app/core/definitions/key-types.ts
@@ -10,3 +10,7 @@ export type UnsafeHtml = string;
  */
 export type Decimal = string;
 export type Base64Encoded = string;
+/**
+ * A string with six hexadecimal-digits leaded by an `#`.
+ */
+export type HtmlColor = string;

--- a/client/src/app/core/repositories/management/committee-repository.service.ts
+++ b/client/src/app/core/repositories/management/committee-repository.service.ts
@@ -39,7 +39,8 @@ export class CommitteeRepositoryService
             'meeting_ids',
             'member_ids',
             'manager_ids',
-            'forward_to_committee_ids'
+            'forward_to_committee_ids',
+            'organisation_tag_ids'
         ]);
         const editFields: (keyof Committee)[] = titleFields.concat(['default_meeting_id', 'template_meeting_id']);
         return {

--- a/client/src/app/core/repositories/management/meeting-repository.service.ts
+++ b/client/src/app/core/repositories/management/meeting-repository.service.ts
@@ -40,7 +40,7 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
         const accessField: (keyof Meeting)[] = [ViewMeeting.ACCESSIBILITY_FIELD];
 
         const nameFields: (keyof Meeting)[] = accessField.concat(['name', 'start_time', 'end_time']);
-        const listFields: (keyof Meeting)[] = nameFields.concat('user_ids');
+        const listFields: (keyof Meeting)[] = nameFields.concat('user_ids', 'organisation_tag_ids');
         const editFields: (keyof Meeting)[] = listFields.concat([
             'welcome_title',
             'description',

--- a/client/src/app/core/repositories/management/organisation-repository.service.ts
+++ b/client/src/app/core/repositories/management/organisation-repository.service.ts
@@ -24,25 +24,21 @@ export class OrganisationRepositoryService extends BaseRepository<ViewOrganisati
     };
 
     public getFieldsets(): Fieldsets<Organisation> {
-        const settingsFieldset: (keyof OrganisationSetting)[] = [
-            'name',
-            'description',
+        const coreFieldset: (keyof Organisation)[] = ['name', 'description'];
+        const settingsFieldset: (keyof (OrganisationSetting & Organisation))[] = coreFieldset.concat(
             'legal_notice',
             'privacy_policy',
             'login_text',
             'theme',
             'custom_translations',
             'reset_password_verbose_errors'
-        ];
-        const detailFieldset: (keyof Organisation)[] = [
-            'committee_ids',
-            'description',
-            'name',
-            'role_ids',
-            'superadmin_role_id'
-        ];
+        );
+        const listFieldset: (keyof Organisation)[] = coreFieldset.concat('committee_ids', 'organisation_tag_ids');
+        const detailFieldset: (keyof Organisation)[] = listFieldset.concat('role_ids', 'superadmin_role_id');
         return {
             [DEFAULT_FIELDSET]: detailFieldset,
+            title: coreFieldset,
+            list: listFieldset,
             settings: settingsFieldset
         };
     }

--- a/client/src/app/core/repositories/management/organisation-tag-repository.service.ts
+++ b/client/src/app/core/repositories/management/organisation-tag-repository.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@angular/core';
+
+import { OrganisationTagAction } from 'app/core/actions/organisation-tag-action';
+import {
+    DEFAULT_FIELDSET,
+    Fieldsets,
+    SimplifiedModelRequest
+} from 'app/core/core-services/model-request-builder.service';
+import { ORGANISATION_ID } from 'app/core/core-services/organisation.service';
+import { ViewOrganisation } from 'app/management/models/view-organisation';
+import { ViewOrganisationTag } from 'app/management/models/view-organisation-tag';
+import { Identifiable } from 'app/shared/models/base/identifiable';
+import { OrganisationTag } from 'app/shared/models/event-management/organisation-tag';
+import { BaseRepository } from '../base-repository';
+import { ModelRequestRepository } from '../model-request-repository';
+import { RepositoryServiceCollectorWithoutActiveMeetingService } from '../repository-service-collector-without-active-meeting-service';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class OrganisationTagRepositoryService
+    extends BaseRepository<ViewOrganisationTag, OrganisationTag>
+    implements ModelRequestRepository {
+    public constructor(serviceCollector: RepositoryServiceCollectorWithoutActiveMeetingService) {
+        super(serviceCollector, OrganisationTag);
+    }
+
+    public getVerboseName = (plural?: boolean): string => {
+        return plural ? 'Organization tags' : 'Organization tag';
+    };
+    public getTitle = (viewModel: ViewOrganisationTag): string => {
+        return viewModel.name;
+    };
+    public getFieldsets(): Fieldsets<OrganisationTag> {
+        const detailFieldset: (keyof OrganisationTag)[] = ['color', 'name', 'committee_ids', 'organisation_id'];
+        return {
+            [DEFAULT_FIELDSET]: detailFieldset
+        };
+    }
+
+    public create(tag: OrganisationTagAction.OrganisationTagPayload): Promise<Identifiable> {
+        const payload: OrganisationTagAction.CreatePayload = {
+            name: tag.name,
+            color: tag.color,
+            organisation_id: ORGANISATION_ID
+        };
+        return this.sendActionToBackend(OrganisationTagAction.CREATE, payload);
+    }
+
+    public update(
+        update: Partial<OrganisationTagAction.OrganisationTagPayload>,
+        viewModel: ViewOrganisationTag
+    ): Promise<void> {
+        const payload: OrganisationTagAction.UpdatePayload = {
+            id: viewModel.id,
+            name: update.name,
+            color: update.color
+        };
+        return this.sendActionToBackend(OrganisationTagAction.UPDATE, payload);
+    }
+
+    public delete(...organisationTags: ViewOrganisationTag[]): Promise<void> {
+        const payload: OrganisationTagAction.DeletePayload[] = organisationTags.map(orgaTag => ({ id: orgaTag.id }));
+        return this.sendBulkActionToBackend(OrganisationTagAction.DELETE, payload);
+    }
+
+    public getRequestToGetAllModels(): SimplifiedModelRequest {
+        return {
+            viewModelCtor: ViewOrganisation,
+            ids: [1],
+            follow: [
+                {
+                    idField: 'organisation_tag_ids'
+                }
+            ],
+            fieldset: []
+        };
+    }
+}

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -1,6 +1,7 @@
 import { ViewCommittee } from 'app/management/models/view-committee';
 import { ViewMeeting } from 'app/management/models/view-meeting';
 import { ViewOrganisation } from 'app/management/models/view-organisation';
+import { ViewOrganisationTag } from 'app/management/models/view-organisation-tag';
 import { ViewResource } from 'app/management/models/view-resource';
 import { ViewOption } from 'app/shared/models/poll/view-option';
 import { ViewPoll } from 'app/shared/models/poll/view-poll';
@@ -122,6 +123,12 @@ export const RELATIONS: Relation[] = [
         OViewModel: ViewOrganisation,
         MViewModel: ViewResource,
         OField: 'resources',
+        MField: 'organisation'
+    }),
+    ...makeM2O({
+        OViewModel: ViewOrganisation,
+        MViewModel: ViewOrganisationTag,
+        OField: 'organisation_tags',
         MField: 'organisation'
     }),
     // ########## User
@@ -246,6 +253,12 @@ export const RELATIONS: Relation[] = [
         BViewModel: ViewCommittee,
         AField: 'forward_to_committees',
         BField: 'receive_forwardings_from_committees'
+    }),
+    ...makeM2M({
+        AViewModel: ViewCommittee,
+        BViewModel: ViewOrganisationTag,
+        AField: 'organisation_tags',
+        BField: 'committees'
     }),
     // ########## Meetings
     ...makeO2O({
@@ -461,6 +474,12 @@ export const RELATIONS: Relation[] = [
         MViewModel: ViewUser,
         OField: 'guests',
         MField: 'guest_meetings'
+    }),
+    ...makeM2M({
+        AViewModel: ViewMeeting,
+        BViewModel: ViewOrganisationTag,
+        AField: 'organisation_tags',
+        BField: 'meetings'
     }),
     ...makeO2O({
         AViewModel: ViewMeeting,

--- a/client/src/app/core/ui-services/color.service.ts
+++ b/client/src/app/core/ui-services/color.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+
+import { HtmlColor } from '../definitions/key-types';
+
+export class Color {
+    public get red(): string {
+        return parseInt(this._value.substr(0, 2), 16).toString();
+    }
+
+    public get green(): string {
+        return parseInt(this._value.substr(2, 2), 16).toString();
+    }
+
+    public get blue(): string {
+        return parseInt(this._value.substr(4, 2), 16).toString();
+    }
+
+    public get value(): HtmlColor {
+        return `#${this._value}`;
+    }
+
+    private _value: string;
+
+    public constructor(color: string | HtmlColor) {
+        this._value = color.startsWith('#') ? color.slice(1) : color;
+    }
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ColorService {
+    public parseHtmlColorToColor(htmlColor: string | HtmlColor): Color {
+        return new Color(htmlColor);
+    }
+
+    public getRandomHtmlColor(): HtmlColor {
+        const singleValue = () => {
+            const nextValue = Math.round(Math.random() * 255).toString(16);
+            return nextValue.length === 2 ? nextValue : `0${nextValue}`;
+        };
+        const nextColor = [1, 1, 1].reduce(prevValue => prevValue + singleValue(), '');
+        return `#${nextColor}`;
+    }
+}

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -45,6 +45,18 @@
         </mat-form-field>
 
         <mat-form-field>
+            <mat-label>{{ 'Organization tags' | translate }}</mat-label>
+            <os-search-repo-selector
+                formControlName="organisation_tag_ids"
+                [repo]="orgaTagRepo"
+                [multiple]="true"
+                [showNotFoundButton]="true"
+                (clickNotFound)="onOrgaTagNotFound($event)"
+                placeholder="{{ 'Organization tags' | translate }}"
+            ></os-search-repo-selector>
+        </mat-form-field>
+
+        <mat-form-field>
             <mat-label>{{ 'Description' | translate }}</mat-label>
             <input matInput formControlName="description" />
         </mat-form-field>

--- a/client/src/app/management/components/committee-list/committee-list.component.html
+++ b/client/src/app/management/components/committee-list/committee-list.component.html
@@ -48,6 +48,14 @@
         </div>
     </div>
 
+    <div *pblNgridCellDef="'organization_tags'; row as committee" class="cell-slot fill">
+        <os-chip-list *ngIf="committee.organisation_tags?.length" [model]="committee.organisation_tags">
+            <ng-template let-tag>
+                {{ tag.name }}
+            </ng-template>
+        </os-chip-list>
+    </div>
+
     <div *pblNgridCellDef="'forwarding'; row as committee" class="cell-slot fill">
         <a class="detail-link" [routerLink]="committee.id" *ngIf="!isMultiSelect"></a>
         <div *ngIf="committee.forward_to_committees?.length">

--- a/client/src/app/management/components/committee-list/committee-list.component.ts
+++ b/client/src/app/management/components/committee-list/committee-list.component.ts
@@ -25,6 +25,10 @@ export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee>
             width: 'auto'
         },
         {
+            prop: 'organization_tags',
+            width: '250px'
+        },
+        {
             prop: 'forwarding',
             width: '250px'
         },
@@ -113,6 +117,9 @@ export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee>
                         {
                             idField: 'manager_ids',
                             fieldset: 'shortName'
+                        },
+                        {
+                            idField: 'organisation_tag_ids'
                         }
                     ]
                 }

--- a/client/src/app/management/components/management-navigation/management-navigation.component.ts
+++ b/client/src/app/management/components/management-navigation/management-navigation.component.ts
@@ -29,6 +29,13 @@ export class ManagementNavigationComponent {
             weight: 200
         },
         {
+            route: '/organization-tags',
+            displayName: 'Organization tags',
+            icon: 'label',
+            // permission: Permission.coreCanSeeFrontpage,
+            weight: 250
+        },
+        {
             route: '/members',
             displayName: 'Members',
             icon: 'group',

--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.html
@@ -54,6 +54,21 @@
         </mat-form-field>
 
         <mat-form-field>
+            <mat-label>{{ 'Organization tags' | translate }}</mat-label>
+            <os-search-repo-selector
+                [repo]="orgaTagRepo"
+                [multiple]="true"
+                formControlName="organisation_tag_ids"
+                [showNotFoundButton]="true"
+                (clickNotFound)="onOrgaTagNotFound($event)"
+            >
+                <ng-container notFoundDescription>
+                    {{ 'Add new organization tag' | translate }}
+                </ng-container>
+            </os-search-repo-selector>
+        </mat-form-field>
+
+        <mat-form-field>
             <mat-label> {{ 'Participants' | translate }}</mat-label>
             <os-search-value-selector
                 formControlName="userIds"

--- a/client/src/app/management/components/meeting-list/meeting-list.component.html
+++ b/client/src/app/management/components/meeting-list/meeting-list.component.html
@@ -58,6 +58,14 @@
         </div>
     </div>
 
+    <div *pblNgridCellDef="'organisation_tags'; row as meeting" class="cell-slot fill">
+        <os-chip-list *ngIf="meeting.organisation_tags?.length" [model]="meeting.organisation_tags">
+            <ng-template let-tag>
+                {{ tag.name }}
+            </ng-template>
+        </os-chip-list>
+    </div>
+
     <div *pblNgridCellDef="'users'; row as meeting" class="cell-slot fill">
         <a class="detail-link" [routerLink]="meeting.getUrl()" *ngIf="!isMultiSelect"></a>
         <div>

--- a/client/src/app/management/components/meeting-list/meeting-list.component.ts
+++ b/client/src/app/management/components/meeting-list/meeting-list.component.ts
@@ -33,6 +33,10 @@ export class MeetingListComponent extends BaseListViewComponent<ViewOrganisation
             width: 'auto'
         },
         {
+            prop: 'organisation_tags',
+            width: 'auto'
+        },
+        {
             prop: 'users',
             width: '70px'
         }
@@ -114,7 +118,12 @@ export class MeetingListComponent extends BaseListViewComponent<ViewOrganisation
             follow: [
                 {
                     idField: 'meeting_ids',
-                    fieldset: 'list'
+                    fieldset: 'list',
+                    follow: [
+                        {
+                            idField: 'organisation_tag_ids'
+                        }
+                    ]
                 }
             ],
             fieldset: 'list'

--- a/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.html
+++ b/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.html
@@ -1,0 +1,38 @@
+<h2 mat-dialog-title>{{ (isCreateView ? 'Create an organization tag' : 'Edit an organization tag') | translate }}</h2>
+<div mat-dialog-content class="organization-tag-content">
+    <form [formGroup]="organisationTagForm">
+        <mat-form-field appearance="fill">
+            <mat-label>{{ 'Name' | translate }}</mat-label>
+            <input #name matInput formControlName="name" required />
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+            <mat-label>{{ 'Color' | translate }}</mat-label>
+            <input
+                matInput
+                formControlName="color"
+                [required]="isCreateView"
+                [osOnlyNumber]="true"
+                [osOnlyNumberAllowHex]="true"
+                [osOnlyNumberAllowLeadingZero]="true"
+                maxlength="6"
+            />
+            <span matPrefix>#&nbsp;</span>
+            <button
+                mat-icon-button
+                matSuffix
+                (click)="generateColor()"
+                matTooltip="{{ 'Generate a new color' | translate }}"
+            >
+                <mat-icon> sync </mat-icon>
+            </button>
+            <mat-error *ngIf="organisationTagForm.get('color').errors?.pattern">
+                {{ 'You have to enter six hexadecimal digits' | translate }}
+            </mat-error>
+        </mat-form-field>
+        <os-chip *ngIf="name.value" [color]="currentColor">{{ name.value }}</os-chip>
+    </form>
+</div>
+<div mat-dialog-actions>
+    <button mat-raised-button color="primary" (click)="onSaveClicked()">{{ 'Save' | translate }}</button>
+    <button mat-raised-button [mat-dialog-close]="null">{{ 'Cancel' | translate }}</button>
+</div>

--- a/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.scss
+++ b/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.scss
@@ -1,0 +1,9 @@
+.organization-tag-content {
+    form {
+        & > * {
+            &:not(:first-child) {
+                padding-left: 16px;
+            }
+        }
+    }
+}

--- a/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.spec.ts
+++ b/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrganisationTagDialogComponent } from './organisation-tag-dialog.component';
+
+describe('OrganisationTagDialogComponent', () => {
+    let component: OrganisationTagDialogComponent;
+    let fixture: ComponentFixture<OrganisationTagDialogComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [OrganisationTagDialogComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(OrganisationTagDialogComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.ts
+++ b/client/src/app/management/components/organisation-tag-dialog/organisation-tag-dialog.component.ts
@@ -1,0 +1,89 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { HtmlColor } from 'app/core/definitions/key-types';
+import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { ViewOrganisationTag } from 'app/management/models/view-organisation-tag';
+import { BaseComponent } from 'app/site/base/components/base.component';
+
+interface OrganisationTagDialogData {
+    organisationTag?: ViewOrganisationTag;
+    getRandomColor: () => HtmlColor;
+}
+
+@Component({
+    selector: 'os-organisation-tag-dialog',
+    templateUrl: './organisation-tag-dialog.component.html',
+    styleUrls: ['./organisation-tag-dialog.component.scss']
+})
+export class OrganisationTagDialogComponent extends BaseComponent implements OnInit {
+    public get isCreateView(): boolean {
+        return this._isCreateView;
+    }
+
+    public get currentColor(): string {
+        return this._lastValidColor;
+    }
+
+    public organisationTagForm: FormGroup;
+
+    private _isCreateView = false;
+    private _lastValidColor: string;
+
+    public constructor(
+        serviceCollector: ComponentServiceCollector,
+        @Inject(MAT_DIALOG_DATA) public data: OrganisationTagDialogData,
+        private dialogRef: MatDialogRef<OrganisationTagDialogComponent>,
+        private fb: FormBuilder
+    ) {
+        super(serviceCollector);
+    }
+
+    public ngOnInit(): void {
+        this.createForm();
+        if (!this.data.organisationTag) {
+            this._isCreateView = true;
+        } else {
+            this.updateForm();
+        }
+    }
+
+    public onSaveClicked(): void {
+        const { name, color }: { name: string; color: string } = this.organisationTagForm.value;
+        this.dialogRef.close({ name, color: `#${color}` });
+    }
+
+    public generateColor(): void {
+        this.organisationTagForm.patchValue({ color: this.getRandomColor() });
+    }
+
+    private getRandomColor(): string {
+        const nextColor = this.data.getRandomColor();
+        return nextColor.startsWith('#') ? nextColor.slice(1) : nextColor;
+    }
+
+    private createForm(): void {
+        this._lastValidColor = this.getRandomColor();
+        this.organisationTagForm = this.fb.group({
+            name: ['', Validators.required],
+            color: [this._lastValidColor, Validators.pattern(/^[0-9a-fA-F]{6}$/)]
+        });
+        this.subscriptions.push(
+            this.organisationTagForm.get('color').valueChanges.subscribe((currentColor: string) => {
+                if (currentColor.length === 6) {
+                    this._lastValidColor = currentColor;
+                }
+            })
+        );
+    }
+
+    private updateForm(): void {
+        const color = this.data.organisationTag.color;
+        const update = {
+            name: this.data.organisationTag.name,
+            color: color.startsWith('#') ? color.slice(1) : color
+        };
+        this.organisationTagForm.patchValue(update);
+    }
+}

--- a/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.html
+++ b/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.html
@@ -1,0 +1,100 @@
+<os-head-bar
+    [customMenu]="true"
+    [hasMainButton]="true"
+    (mainEvent)="createOrganizationTag()"
+    [multiSelectMode]="isMultiSelect"
+>
+    <!-- Title -->
+    <div class="title-slot">
+        <h2>{{ 'Organization tags' | translate }}</h2>
+    </div>
+
+    <ng-container class="custom-menu-slot">
+        <os-management-navigation></os-management-navigation>
+    </ng-container>
+
+    <!-- Menu -->
+    <div class="menu-slot">
+        <button type="button" mat-icon-button [matMenuTriggerFor]="orgaTagMenu"><mat-icon>more_vert</mat-icon></button>
+    </div>
+
+    <!-- Multiselect info -->
+    <div class="central-info-slot">
+        <button mat-icon-button (click)="toggleMultiSelect()"><mat-icon>arrow_back</mat-icon></button>
+        <span>{{ selectedRows.length }}&nbsp;</span><span>{{ 'selected' | translate }}</span>
+    </div>
+</os-head-bar>
+
+<os-list-view-table
+    [listObservable]="repo.getViewModelListObservable()"
+    [columns]="tableColumnDefinition"
+    [showListOfSpeakers]="false"
+    [(selectedRows)]="selectedRows"
+    [allowProjector]="false"
+    [multiSelect]="isMultiSelect"
+    listStorageKey="orgaTags"
+    (dataSourceChange)="onDataSourceChange($event)"
+>
+    <div *pblNgridCellDef="'name'; row as orgaTag" class="cell-slot fill">
+        <div>
+            <os-chip [color]="orgaTag.color">{{ orgaTag.name }}</os-chip>
+        </div>
+    </div>
+    <div *pblNgridCellDef="'info'; row as orgaTag" class="cell-slot fill">
+        <div>
+            <div *ngIf="orgaTag.committees?.length">
+                <os-icon-container
+                    icon="account_balance"
+                    iconTooltip="{{ 'Related committees' | translate }}"
+                    [noWrap]="true"
+                >
+                    <span *ngFor="let committee of orgaTag.committees; last as last">
+                        {{ committee.name }}<span *ngIf="!last">,&nbsp;</span>
+                    </span>
+                </os-icon-container>
+            </div>
+            <div *ngIf="orgaTag.meetings?.length">
+                <os-icon-container
+                    icon="calendar_today"
+                    iconTooltip="{{ 'Related meetings' | translate }}"
+                    [noWrap]="true"
+                >
+                    <span *ngFor="let meeting of orgaTag.meetings; last as last">
+                        {{ meeting.name }}<span *ngIf="!last">,&nbsp;</span>
+                    </span>
+                </os-icon-container>
+            </div>
+        </div>
+    </div>
+    <div *pblNgridCellDef="'actions'; row as orgaTag" class="cell-slot fill">
+        <div class="button-group">
+            <button mat-stroked-button (click)="editOrganizationTag(orgaTag)">{{ 'Edit' | translate }}</button>
+            <button mat-stroked-button (click)="deleteOrganizationTags(orgaTag)">{{ 'Delete' | translate }}</button>
+        </div>
+    </div>
+</os-list-view-table>
+
+<mat-menu #orgaTagMenu="matMenu">
+    <div *ngIf="!isMultiSelect">
+        <button mat-menu-item (click)="toggleMultiSelect()">
+            <mat-icon>library_add</mat-icon>
+            <span>{{ 'Multiselect' | translate }}</span>
+        </button>
+    </div>
+    <div *ngIf="isMultiSelect">
+        <button mat-menu-item (click)="selectAll()">
+            <mat-icon>done_all</mat-icon>
+            <span>{{ 'Select all' | translate }}</span>
+        </button>
+
+        <button mat-menu-item [disabled]="!selectedRows.length" (click)="deselectAll()">
+            <mat-icon>clear</mat-icon>
+            <span>{{ 'Deselect all' | translate }}</span>
+        </button>
+        <mat-divider></mat-divider>
+        <button mat-menu-item class="red-warning-text" [disabled]="!selectedRows.length" (click)="deleteSelectedTags()">
+            <mat-icon>delete</mat-icon>
+            <span>{{ 'Delete' | translate }}</span>
+        </button>
+    </div>
+</mat-menu>

--- a/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.scss
+++ b/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.scss
@@ -1,0 +1,12 @@
+.button-group {
+    button:not(:first-child) {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+    button:not(:last-child) {
+        border-right: 0;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+}

--- a/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.spec.ts
+++ b/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrganisationTagListComponent } from './organisation-tag-list.component';
+
+describe('OrganisationTagListComponent', () => {
+    let component: OrganisationTagListComponent;
+    let fixture: ComponentFixture<OrganisationTagListComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [OrganisationTagListComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(OrganisationTagListComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.ts
+++ b/client/src/app/management/components/organisation-tag-list/organisation-tag-list.component.ts
@@ -1,0 +1,112 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+
+import { PblColumnDefinition } from '@pebula/ngrid';
+
+import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
+import { OrganisationTagRepositoryService } from 'app/core/repositories/management/organisation-tag-repository.service';
+import { ColorService } from 'app/core/ui-services/color.service';
+import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PromptService } from 'app/core/ui-services/prompt.service';
+import { ViewOrganisation } from 'app/management/models/view-organisation';
+import { ViewOrganisationTag } from 'app/management/models/view-organisation-tag';
+import { mediumDialogSettings } from 'app/shared/utils/dialog-settings';
+import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component';
+import { OrganisationTagDialogComponent } from '../organisation-tag-dialog/organisation-tag-dialog.component';
+
+@Component({
+    selector: 'os-organisation-tag-list',
+    templateUrl: './organisation-tag-list.component.html',
+    styleUrls: ['./organisation-tag-list.component.scss']
+})
+export class OrganisationTagListComponent extends BaseListViewComponent<ViewOrganisationTag> implements OnInit {
+    public tableColumnDefinition: PblColumnDefinition[] = [
+        {
+            prop: 'name',
+            width: 'auto'
+        },
+        {
+            prop: 'info',
+            width: '65%'
+        },
+        {
+            prop: 'actions',
+            width: 'auto'
+        }
+    ];
+
+    public constructor(
+        serviceCollector: ComponentServiceCollector,
+        public repo: OrganisationTagRepositoryService,
+        private dialog: MatDialog,
+        private promptService: PromptService,
+        private colorService: ColorService
+    ) {
+        super(serviceCollector);
+        super.setTitle('Organization tags');
+        this.canMultiSelect = true;
+    }
+
+    public ngOnInit(): void {
+        super.ngOnInit();
+    }
+
+    public createOrganizationTag(): Promise<void> {
+        return this.editOrganizationTag();
+    }
+
+    public async editOrganizationTag(orgaTag?: ViewOrganisationTag): Promise<void> {
+        const dialogRef = this.dialog.open(OrganisationTagDialogComponent, {
+            ...mediumDialogSettings,
+            data: {
+                organisationTag: orgaTag,
+                getRandomColor: () => this.colorService.getRandomHtmlColor()
+            }
+        });
+        const result = await dialogRef.afterClosed().toPromise();
+        if (result) {
+            if (!orgaTag) {
+                // Creating a new tag...
+                this.repo.create(result);
+            } else {
+                this.repo.update(result, orgaTag);
+            }
+        }
+    }
+
+    public async deleteOrganizationTags(...orgaTags: ViewOrganisationTag[]): Promise<void> {
+        const dialogTitle =
+            orgaTags.length === 1
+                ? this.translate.instant('Are you sure you want to delete this organization tag?')
+                : this.translate.instant('Are you sure you want to delete all selected tags?');
+        const dialogSubtitle = orgaTags.length === 1 ? orgaTags[0].name : '';
+        if (await this.promptService.open(dialogTitle, dialogSubtitle)) {
+            await this.repo.delete(...orgaTags);
+        }
+    }
+
+    public deleteSelectedTags(): void {
+        this.deleteOrganizationTags(...this.selectedRows);
+    }
+
+    protected getModelRequest(): SimplifiedModelRequest {
+        return {
+            viewModelCtor: ViewOrganisation,
+            ids: [1],
+            fieldset: 'list',
+            follow: [
+                {
+                    idField: 'organisation_tag_ids',
+                    follow: [
+                        {
+                            idField: 'committee_ids'
+                        },
+                        {
+                            idField: 'meeting_ids'
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+}

--- a/client/src/app/management/management-routing.module.ts
+++ b/client/src/app/management/management-routing.module.ts
@@ -11,7 +11,7 @@ import { MeetingListComponent } from './components/meeting-list/meeting-list.com
 import { MemberEditComponent } from './components/member-edit/member-edit.component';
 import { MemberListComponent } from './components/member-list/member-list.component';
 import { OrgaSettingsComponent } from './components/orga-settings/orga-settings.component';
-// import { OrganisationListComponent } from './components/organisation-list/organisation-list.component';
+import { OrganisationTagListComponent } from './components/organisation-tag-list/organisation-tag-list.component';
 
 const routes: Route[] = [
     {
@@ -69,6 +69,10 @@ const routes: Route[] = [
                         ]
                     }
                 ]
+            },
+            {
+                path: 'organization-tags',
+                component: OrganisationTagListComponent
             },
             {
                 path: 'settings',

--- a/client/src/app/management/management.config.ts
+++ b/client/src/app/management/management.config.ts
@@ -2,16 +2,19 @@ import { AppConfig } from '../core/definitions/app-config';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { MeetingRepositoryService } from 'app/core/repositories/management/meeting-repository.service';
 import { OrganisationRepositoryService } from 'app/core/repositories/management/organisation-repository.service';
+import { OrganisationTagRepositoryService } from 'app/core/repositories/management/organisation-tag-repository.service';
 import { ResourceRepositoryService } from 'app/core/repositories/management/resource-repository.service';
 import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
 import { Committee } from 'app/shared/models/event-management/committee';
 import { Meeting } from 'app/shared/models/event-management/meeting';
 import { Organisation } from 'app/shared/models/event-management/organisation';
+import { OrganisationTag } from 'app/shared/models/event-management/organisation-tag';
 import { Resource } from 'app/shared/models/event-management/resource';
 import { User } from 'app/shared/models/users/user';
 import { ViewCommittee } from './models/view-committee';
 import { ViewMeeting } from './models/view-meeting';
 import { ViewOrganisation } from './models/view-organisation';
+import { ViewOrganisationTag } from './models/view-organisation-tag';
 import { ViewResource } from './models/view-resource';
 import { ViewUser } from '../site/users/models/view-user';
 
@@ -42,6 +45,11 @@ export const ManagementAppConfig: AppConfig = {
             model: Resource,
             viewModel: ViewResource,
             repository: ResourceRepositoryService
+        },
+        {
+            model: OrganisationTag,
+            viewModel: ViewOrganisationTag,
+            repository: OrganisationTagRepositoryService
         }
     ]
 };

--- a/client/src/app/management/management.module.ts
+++ b/client/src/app/management/management.module.ts
@@ -14,6 +14,8 @@ import { MeetingListComponent } from './components/meeting-list/meeting-list.com
 import { MemberEditComponent } from './components/member-edit/member-edit.component';
 import { MemberListComponent } from './components/member-list/member-list.component';
 import { OrgaSettingsComponent } from './components/orga-settings/orga-settings.component';
+import { OrganisationTagDialogComponent } from './components/organisation-tag-dialog/organisation-tag-dialog.component';
+import { OrganisationTagListComponent } from './components/organisation-tag-list/organisation-tag-list.component';
 
 @NgModule({
     imports: [CommonModule, SharedModule, ManagementRoutingModule],
@@ -28,7 +30,9 @@ import { OrgaSettingsComponent } from './components/orga-settings/orga-settings.
         MemberEditComponent,
         ManagementNavigationComponent,
         OrgaSettingsComponent,
-        AccountDialogComponent
+        AccountDialogComponent,
+        OrganisationTagListComponent,
+        OrganisationTagDialogComponent
     ]
 })
 export class ManagementModule {}

--- a/client/src/app/management/models/view-committee.ts
+++ b/client/src/app/management/models/view-committee.ts
@@ -3,6 +3,7 @@ import { BaseViewModel } from 'app/site/base/base-view-model';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { ViewMeeting } from './view-meeting';
 import { ViewOrganisation } from './view-organisation';
+import { ViewOrganisationTag } from './view-organisation-tag';
 
 export class ViewCommittee extends BaseViewModel<Committee> {
     public static COLLECTION = Committee.COLLECTION;
@@ -28,6 +29,7 @@ interface ICommitteeRelations {
     forward_to_committees: ViewCommittee[];
     receive_forwardings_from_committees: ViewCommittee[];
     organisation: ViewOrganisation;
+    organisation_tags: ViewOrganisationTag[];
     template_meeting: ViewMeeting;
 }
 export interface ViewCommittee extends Committee, ICommitteeRelations {}

--- a/client/src/app/management/models/view-meeting.ts
+++ b/client/src/app/management/models/view-meeting.ts
@@ -31,6 +31,7 @@ import { ViewGroup } from 'app/site/users/models/view-group';
 import { ViewPersonalNote } from 'app/site/users/models/view-personal-note';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { ViewCommittee } from './view-committee';
+import { ViewOrganisationTag } from './view-organisation-tag';
 
 export interface HasMeeting {
     meeting: ViewMeeting;
@@ -113,5 +114,6 @@ interface IMeetingRelations {
     projections: ViewProjection[];
     default_group: ViewGroup;
     admin_group: ViewGroup;
+    organisation_tags: ViewOrganisationTag[];
 }
 export interface ViewMeeting extends Meeting, IMeetingRelations, HasProjectorTitle {}

--- a/client/src/app/management/models/view-organisation-tag.ts
+++ b/client/src/app/management/models/view-organisation-tag.ts
@@ -1,0 +1,22 @@
+import { OrganisationTag } from 'app/shared/models/event-management/organisation-tag';
+import { BaseViewModel } from 'app/site/base/base-view-model';
+import { ViewCommittee } from './view-committee';
+import { ViewMeeting } from './view-meeting';
+import { ViewOrganisation } from './view-organisation';
+
+export class ViewOrganisationTag extends BaseViewModel<OrganisationTag> {
+    public static readonly COLLECTION = OrganisationTag.COLLECTION;
+    protected _collection = OrganisationTag.COLLECTION;
+
+    public get organisationTag(): OrganisationTag {
+        return this._model;
+    }
+}
+
+interface IOrganisationTagRelations {
+    organisation: ViewOrganisation;
+    committees: ViewCommittee[];
+    meetings: ViewMeeting[];
+}
+
+export interface ViewOrganisationTag extends OrganisationTag, IOrganisationTagRelations {}

--- a/client/src/app/management/models/view-organisation.ts
+++ b/client/src/app/management/models/view-organisation.ts
@@ -2,6 +2,7 @@ import { Organisation } from 'app/shared/models/event-management/organisation';
 import { BaseViewModel } from 'app/site/base/base-view-model';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { ViewCommittee } from './view-committee';
+import { ViewOrganisationTag } from './view-organisation-tag';
 import { ViewResource } from './view-resource';
 
 export class ViewOrganisation extends BaseViewModel<Organisation> {
@@ -17,5 +18,6 @@ interface IOrganisationRelations {
     roles: ViewUser[];
     superadmin_role: ViewUser;
     resources: ViewResource[];
+    organisation_tags: ViewOrganisationTag;
 }
 export interface ViewOrganisation extends Organisation, IOrganisationRelations {}

--- a/client/src/app/shared/components/chip-list/chip-list.component.html
+++ b/client/src/app/shared/components/chip-list/chip-list.component.html
@@ -1,0 +1,5 @@
+<mat-chip-list>
+    <os-chip *ngFor="let model of models" [color]="model.color">
+        <ng-template [ngTemplateOutlet]="templateRef" [ngTemplateOutletContext]="{ $implicit: model }"></ng-template>
+    </os-chip>
+</mat-chip-list>

--- a/client/src/app/shared/components/chip-list/chip-list.component.spec.ts
+++ b/client/src/app/shared/components/chip-list/chip-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChipListComponent } from './chip-list.component';
+
+describe('ChipListComponent', () => {
+    let component: ChipListComponent;
+    let fixture: ComponentFixture<ChipListComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ChipListComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ChipListComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/shared/components/chip-list/chip-list.component.ts
+++ b/client/src/app/shared/components/chip-list/chip-list.component.ts
@@ -1,0 +1,75 @@
+import { Component, ContentChild, Input, OnDestroy, OnInit, TemplateRef } from '@angular/core';
+
+import { Observable, Subscription } from 'rxjs';
+
+import { HtmlColor } from 'app/core/definitions/key-types';
+import { HasColor } from 'app/shared/models/base/has-color';
+
+@Component({
+    selector: 'os-chip-list',
+    templateUrl: './chip-list.component.html',
+    styleUrls: ['./chip-list.component.scss']
+})
+export class ChipListComponent implements OnInit, OnDestroy {
+    /**
+     * Reference to the template content.
+     */
+    @ContentChild(TemplateRef, { static: true })
+    public templateRef: TemplateRef<any>;
+
+    /**
+     * A reference to a model containing an htmlcolor or a string as htmlcolor or a css-class.
+     * This can also be a list of them or an observable with one or a list of them.
+     * Everything is mapped to the interface `HasColor`.
+     */
+    @Input()
+    public model:
+        | HtmlColor
+        | HasColor
+        | (HtmlColor | HasColor)[]
+        | Observable<HtmlColor | HasColor | (HasColor | HtmlColor)[]>;
+
+    public get models(): HasColor[] {
+        return this._models;
+    }
+
+    private subscription: Subscription | null = null;
+    private _models: HasColor[] = [];
+
+    public constructor() {}
+
+    public ngOnInit(): void {
+        if (this.model instanceof Observable) {
+            this.initSubscription();
+        } else {
+            this.initModels(this.model);
+        }
+    }
+
+    public ngOnDestroy(): void {
+        if (this.subscription) {
+            this.subscription.unsubscribe();
+            this.subscription = null;
+        }
+    }
+
+    private initSubscription(): void {
+        this.subscription = (this.model as Observable<
+            HasColor | HtmlColor | (HtmlColor | HasColor)[]
+        >).subscribe(models => this.initModels(models));
+    }
+
+    private initModels(models: HtmlColor | HasColor | (HtmlColor | HasColor)[]): void {
+        let nextModels: (HtmlColor | HasColor)[] = [];
+        if (Array.isArray(models)) {
+            nextModels = models;
+        } else {
+            nextModels = [models];
+        }
+        if (typeof nextModels[0] === 'string') {
+            this._models = (nextModels as HtmlColor[]).map(model => ({ color: model }));
+        } else {
+            this._models = nextModels as HasColor[];
+        }
+    }
+}

--- a/client/src/app/shared/components/chip/chip.component.html
+++ b/client/src/app/shared/components/chip/chip.component.html
@@ -1,0 +1,3 @@
+<mat-basic-chip class="os-chip" [ngClass]="cssClass ? cssClass : ''" [disableRipple]="true">
+    <ng-content></ng-content>
+</mat-basic-chip>

--- a/client/src/app/shared/components/chip/chip.component.scss
+++ b/client/src/app/shared/components/chip/chip.component.scss
@@ -1,0 +1,37 @@
+/**
+ * For further information, see https://css-tricks.com/switch-font-color-for-different-backgrounds-with-css/
+ */
+:host {
+    --os-chip-red: 0;
+    --os-chip-green: 0;
+    --os-chip-blue: 0;
+
+    /**
+     * The threshold at which colors are considered "light".
+     * Range: decimals from 0 to 1,
+     * recommended 0.5 - 0.6
+     */
+    --os-chip-threshold: 0.5;
+}
+
+.os-chip {
+    background: rgb(var(--os-chip-red), var(--os-chip-green), var(--os-chip-blue));
+
+    /**
+     * Calc using the
+     * W3C luma method
+     * lightness = (red * 0.299 + green * 0.587 + blue * 0.114) / 255
+     */
+    --red: calc(var(--os-chip-red) * 0.299);
+    --green: calc(var(--os-chip-green) * 0.587);
+    --blue: calc(var(--os-chip-blue) * 0.114);
+    --sum: calc(var(--red) + var(--green) + var(--blue));
+
+    --perceived-lightness: calc(var(--sum) / 255);
+
+    /**
+     * 1) Any lightness value above the threshold will be considered "light", therefore apply a black text color. Any bellow will be considered dark, and use white color.
+     * This results from appying either a sub-zero (negative) or a higher-than-100 lightness value, which are capped to 0 and 100 respectively, to a HSL declaration
+     */
+    color: hsl(0, 0%, calc((var(--perceived-lightness) - var(--os-chip-threshold)) * -10000000%));
+}

--- a/client/src/app/shared/components/chip/chip.component.spec.ts
+++ b/client/src/app/shared/components/chip/chip.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChipComponent } from './chip.component';
+
+describe('ChipComponent', () => {
+    let component: ChipComponent;
+    let fixture: ComponentFixture<ChipComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ChipComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ChipComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/shared/components/chip/chip.component.ts
+++ b/client/src/app/shared/components/chip/chip.component.ts
@@ -1,0 +1,40 @@
+import { Component, ElementRef, Input } from '@angular/core';
+
+import { HtmlColor } from 'app/core/definitions/key-types';
+import { Color, ColorService } from 'app/core/ui-services/color.service';
+
+@Component({
+    selector: 'os-chip',
+    templateUrl: './chip.component.html',
+    styleUrls: ['./chip.component.scss']
+})
+export class ChipComponent {
+    /**
+     * An htmlcolor or a css-class can be given as `color`.
+     */
+    @Input()
+    public set color(color: HtmlColor | string) {
+        if (/^(#?)[0-9a-fA-F]{6}$/.test(color)) {
+            this._color = this.colorService.parseHtmlColorToColor(color);
+            this.recalcForegroundColor();
+        } else {
+            this.cssClass = color;
+        }
+    }
+
+    public cssClass: string;
+
+    private _color: Color = null;
+    private _threshold = '0.5';
+
+    private root = this.hostElement.nativeElement;
+
+    public constructor(private hostElement: ElementRef<HTMLElement>, private colorService: ColorService) {}
+
+    private recalcForegroundColor(): void {
+        this.root.style.setProperty('--os-chip-red', this._color.red);
+        this.root.style.setProperty('--os-chip-green', this._color.green);
+        this.root.style.setProperty('--os-chip-blue', this._color.blue);
+        this.root.style.setProperty('--os-chip-threshold', this._threshold);
+    }
+}

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.html
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.html
@@ -6,7 +6,7 @@
     [errorStateMatcher]="errorStateMatcher"
 >
     <mat-option>
-        <ngx-mat-select-search [formControl]="searchValueForm"></ngx-mat-select-search>
+        <ngx-mat-select-search [formControl]="searchValueForm" noEntriesFoundLabel=""></ngx-mat-select-search>
     </mat-option>
     <ng-container *ngIf="multiple && showChips">
         <div #chipPlaceholder>
@@ -32,6 +32,9 @@
         </button>
     </ng-container>
     <cdk-virtual-scroll-viewport class="vscroll-viewport" minBufferPx="400" maxBufferPx="600" [itemSize]="50">
+        <mat-option *ngIf="!getFilteredItemsBySearchValue().length" class="os-search-selector--no-options" disabled>
+            {{ noOptionsFoundLabel | translate }}
+        </mat-option>
         <mat-option *cdkVirtualFor="let selectedItem of getFilteredItemsBySearchValue()" [value]="selectedItem.id">
             {{ selectedItem.getTitle() | translate }}
         </mat-option>

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.scss
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.scss
@@ -2,6 +2,12 @@
     max-height: 312px !important ;
 }
 
+.os-search-selector--no-options {
+    mat-pseudo-checkbox {
+        display: none;
+    }
+}
+
 .os-search-selector--chip-container {
     margin: 5px;
     width: max-content;

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
@@ -44,6 +44,12 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormControlCo
     public showNotFoundButton = false;
 
     /**
+     * Label showing, if there are no options for a specific search.
+     */
+    @Input()
+    public noOptionsFoundLabel = 'No options found';
+
+    /**
      * Emits the currently searched string.
      */
     @Output()

--- a/client/src/app/shared/directives/only-number.directive.ts
+++ b/client/src/app/shared/directives/only-number.directive.ts
@@ -1,42 +1,78 @@
-import { Directive, HostListener, Input } from '@angular/core';
+import { Directive, ElementRef, HostListener, Input, OnInit } from '@angular/core';
 
 @Directive({
     selector: '[osOnlyNumber]'
 })
-export class OnlyNumberDirective {
+export class OnlyNumberDirective implements OnInit {
     @Input()
     public osOnlyNumber = true;
+
+    /**
+     * Whether it is allowed to enter hexadecimal digits (A - F).
+     */
+    @Input()
+    public set osOnlyNumberAllowHex(isAllowed: boolean) {
+        this._osOnlyNumberAllowHex = isAllowed;
+        this.updateAllowedCharacters();
+    }
+
+    /**
+     * Whether a number can be leaded by a `0`. For example: `000023`.
+     */
+    @Input()
+    public set osOnlyNumberAllowLeadingZero(isAllowed: boolean) {
+        this._osOnlyNumberAllowLeadingZero = isAllowed;
+        this.updateAllowedCharacters();
+    }
+
+    /**
+     * Whether decimal numbers are allowed. These can be introduced with a `,` or `.`.
+     * If decimal numbers are allowed, `osOnlyNumberAllowHex` and `osOnlyNumberAllowLeadingZero` will be ignored.
+     */
+    @Input()
+    public set osOnlyNumberAllowDecimal(isAllowed: boolean) {
+        this._osOnlyNumberAllowDecimal = isAllowed;
+        this.updateAllowedCharacters();
+    }
+
+    /**
+     * Sets a maximum number of allowed decimal digits. Defaults to `6`.
+     * A `0` means, an unlimited number of decimal digits is allowed.
+     */
+    @Input()
+    public set osOnlyNumberMaxDecimalDigits(amount: number) {
+        this._osOnlyNumberMaxDecimalDigits = amount;
+        this.updateAllowedCharacters();
+    }
+
+    private _osOnlyNumberAllowHex = false;
+    private _osOnlyNumberAllowLeadingZero = false;
+    private _osOnlyNumberAllowDecimal = false;
+    private _osOnlyNumberMaxDecimalDigits = 6;
 
     /**
      * Regex to validate only numbers
      * ^: starts with
      * $: ends
      */
-    private regExp = new RegExp('^([1-9][0-9]*|0)?$');
+    // private regExp = new RegExp('^([1-9][0-9]*|0)?$');
+    private regExp: RegExp;
 
-    private allowedCharacters = [
-        '0',
-        '1',
-        '2',
-        '3',
-        '4',
-        '5',
-        '6',
-        '7',
-        '8',
-        '9',
-        'Backspace',
-        'ArrowLeft',
-        'ArrowRight',
-        'ArrowUp',
-        'ArrowDown'
-    ];
+    private allowedKeys = ['Backspace', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Tab'];
+
+    public constructor(private hostElement: ElementRef<HTMLInputElement>) {}
+
+    public ngOnInit(): void {
+        this.updateAllowedCharacters();
+    }
 
     @HostListener('keydown', ['$event'])
     public onKeyDown(event: KeyboardEvent): void {
+        this.regExp.lastIndex = 0;
+        const nextValue = this.hostElement.nativeElement.value + event.key;
         if (this.osOnlyNumber) {
             if (
-                this.allowedCharacters.includes(event.key) ||
+                this.allowedKeys.includes(event.key) ||
                 // Allow: Ctrl+A
                 (event.key === 'a' && event.ctrlKey) ||
                 // Allow: Ctrl+C
@@ -44,16 +80,30 @@ export class OnlyNumberDirective {
                 // Allow: Ctrl+V
                 (event.key === 'v' && event.ctrlKey) ||
                 // Allow: Ctrl+X
-                (event.key === 'x' && event.ctrlKey)
+                (event.key === 'x' && event.ctrlKey) ||
+                this.regExp.test(nextValue)
             ) {
-                // let it happen, don't do anything
-                return;
-            }
-            if (this.regExp.test(event.key)) {
                 return;
             } else {
                 event.preventDefault();
             }
         }
+    }
+
+    private updateAllowedCharacters(): void {
+        let regexString = '';
+        if (this._osOnlyNumberAllowDecimal) {
+            const maximumDecimalDigits =
+                this._osOnlyNumberMaxDecimalDigits === 0 ? '' : `{${this._osOnlyNumberMaxDecimalDigits}}`;
+            regexString = `^([1-9][0-9]*|0)((\,|\.)${maximumDecimalDigits})?$`;
+        } else {
+            const hexCharacters = this._osOnlyNumberAllowHex ? 'a-fA-F' : '';
+            const allowedFirstCharacter = `[1-9${hexCharacters}]`;
+            const allowedOtherCharacters = `[0-9${hexCharacters}]`;
+            regexString = this._osOnlyNumberAllowLeadingZero
+                ? `^(${allowedOtherCharacters}*)$`
+                : `^(${allowedFirstCharacter}${allowedOtherCharacters}*|0)?$`;
+        }
+        this.regExp = new RegExp(regexString);
     }
 }

--- a/client/src/app/shared/models/base/has-color.ts
+++ b/client/src/app/shared/models/base/has-color.ts
@@ -1,0 +1,5 @@
+import { HtmlColor } from 'app/core/definitions/key-types';
+
+export interface HasColor {
+    color: HtmlColor;
+}

--- a/client/src/app/shared/models/event-management/committee.ts
+++ b/client/src/app/shared/models/event-management/committee.ts
@@ -16,6 +16,7 @@ export class Committee extends BaseModel<Committee> {
     public forward_to_committee_ids: Id[]; // (committee/receive_forwardings_from_committee_ids)[];
     public receive_forwardings_from_committee_ids: Id[]; // (committee/forward_to_committee_ids)[];
     public organisation_id: Id; // organisation/committee_ids;
+    public organisation_tag_ids: Id[]; // (committee/organisation_tag_ids)[];
 
     public constructor(input?: any) {
         super(Committee.COLLECTION, input);

--- a/client/src/app/shared/models/event-management/meeting.ts
+++ b/client/src/app/shared/models/event-management/meeting.ts
@@ -197,6 +197,8 @@ export class Meeting extends BaseModel<Meeting> {
     public default_group_id: Id; // group/default_group_for_meeting_id;
     public admin_group_id: Id; // group/admin_group_for_meeting_id;
 
+    public organisation_tag_ids: Id[]; // (organisation_tag/meeting_ids)[];
+
     public constructor(input?: any) {
         super(Meeting.COLLECTION, input);
     }

--- a/client/src/app/shared/models/event-management/organisation-tag.ts
+++ b/client/src/app/shared/models/event-management/organisation-tag.ts
@@ -1,0 +1,19 @@
+import { HtmlColor, Id } from 'app/core/definitions/key-types';
+import { BaseModel } from '../base/base-model';
+import { HasColor } from '../base/has-color';
+
+export class OrganisationTag extends BaseModel<OrganisationTag> implements HasColor {
+    public static readonly COLLECTION = 'organisation_tag';
+
+    public id: Id;
+    public name: string;
+    public color: HtmlColor;
+
+    public organisation_id: Id; // organisation/organisation_tag_ids;
+    public committee_ids: Id[]; // (committee/organisation_tag_ids)[];
+    public meeting_ids: Id[]; // (meeting/organisation_tag_ids)[];
+
+    public constructor(input?: any) {
+        super(OrganisationTag.COLLECTION, input);
+    }
+}

--- a/client/src/app/shared/models/event-management/organisation.ts
+++ b/client/src/app/shared/models/event-management/organisation.ts
@@ -33,6 +33,7 @@ export class Organisation extends BaseModel<Organisation> {
     public role_ids: Id[]; // (role/organisation_id)[];
     public superadmin_role_id: Id; // role/superadmin_role_for_organisation_id;
     public resource_ids: Id[]; // (resource/organisation_id)[];
+    public organisation_tag_ids: Id[]; // (organisation_tag/organisation_id)[]
 
     public constructor(input?: any) {
         super(Organisation.COLLECTION, input);

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -105,6 +105,8 @@ import { ListenEditingDirective } from './directives/listen-editing.directive';
 import { ChangePasswordComponent } from './components/change-password/change-password.component';
 import { UserDetailViewComponent } from './components/user-detail-view/user-detail-view.component';
 import { SelectionTreeComponent } from './components/selection-tree/selection-tree.component';
+import { ChipComponent } from './components/chip/chip.component';
+import { ChipListComponent } from './components/chip-list/chip-list.component';
 
 const declarations = [
     PermsDirective,
@@ -177,7 +179,9 @@ const declarations = [
     ListenEditingDirective,
     ChangePasswordComponent,
     UserDetailViewComponent,
-    SelectionTreeComponent
+    SelectionTreeComponent,
+    ChipComponent,
+    ChipListComponent
 ];
 
 const sharedModules = [


### PR DESCRIPTION
Fixes #192 

- Implements orga-tag-actions and (view-) models
- Implements a view to manage all orga-tags
- Adds form-fields to add or remove orga-tags to committees or meetings

Depends [openslides-backend#639](https://github.com/OpenSlides/openslides-backend/issues/639)