### PR TITLE
Fixed lifecycle in multiple places

### DIFF
--- a/client/src/app/core/core-services/active-meeting.service.ts
+++ b/client/src/app/core/core-services/active-meeting.service.ts
@@ -14,7 +14,7 @@ export class NoActiveMeeting extends Error {}
     providedIn: 'root'
 })
 export class ActiveMeetingService {
-    private meetingSubject = new BehaviorSubject<ViewMeeting | null>(null);
+    private meetingSubject = new BehaviorSubject<ViewMeeting | null>(undefined);
     private meetingSubcription: Subscription = null;
 
     protected modelAutoupdateSubscription: ModelSubscription | null = null;
@@ -58,17 +58,20 @@ export class ActiveMeetingService {
             this.modelAutoupdateSubscription = null;
         }
 
+        if (this.meetingSubcription) {
+            this.meetingSubcription.unsubscribe();
+        }
+
         if (id) {
             this.modelAutoupdateSubscription = await this.autoupdateService.simpleRequest(
                 this.getModelRequest(),
                 'ActiveMeetingService'
             );
 
-            if (this.meetingSubcription) {
-                this.meetingSubcription.unsubscribe();
-            }
             this.meetingSubcription = this.repo.getViewModelObservable(id).subscribe(meeting => {
-                this.meetingSubject.next(meeting);
+                if (meeting !== undefined) {
+                    this.meetingSubject.next(meeting);
+                }
             });
         } else {
             this.meetingSubject.next(null);

--- a/client/src/app/core/core-services/auth-guard.service.ts
+++ b/client/src/app/core/core-services/auth-guard.service.ts
@@ -40,7 +40,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
      */
     public async canActivate(route: ActivatedRouteSnapshot): Promise<boolean | UrlTree> {
         const basePerm: Permission | Permission[] = route.data.basePerm;
-        await this.operator.loaded;
+        await this.operator.ready;
         if ((this.operator.isAnonymous && this.activeMeeting.guestsEnabled) || this.operator.isAuthenticated) {
             return this.hasPerms(basePerm);
         } else {
@@ -55,7 +55,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
      * @param route the route the user wants to navigate to
      */
     public async canActivateChild(route: ActivatedRouteSnapshot): Promise<boolean> {
-        await this.operator.loaded;
+        await this.operator.ready;
 
         if (this.canActivate(route)) {
             return true;

--- a/client/src/app/core/core-services/auth-token.service.ts
+++ b/client/src/app/core/core-services/auth-token.service.ts
@@ -22,7 +22,8 @@ export class AuthTokenService {
         return this._rawAccessToken;
     }
 
-    private accessTokenSubject = new BehaviorSubject<AuthToken | null>(null);
+    // Use undefined as the state of not being initialized
+    private accessTokenSubject = new BehaviorSubject<AuthToken | null>(undefined);
 
     public get accessTokenObservable(): Observable<AuthToken | null> {
         return this.accessTokenSubject.asObservable();

--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -89,7 +89,7 @@ export class AutoupdateService {
      */
     public async simpleRequest(simpleRequest: SimplifiedModelRequest, description: string): Promise<ModelSubscription> {
         const request = await this.modelRequestBuilder.build(simpleRequest);
-        console.log('request send:', simpleRequest, request);
+        console.log('autoupdate: new request:', description, simpleRequest, request);
         return await this.request(request, description);
     }
 
@@ -106,7 +106,7 @@ export class AutoupdateService {
 
     private async handleAutoupdateWithStupidFormat(autoupdateData: AutoupdateModelData, id: number): Promise<void> {
         const modelData = autoupdateFormatToModelData(autoupdateData);
-        console.log('handle autoupdate from stream ' + id, modelData, 'raw data:', autoupdateData);
+        console.log('autoupdate: from stream', id, modelData, 'raw data:', autoupdateData);
         await this.handleAutoupdate(modelData);
     }
 

--- a/client/src/app/core/core-services/collection-mapper.service.ts
+++ b/client/src/app/core/core-services/collection-mapper.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { BaseRepository } from 'app/core/repositories/base-repository';
 import { BaseViewModel, ViewModelConstructor } from 'app/site/base/base-view-model';
 import { BaseModel, ModelConstructor } from '../../shared/models/base/base-model';
+import { BaseRepositoryWithActiveMeeting } from '../repositories/base-repository-with-active-meeting';
 
 /**
  * Unifies the ModelConstructor and ViewModelConstructor.
@@ -15,7 +16,7 @@ interface UnifiedConstructors {
 /**
  * Every types supported: (View)ModelConstructors, repos and collections.
  */
-type TypeNumber = UnifiedConstructors | BaseRepository<any, any> | string;
+type CollectionType = UnifiedConstructors | BaseRepository<any, any> | string;
 
 type CollectionMappedTypes = [
     ModelConstructor<BaseModel>,
@@ -58,7 +59,7 @@ export class CollectionMapperService {
      * @param obj The object to get the collection string from.
      * @returns the collection
      */
-    public getCollection(obj: TypeNumber): string {
+    public getCollection(obj: CollectionType): string {
         if (typeof obj === 'string') {
             return obj;
         } else {
@@ -77,7 +78,7 @@ export class CollectionMapperService {
      * @param obj The object to get the model constructor from.
      * @returns the model constructor
      */
-    public getModelConstructor<M extends BaseModel>(obj: TypeNumber): ModelConstructor<M> | null {
+    public getModelConstructor<M extends BaseModel>(obj: CollectionType): ModelConstructor<M> | null {
         if (this.isCollectionRegistered(this.getCollection(obj))) {
             return this.collectionMapping[this.getCollection(obj)][0] as ModelConstructor<M>;
         }
@@ -87,7 +88,7 @@ export class CollectionMapperService {
      * @param obj The object to get the view model constructor from.
      * @returns the view model constructor
      */
-    public getViewModelConstructor<M extends BaseViewModel>(obj: TypeNumber): ViewModelConstructor<M> | null {
+    public getViewModelConstructor<M extends BaseViewModel>(obj: CollectionType): ViewModelConstructor<M> | null {
         if (this.isCollectionRegistered(this.getCollection(obj))) {
             return this.collectionMapping[this.getCollection(obj)][1] as ViewModelConstructor<M>;
         }
@@ -97,7 +98,9 @@ export class CollectionMapperService {
      * @param obj The object to get the repository from.
      * @returns the repository
      */
-    public getRepository<V extends BaseViewModel, M extends BaseModel>(obj: TypeNumber): BaseRepository<V, M> | null {
+    public getRepository<V extends BaseViewModel, M extends BaseModel>(
+        obj: CollectionType
+    ): BaseRepository<V, M> | null {
         if (this.isCollectionRegistered(this.getCollection(obj))) {
             return this.collectionMapping[this.getCollection(obj)][2] as BaseRepository<V, M>;
         }
@@ -108,5 +111,13 @@ export class CollectionMapperService {
      */
     public getAllRepositories(): BaseRepository<any, any>[] {
         return Object.values(this.collectionMapping).map((types: CollectionMappedTypes) => types[2]);
+    }
+
+    public isMeetingSpecificCollection(obj: CollectionType): boolean {
+        const repo = this.getRepository(obj);
+        if (!repo) {
+            return false;
+        }
+        return repo instanceof BaseRepositoryWithActiveMeeting;
     }
 }

--- a/client/src/app/core/core-services/communication-manager.service.ts
+++ b/client/src/app/core/core-services/communication-manager.service.ts
@@ -15,6 +15,8 @@ class StreamContainerWithCloseFn extends StreamContainer {
     public closeFn: () => void;
 }
 
+const LOG = true;
+
 /**
  * Main class for communication in streams with the server. You have to register an
  * endpoint to communicate with `registerEndpoint` and connect to it with `connect`.
@@ -73,8 +75,10 @@ export class CommunicationManagerService {
             await this._connect(container);
         }
 
-        console.log('Opened', container.description, container.id, container);
-        this.printActiveStreams();
+        if (LOG) {
+            console.log('Opened', container.description, container.id, container);
+            this.printActiveStreams();
+        }
 
         return () => this.close(container);
     }
@@ -128,8 +132,10 @@ export class CommunicationManagerService {
         }
         delete this.requestedStreams[container.id];
 
-        console.log('Closed', container.description, container.id, container);
-        this.printActiveStreams();
+        if (LOG) {
+            console.log('Closed', container.description, container.id, container);
+            this.printActiveStreams();
+        }
     }
 
     private printActiveStreams(): void {

--- a/client/src/app/core/core-services/openslides.service.ts
+++ b/client/src/app/core/core-services/openslides.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 
 import { AuthService } from './auth.service';
-import { DataStoreService } from './data-store.service';
 import { LifecycleService } from './lifecycle.service';
 import { OfflineBroadcastService, OfflineReasonValue } from './offline-broadcast.service';
 
@@ -13,7 +12,6 @@ import { OfflineBroadcastService, OfflineReasonValue } from './offline-broadcast
 })
 export class OpenSlidesService {
     public constructor(
-        private DS: DataStoreService,
         private offlineBroadcastService: OfflineBroadcastService,
         private lifecycleService: LifecycleService,
         private authService: AuthService
@@ -34,6 +32,7 @@ export class OpenSlidesService {
             return;
         }
 
+        // TODO
         /*if (!this.operator.isAuthenticated) {
             if (!location.pathname.includes('error')) {
                 this.authService.redirectUrl = location.pathname;
@@ -43,7 +42,6 @@ export class OpenSlidesService {
             this.afterAuthenticatedBootup();
         }*/
 
-        this.DS.clear();
         this.lifecycleService.bootup();
     }
 }

--- a/client/src/app/core/repositories/base-repository-with-active-meeting.ts
+++ b/client/src/app/core/repositories/base-repository-with-active-meeting.ts
@@ -26,7 +26,6 @@ export abstract class BaseRepositoryWithActiveMeeting<
         protected baseModelCtor: ModelConstructor<M>
     ) {
         super(fullRepositoryServiceCollector, baseModelCtor);
-        this.activeMeetingIdService.meetingHasChangedObservable.subscribe(() => this.clear());
     }
 
     protected createViewModel(model: M): V {

--- a/client/src/app/core/repositories/base-repository.ts
+++ b/client/src/app/core/repositories/base-repository.ts
@@ -119,10 +119,6 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         return this.repositoryServiceCollector.relationManager;
     }
 
-    protected get authService(): AuthService {
-        return this.repositoryServiceCollector.authService;
-    }
-
     public constructor(
         private repositoryServiceCollector: RepositoryServiceCollectorWithoutActiveMeetingService,
         protected baseModelCtor: ModelConstructor<M>
@@ -132,8 +128,6 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         this.relationManager.getRelationsForCollection(this.collection).forEach(relation => {
             this.relationsByKey[relation.ownField] = relation;
         });
-
-        this.authService.onLogout.subscribe(() => this.DS.clear());
 
         // All data is piped through an auditTime of 1ms. This is to prevent massive
         // updates, if e.g. an autoupdate with a lot motions come in. The result is just one
@@ -291,7 +285,7 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         if (!this.viewModelSubjects[id]) {
             this.viewModelSubjects[id] = new BehaviorSubject<V>(this.viewModelStore[id]);
         }
-        return this.viewModelSubjects[id].pipe(filter(value => !!value));
+        return this.viewModelSubjects[id].asObservable();
     }
 
     /**

--- a/client/src/app/core/repositories/repository-service-collector-without-active-meeting-service.ts
+++ b/client/src/app/core/repositories/repository-service-collector-without-active-meeting-service.ts
@@ -21,7 +21,6 @@ export class RepositoryServiceCollectorWithoutActiveMeetingService {
         public viewModelStoreService: ViewModelStoreService,
         public translate: TranslateService,
         public relationManager: RelationManagerService,
-        public errorService: ErrorService,
-        public authService: AuthService
+        public errorService: ErrorService
     ) {}
 }

--- a/client/src/app/core/repositories/repository-service-collector.ts
+++ b/client/src/app/core/repositories/repository-service-collector.ts
@@ -24,7 +24,6 @@ export class RepositoryServiceCollector extends RepositoryServiceCollectorWithou
         translate: TranslateService,
         relationManager: RelationManagerService,
         errorService: ErrorService,
-        authService: AuthService,
         public activeMeetingIdService: ActiveMeetingIdService
     ) {
         super(
@@ -34,8 +33,7 @@ export class RepositoryServiceCollector extends RepositoryServiceCollectorWithou
             viewModelStoreService,
             translate,
             relationManager,
-            errorService,
-            authService
+            errorService
         );
     }
 }

--- a/client/src/app/fullscreen/download/modules/download/download.component.ts
+++ b/client/src/app/fullscreen/download/modules/download/download.component.ts
@@ -19,7 +19,7 @@ export class DownloadComponent implements OnInit {
     ) {}
 
     public async ngOnInit(): Promise<void> {
-        await this.operator.loaded;
+        await this.operator.ready;
         this.loadResourceById();
     }
 

--- a/client/src/app/management/components/dashboard/dashboard.component.ts
+++ b/client/src/app/management/components/dashboard/dashboard.component.ts
@@ -49,7 +49,7 @@ export class DashboardComponent extends BaseModelContextComponent implements OnI
     public ngOnInit(): void {
         this.subscriptions.push(
             this.organizationRepo.getViewModelObservable(1).subscribe(organization => {
-                this._orgaName = organization.name;
+                this._orgaName = organization?.name;
             })
         );
     }

--- a/client/src/app/management/components/meeting-list/meeting-list.component.ts
+++ b/client/src/app/management/components/meeting-list/meeting-list.component.ts
@@ -101,7 +101,7 @@ export class MeetingListComponent extends BaseListViewComponent<ViewOrganisation
         this.subscriptions.push(
             this.currentCommitteeObservable.subscribe(committee => {
                 this.currentCommittee = committee;
-                this.meetingsSubject.next(committee.meetings || []);
+                this.meetingsSubject.next(committee?.meetings || []);
             })
         );
     }

--- a/client/src/app/shared/components/list-view-table/list-view-table.component.ts
+++ b/client/src/app/shared/components/list-view-table/list-view-table.component.ts
@@ -352,7 +352,7 @@ export class ListViewTableComponent<V extends BaseViewModel | BaseProjectableVie
         }
 
         // hide the speakers in mobile
-        if (this.isMobile || !this.operator.hasPerms(Permission.listOfSpeakersCanSee) || !this.showListOfSpeakers) {
+        if (this.isMobile || !this.showListOfSpeakers || !this.operator.hasPerms(Permission.listOfSpeakersCanSee)) {
             hidden.push('speaker');
         }
 


### PR DESCRIPTION
- DS was cleared too late
- setting the meeting id was too late
- operator can now be "not ready". Used when changing meetings etc.
- active meeting service did not clean up subscriptions when leaving
meeting
- call to has perms in meeting list
- correctly use undefined instead of null to indicate uninitialized
state and prevent multiple updates
- many more...