### PR TITLE
Add motion submitters in the agenda subtitles. Fixes #206

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -38,6 +38,16 @@ export const GET_POSSIBLE_RECOMMENDATIONS: Follow = {
     ]
 };
 
+export const SUBMITTER_FOLLOW: Follow = {
+    idField: 'submitter_ids',
+    follow: [
+        {
+            idField: 'user_id',
+            fieldset: 'shortName'
+        }
+    ]
+};
+
 /**
  * Repository Services for motions (and potentially categories)
  *

--- a/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.html
+++ b/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.html
@@ -49,7 +49,7 @@
             </div>
 
             <!-- Subtitle line -->
-            <div class="subtitle ellipsis-overflow" *ngIf="showSubtitle">
+            <div class="subtitle ellipsis-overflow" *ngIf="showSubtitles | async">
                 {{ item.getSubtitle() }}
             </div>
 

--- a/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.ts
+++ b/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { PblColumnDefinition } from '@pebula/ngrid';
+import { Observable } from 'rxjs';
 
 import { AgendaCsvExportService } from '../../services/agenda-csv-export.service';
 import { AgendaFilterListService } from '../../services/agenda-filter-list.service';
@@ -19,6 +20,7 @@ import {
     MeetingProjectionType,
     MeetingRepositoryService
 } from 'app/core/repositories/management/meeting-repository.service';
+import { SUBMITTER_FOLLOW } from 'app/core/repositories/motions/motion-repository.service';
 import { TopicRepositoryService } from 'app/core/repositories/topics/topic-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { DurationService } from 'app/core/ui-services/duration.service';
@@ -57,7 +59,7 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
      */
     public isNumberingAllowed: boolean;
 
-    public showSubtitle: boolean;
+    public showSubtitles: Observable<boolean> = this.meetingsSettingsService.get('agenda_show_subtitles');
 
     /**
      * Helper to check main button permissions
@@ -149,9 +151,6 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
             this.meetingsSettingsService
                 .get('agenda_enable_numbering')
                 .subscribe(autoNumbering => (this.isNumberingAllowed = autoNumbering)),
-            this.meetingsSettingsService
-                .get('agenda_show_subtitles')
-                .subscribe(showSubtitle => (this.showSubtitle = showSubtitle)),
             this.activeMeetingIdService.meetingIdObservable.subscribe(id => {
                 if (id) {
                     this.itemListSlide = {
@@ -184,7 +183,7 @@ export class AgendaItemListComponent extends BaseListViewComponent<ViewAgendaIte
                     follow: [
                         {
                             idField: 'content_object_id',
-                            follow: [SPEAKER_BUTTON_FOLLOW],
+                            follow: [SPEAKER_BUTTON_FOLLOW, SUBMITTER_FOLLOW],
                             fieldset: 'title',
 
                             // To enable the reverse relation from content_object->agenda_item.

--- a/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
+++ b/client/src/app/site/motions/modules/amendment-list/amendment-list.component.ts
@@ -12,7 +12,8 @@ import { ActiveMeetingIdService } from 'app/core/core-services/active-meeting-id
 import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
 import {
     GET_POSSIBLE_RECOMMENDATIONS,
-    MotionRepositoryService
+    MotionRepositoryService,
+    SUBMITTER_FOLLOW
 } from 'app/core/repositories/motions/motion-repository.service';
 import { MotionService } from 'app/core/repositories/motions/motion.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
@@ -145,16 +146,8 @@ export class AmendmentListComponent extends BaseListViewComponent<ViewMotion> im
                             idField: 'recommendation_id',
                             fieldset: 'list'
                         },
-                        {
-                            idField: 'submitter_ids',
-                            follow: [
-                                {
-                                    idField: 'user_id',
-                                    fieldset: 'shortName'
-                                }
-                            ]
-                        },
-                        SPEAKER_BUTTON_FOLLOW
+                        SPEAKER_BUTTON_FOLLOW,
+                        SUBMITTER_FOLLOW
                     ],
                     fieldset: 'amendment'
                 }

--- a/client/src/app/site/motions/modules/motion-block/components/motion-block-detail/motion-block-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-block/components/motion-block-detail/motion-block-detail.component.ts
@@ -9,7 +9,7 @@ import { SimplifiedModelRequest } from 'app/core/core-services/model-request-bui
 import { Permission } from 'app/core/core-services/permission';
 import { AgendaItemRepositoryService } from 'app/core/repositories/agenda/agenda-item-repository.service';
 import { MotionBlockRepositoryService } from 'app/core/repositories/motions/motion-block-repository.service';
-import { MotionRepositoryService } from 'app/core/repositories/motions/motion-repository.service';
+import { MotionRepositoryService, SUBMITTER_FOLLOW } from 'app/core/repositories/motions/motion-repository.service';
 import { MotionService } from 'app/core/repositories/motions/motion.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { MeetingSettingsService } from 'app/core/ui-services/meeting-settings.service';
@@ -175,15 +175,7 @@ export class MotionBlockDetailComponent extends BaseListViewComponent<ViewMotion
                             idField: 'recommendation_id',
                             fieldset: 'list'
                         },
-                        {
-                            idField: 'submitter_ids',
-                            follow: [
-                                {
-                                    idField: 'user_id',
-                                    fieldset: 'shortName'
-                                }
-                            ]
-                        },
+                        SUBMITTER_FOLLOW,
                         SPEAKER_BUTTON_FOLLOW
                     ]
                 },

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -20,7 +20,8 @@ import { Deferred } from 'app/core/promises/deferred';
 import { AgendaItemRepositoryService } from 'app/core/repositories/agenda/agenda-item-repository.service';
 import {
     GET_POSSIBLE_RECOMMENDATIONS,
-    MotionRepositoryService
+    MotionRepositoryService,
+    SUBMITTER_FOLLOW
 } from 'app/core/repositories/motions/motion-repository.service';
 import { MotionService } from 'app/core/repositories/motions/motion.service';
 import { AmendmentService } from 'app/core/ui-services/amendment.service';
@@ -416,15 +417,7 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
                             }
                         ]
                     },
-                    {
-                        idField: 'submitter_ids',
-                        follow: [
-                            {
-                                idField: 'user_id',
-                                fieldset: 'shortName'
-                            }
-                        ]
-                    },
+                    SUBMITTER_FOLLOW,
                     {
                         idField: 'supporter_ids',
                         fieldset: 'shortName'

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -11,7 +11,8 @@ import { MotionBlockRepositoryService } from 'app/core/repositories/motions/moti
 import { MotionCategoryRepositoryService } from 'app/core/repositories/motions/motion-category-repository.service';
 import {
     GET_POSSIBLE_RECOMMENDATIONS,
-    MotionRepositoryService
+    MotionRepositoryService,
+    SUBMITTER_FOLLOW
 } from 'app/core/repositories/motions/motion-repository.service';
 import { MotionWorkflowRepositoryService } from 'app/core/repositories/motions/motion-workflow-repository.service';
 import { MotionService } from 'app/core/repositories/motions/motion.service';
@@ -319,15 +320,7 @@ export class MotionListComponent extends BaseListViewComponent<ViewMotion> imple
                             idField: 'recommendation_id',
                             fieldset: 'list'
                         },
-                        {
-                            idField: 'submitter_ids',
-                            follow: [
-                                {
-                                    idField: 'user_id',
-                                    fieldset: 'shortName'
-                                }
-                            ]
-                        },
+                        SUBMITTER_FOLLOW,
                         SPEAKER_BUTTON_FOLLOW
                     ],
                     fieldset: 'list',


### PR DESCRIPTION
Follow item->motion->submitter->user in the agenda. Adjusted the
modelbuilder to not warn for invali relations and explicitly skip them.
This allows for following some relations for only a subset of models in
a genereic scenario.