### PR TITLE
Adds cml- and oml-permissions with directives

### DIFF
--- a/client/src/app/core/actions/committee-action.ts
+++ b/client/src/app/core/actions/committee-action.ts
@@ -8,14 +8,14 @@ export namespace CommitteeAction {
 
     interface PartialPayload {
         description?: UnsafeHtml;
-        // For UPDATE: Required permission: OML.can_manage_organisation
+        // For UPDATE: Required permission: OML.can_manage_organization
         user_ids?: Id[];
-        // For UPDATE: Required permission: CML.can_manage || OML.can_manage_organisation
-        organisation_tag_ids?: Id[];
+        // For UPDATE: Required permission: CML.can_manage || OML.can_manage_organization
+        organization_tag_ids?: Id[];
     }
 
     /**
-     * Required permission: `OML.can_manage_organisation`
+     * Required permission: `OML.can_manage_organization`
      */
     export interface CreatePayload extends PartialPayload {
         name: string;
@@ -23,7 +23,7 @@ export namespace CommitteeAction {
     }
 
     /**
-     * Required permission: `CML.can_manage` || `OML.can_manage_organisation`
+     * Required permission: `CML.can_manage` || `OML.can_manage_organization`
      */
     export interface UpdatePayload extends Identifiable, PartialPayload {
         // Optional
@@ -31,7 +31,7 @@ export namespace CommitteeAction {
         name?: string;
         template_meeting_id?: Id;
         default_meeting_id?: Id;
-        // Required permission: OML.can_manage_organisation
+        // Required permission: OML.can_manage_organization
         forward_to_committee_ids?: Id[];
         receive_forwardings_from_committee_ids?: Id[];
     }

--- a/client/src/app/core/actions/committee-action.ts
+++ b/client/src/app/core/actions/committee-action.ts
@@ -8,20 +8,32 @@ export namespace CommitteeAction {
 
     interface PartialPayload {
         description?: UnsafeHtml;
-        member_ids?: Id[];
-        manager_ids?: Id[];
+        // For UPDATE: Required permission: OML.can_manage_organisation
+        user_ids?: Id[];
+        // For UPDATE: Required permission: CML.can_manage || OML.can_manage_organisation
+        organisation_tag_ids?: Id[];
     }
 
+    /**
+     * Required permission: `OML.can_manage_organisation`
+     */
     export interface CreatePayload extends PartialPayload {
         name: string;
         organization_id: Id;
     }
+
+    /**
+     * Required permission: `CML.can_manage` || `OML.can_manage_organisation`
+     */
     export interface UpdatePayload extends Identifiable, PartialPayload {
         // Optional
+        // Required permission: CML.can_manage
         name?: string;
         template_meeting_id?: Id;
         default_meeting_id?: Id;
+        // Required permission: OML.can_manage_organisation
         forward_to_committee_ids?: Id[];
+        receive_forwardings_from_committee_ids?: Id[];
     }
 
     export interface DeletePayload extends Identifiable {}

--- a/client/src/app/core/core-services/operator.service.ts
+++ b/client/src/app/core/core-services/operator.service.ts
@@ -6,6 +6,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { NoActiveMeeting } from './active-meeting-id.service';
 import { ActiveMeetingService } from './active-meeting.service';
 import { ViewMeeting } from 'app/management/models/view-meeting';
+import { Committee } from 'app/shared/models/event-management/committee';
 import { Group } from 'app/shared/models/users/group';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { AuthService } from './auth.service';
@@ -16,22 +17,22 @@ import { GroupRepositoryService } from '../repositories/users/group-repository.s
 import { Id } from '../definitions/key-types';
 import { LifecycleService } from './lifecycle.service';
 import { SimplifiedModelRequest, SpecificStructuredField } from './model-request-builder.service';
+import { CML, cmlNameMapping, OML, omlNameMapping } from './organization-permission';
 import { Permission } from './permission';
 import { UserRepositoryService } from '../repositories/users/user-repository.service';
 
 const UNKOWN_USER_ID = -1; // this is an invalid id **and** not equal to 0, null, undefined.
 
 function getUserCML(user: ViewUser): { [id: number]: string } | null {
-    if (!(user as any).committee_$_management_level) {
+    if (!user.committee_$_management_level) {
         return null;
     }
 
-    const CML = {};
-    const templateField = (user as any).committee_$_management_level;
-    for (const replacement of templateField) {
-        CML[+replacement] = (user as any)[`committee_$${replacement}_management_level`];
+    const committeeManagementLevel = {};
+    for (const replacement of user.committee_$_management_level) {
+        committeeManagementLevel[+replacement] = user.committee_management_level(replacement);
     }
-    return CML;
+    return committeeManagementLevel;
 }
 
 /**
@@ -129,6 +130,10 @@ export class OperatorService {
     private get adminGroupId(): number | null {
         const activeMeeting = this.activeMeetingService.meeting;
         return activeMeeting ? activeMeeting.admin_group_id : null;
+    }
+
+    private get currentCommitteeIds(): Id[] {
+        return this.userSubject?.value?.committee_ids || [];
     }
 
     private _hasOperatorDataSubscriptionInitiated = false;
@@ -376,7 +381,7 @@ export class OperatorService {
             return false;
         }
 
-        let result;
+        let result: boolean;
         if (!this.groupIds) {
             result = false;
         } else if (this.isAuthenticated && this.groupIds.includes(this.adminGroupId)) {
@@ -390,6 +395,53 @@ export class OperatorService {
             console.log('has perms', checkPerms, result, this.groupIds, this.isAuthenticated, this.permissions);
         }
         return result;
+    }
+
+    /**
+     * Checks, if the own OML is equals or higher than at least one of the given permissions.
+     *
+     * @param permissionsToCheck The required permissions to check.
+     *
+     * @returns A boolean whether an operator's OML is high enough.
+     */
+    public hasOrganizationPermissions(...permissionsToCheck: OML[]): boolean {
+        return permissionsToCheck.some(permission => (omlNameMapping[this.OML] || 0) >= omlNameMapping[permission]);
+    }
+
+    /**
+     * Checks, if the own CML is equals or higher than at least one of the given permissions.
+     * If an operator has the permission `OML.can_manage_organisation` or higher, then it will always return `true`.
+     *
+     * @param committeeId The committee's id to know for which committee the CML is checked.
+     * @param permissionsToCheck The required permissions to check.
+     *
+     * @returns A boolean whether an operator's CML is high enough.
+     */
+    public hasCommitteePermissions(committeeId: Id | undefined, ...permissionsToCheck: CML[]): boolean {
+        // If a user can manage an entire organisation, they can also manage every committee.
+        if (!this.CML || !committeeId) {
+            return false;
+        }
+        if (this.hasOrganizationPermissions(OML.superadmin, OML.can_manage_organisation)) {
+            return true;
+        }
+        // A user can have a CML for any committee but they could be not present in some of them.
+        if (!this.currentCommitteeIds.includes(committeeId)) {
+            return false;
+        }
+        const currentCommitteePermission = cmlNameMapping[this.CML[committeeId]] || 0;
+        return permissionsToCheck.some(permission => currentCommitteePermission >= cmlNameMapping[permission]);
+    }
+
+    /**
+     * Determines whether the current operator is included in at least one of the committees, which are passed.
+     *
+     * @param committees Several committees to check if the current operator is included in them.
+     *
+     * @returns `true`, if the current operator is included in at least one of the given committees.
+     */
+    public isInCommittees(...committees: Committee[]): boolean {
+        return committees.some(committee => this.currentCommitteeIds.includes(committee.id));
     }
 
     /**
@@ -447,7 +499,7 @@ export class OperatorService {
                 ids: [this.operatorId],
                 viewModelCtor: ViewUser,
                 fieldset: 'shortName',
-                additionalFields: ['organization_management_level', 'committee_$_management_level'],
+                additionalFields: ['organisation_management_level', 'committee_$_management_level', 'committee_ids'],
                 follow: [
                     {
                         idField: SpecificStructuredField('group_$_ids', this.activeMeetingId),
@@ -487,7 +539,7 @@ export class OperatorService {
                 ids: [this.operatorId],
                 viewModelCtor: ViewUser,
                 fieldset: 'shortName',
-                additionalFields: ['organization_management_level', 'committee_$_management_level']
+                additionalFields: ['organisation_management_level', 'committee_$_management_level', 'committee_ids']
             };
         } else {
             // not logged in and no anonymous. We are done with loading, so we have

--- a/client/src/app/core/core-services/operator.service.ts
+++ b/client/src/app/core/core-services/operator.service.ts
@@ -410,7 +410,7 @@ export class OperatorService {
 
     /**
      * Checks, if the own CML is equals or higher than at least one of the given permissions.
-     * If an operator has the permission `OML.can_manage_organisation` or higher, then it will always return `true`.
+     * If an operator has the permission `OML.can_manage_organization` or higher, then it will always return `true`.
      *
      * @param committeeId The committee's id to know for which committee the CML is checked.
      * @param permissionsToCheck The required permissions to check.
@@ -418,11 +418,11 @@ export class OperatorService {
      * @returns A boolean whether an operator's CML is high enough.
      */
     public hasCommitteePermissions(committeeId: Id | undefined, ...permissionsToCheck: CML[]): boolean {
-        // If a user can manage an entire organisation, they can also manage every committee.
+        // If a user can manage an entire organization, they can also manage every committee.
         if (!this.CML || !committeeId) {
             return false;
         }
-        if (this.hasOrganizationPermissions(OML.superadmin, OML.can_manage_organisation)) {
+        if (this.hasOrganizationPermissions(OML.superadmin, OML.can_manage_organization)) {
             return true;
         }
         // A user can have a CML for any committee but they could be not present in some of them.
@@ -499,7 +499,7 @@ export class OperatorService {
                 ids: [this.operatorId],
                 viewModelCtor: ViewUser,
                 fieldset: 'shortName',
-                additionalFields: ['organisation_management_level', 'committee_$_management_level', 'committee_ids'],
+                additionalFields: ['organization_management_level', 'committee_$_management_level', 'committee_ids'],
                 follow: [
                     {
                         idField: SpecificStructuredField('group_$_ids', this.activeMeetingId),
@@ -539,7 +539,7 @@ export class OperatorService {
                 ids: [this.operatorId],
                 viewModelCtor: ViewUser,
                 fieldset: 'shortName',
-                additionalFields: ['organisation_management_level', 'committee_$_management_level', 'committee_ids']
+                additionalFields: ['organization_management_level', 'committee_$_management_level', 'committee_ids']
             };
         } else {
             // not logged in and no anonymous. We are done with loading, so we have

--- a/client/src/app/core/core-services/organization-permission.ts
+++ b/client/src/app/core/core-services/organization-permission.ts
@@ -1,0 +1,23 @@
+export enum CML {
+    can_manage = 'can_manage',
+    default = 'default'
+}
+
+export enum OML {
+    superadmin = 'superadmin',
+    can_manage_organisation = 'can_manage_organisation',
+    can_manage_users = 'can_manage_users',
+    default = 'default'
+}
+
+export const omlNameMapping = {
+    superadmin: 3,
+    can_manage_organisation: 2,
+    can_manage_users: 1,
+    default: 0
+};
+
+export const cmlNameMapping = {
+    can_manage: 1,
+    default: 0
+};

--- a/client/src/app/core/core-services/organization-permission.ts
+++ b/client/src/app/core/core-services/organization-permission.ts
@@ -5,14 +5,14 @@ export enum CML {
 
 export enum OML {
     superadmin = 'superadmin',
-    can_manage_organisation = 'can_manage_organisation',
+    can_manage_organization = 'can_manage_organization',
     can_manage_users = 'can_manage_users',
     default = 'default'
 }
 
 export const omlNameMapping = {
     superadmin: 3,
-    can_manage_organisation: 2,
+    can_manage_organization: 2,
     can_manage_users: 1,
     default: 0
 };

--- a/client/src/app/core/core-services/organization.service.ts
+++ b/client/src/app/core/core-services/organization.service.ts
@@ -16,7 +16,7 @@ export const WEB_HEADER_TOKEN = 'web_header';
 /**
  * The organization_id is always the 1.
  */
-export const ORGANISATION_ID = 1;
+export const ORGANIZATION_ID = 1;
 
 @Injectable({
     providedIn: 'root'
@@ -56,14 +56,14 @@ export class OrganizationService {
             'OrganizationService'
         );
         this.repo
-            .getViewModelObservable(ORGANISATION_ID)
+            .getViewModelObservable(ORGANIZATION_ID)
             .subscribe(organization => this.organizationSubject.next(organization));
     }
 
     private getModelRequest(): SimplifiedModelRequest {
         return {
             viewModelCtor: ViewOrganization,
-            ids: [ORGANISATION_ID],
+            ids: [ORGANIZATION_ID],
             follow: [{ idField: 'resource_ids' }],
             fieldset: 'settings'
         };

--- a/client/src/app/core/repositories/management/committee-repository.service.ts
+++ b/client/src/app/core/repositories/management/committee-repository.service.ts
@@ -56,7 +56,7 @@ export class CommitteeRepositoryService
             name: committee.name,
             organization_id: 1,
             description: committee.description,
-            organisation_tag_ids: committee.organization_tag_ids,
+            organization_tag_ids: committee.organization_tag_ids,
             user_ids: committee.user_ids
         };
         return this.sendActionToBackend(CommitteeAction.CREATE, payload);

--- a/client/src/app/core/repositories/management/organization-tag-repository.service.ts
+++ b/client/src/app/core/repositories/management/organization-tag-repository.service.ts
@@ -6,7 +6,7 @@ import {
     Fieldsets,
     SimplifiedModelRequest
 } from 'app/core/core-services/model-request-builder.service';
-import { ORGANISATION_ID } from 'app/core/core-services/organization.service';
+import { ORGANIZATION_ID } from 'app/core/core-services/organization.service';
 import { ViewOrganization } from 'app/management/models/view-organization';
 import { ViewOrganizationTag } from 'app/management/models/view-organization-tag';
 import { Identifiable } from 'app/shared/models/base/identifiable';
@@ -42,7 +42,7 @@ export class OrganizationTagRepositoryService
         const payload: OrganizationTagAction.CreatePayload = {
             name: tag.name,
             color: tag.color,
-            organization_id: ORGANISATION_ID
+            organization_id: ORGANIZATION_ID
         };
         return this.sendActionToBackend(OrganizationTagAction.CREATE, payload);
     }

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -237,16 +237,9 @@ export const RELATIONS: Relation[] = [
     ...makeM2M({
         AViewModel: ViewCommittee,
         BViewModel: ViewUser,
-        AField: 'members',
-        BField: 'committees_as_member',
-        BIdField: 'committee_as_member_ids'
-    }),
-    ...makeM2M({
-        AViewModel: ViewCommittee,
-        BViewModel: ViewUser,
-        AField: 'managers',
-        BField: 'committees_as_manager',
-        BIdField: 'committee_as_manager_ids'
+        AField: 'users',
+        BField: 'committees',
+        BIdField: 'committee_ids'
     }),
     ...makeM2M({
         AViewModel: ViewCommittee,

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -116,7 +116,7 @@ export class UserRepositoryService
             { templateField: 'vote_weight_$' }
         ]);
         const detailFields = listFields.concat(['username', 'about_me', 'comment', 'default_password']);
-        const orgaListFields = listFields.concat(['committee_as_manager_ids', 'committee_as_member_ids']);
+        const orgaListFields = listFields.concat(['committee_ids']);
         const orgaEditFields = orgaListFields.concat(['default_password']);
 
         return {
@@ -462,12 +462,10 @@ export class UserRepositoryService
 
     public bulkAssignUsersToCommitteesAsMembers(users: ViewUser[], committeeIds: Id[]): Promise<void> {
         const patchFn = (user: ViewUser) => {
-            committeeIds = committeeIds.concat(user.committee_as_member_ids || []);
+            committeeIds = committeeIds.concat(user.committee_ids || []);
             return {
                 id: user.id,
-                committee_as_member_ids: committeeIds.filter(
-                    (committeeId, index, self) => self.indexOf(committeeId) === index
-                )
+                committee_ids: committeeIds.filter((committeeId, index, self) => self.indexOf(committeeId) === index)
             };
         };
         return this.bulkUpdate(patchFn, users);
@@ -476,9 +474,7 @@ export class UserRepositoryService
     public bulkUnassignUsersFromCommitteesAsMembers(users: ViewUser[], committeeIds: Id[]): Promise<void> {
         const patchFn = (user: ViewUser) => ({
             id: user.id,
-            committee_as_member_ids: (user.committee_as_member_ids || []).filter(
-                committeeId => !committeeIds.includes(committeeId)
-            )
+            committee_ids: (user.committee_ids || []).filter(committeeId => !committeeIds.includes(committeeId))
         });
         return this.bulkUpdate(patchFn, users);
     }

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -24,7 +24,7 @@
             <input matInput formControlName="name" />
         </mat-form-field>
 
-        <mat-form-field *osOmlPerms="OML.can_manage_organisation">
+        <mat-form-field *osOmlPerms="OML.can_manage_organization">
             <mat-label> {{ 'Committee users' | translate }}</mat-label>
             <os-search-value-selector
                 formControlName="user_ids"

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -24,23 +24,13 @@
             <input matInput formControlName="name" />
         </mat-form-field>
 
-        <mat-form-field>
-            <mat-label> {{ 'Committee manager' | translate }}</mat-label>
+        <mat-form-field *osOmlPerms="OML.can_manage_organisation">
+            <mat-label> {{ 'Committee users' | translate }}</mat-label>
             <os-search-value-selector
-                formControlName="manager_ids"
+                formControlName="user_ids"
                 [multiple]="true"
-                placeholder="{{ 'Committee manager' | translate }}"
-                [inputListValues]="members"
-            ></os-search-value-selector>
-        </mat-form-field>
-
-        <mat-form-field>
-            <mat-label> {{ 'Committee members' | translate }}</mat-label>
-            <os-search-value-selector
-                formControlName="member_ids"
-                [multiple]="true"
-                placeholder="{{ 'Committee members' | translate }}"
-                [inputListValues]="members"
+                placeholder="{{ 'Committee users' | translate }}"
+                [inputListValues]="organizationMembers"
             ></os-search-value-selector>
         </mat-form-field>
 
@@ -81,16 +71,29 @@
                 ></os-search-value-selector>
             </mat-form-field>
 
-            <mat-form-field>
-                <mat-label>{{ 'Can forward motions to committee' | translate }}</mat-label>
-                <os-search-repo-selector
-                    formControlName="forward_to_committee_ids"
-                    [multiple]="true"
-                    [repo]="committeeRepo"
-                    [pipeFn]="getPipeFilterFn()"
-                    [showChips]="false"
-                ></os-search-repo-selector>
-            </mat-form-field>
+            <ng-container *osOmlPerms="OML.can_manage_users">
+                <mat-form-field>
+                    <mat-label>{{ 'Can forward motions to committee' | translate }}</mat-label>
+                    <os-search-repo-selector
+                        formControlName="forward_to_committee_ids"
+                        [multiple]="true"
+                        [repo]="committeeRepo"
+                        [pipeFn]="getPipeFilterFn()"
+                        [showChips]="false"
+                    ></os-search-repo-selector>
+                </mat-form-field>
+
+                <mat-form-field>
+                    <mat-label>{{ 'Can receive forwarding from committees' | translate }}</mat-label>
+                    <os-search-repo-selector
+                        formControlName="receive_from_committee_ids"
+                        [multiple]="true"
+                        [repo]="committeeRepo"
+                        [pipeFn]="getPipeFilterFn()"
+                        [showChips]="false"
+                    ></os-search-repo-selector>
+                </mat-form-field>
+            </ng-container>
         </ng-container>
     </form>
 </mat-card>

--- a/client/src/app/management/components/committee-edit/committee-edit.component.ts
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.ts
@@ -8,6 +8,7 @@ import { Observable, OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { MemberService } from 'app/core/core-services/member.service';
+import { OML } from 'app/core/core-services/organization-permission';
 import { Id } from 'app/core/definitions/key-types';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { MeetingRepositoryService } from 'app/core/repositories/management/meeting-repository.service';
@@ -32,12 +33,14 @@ const EditCommitteeLabel = _('Edit committee');
     styleUrls: ['./committee-edit.component.scss']
 })
 export class CommitteeEditComponent extends BaseModelContextComponent implements OnInit {
+    public readonly OML = OML;
+
     public addCommitteeLabel = AddCommitteeLabel;
     public editCommitteeLabel = EditCommitteeLabel;
 
     public isCreateView: boolean;
     public committeeForm: FormGroup;
-    public members: Observable<ViewUser[]>;
+    public organizationMembers: Observable<ViewUser[]>;
     public meetingsObservable: Observable<ViewMeeting[]>;
 
     private editCommittee: ViewCommittee;
@@ -64,7 +67,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
         } else {
             super.setTitle(EditCommitteeLabel);
         }
-        this.members = this.memberService.getMemberListObservable();
+        this.organizationMembers = this.memberService.getMemberListObservable();
         this.meetingsObservable = this.meetingRepo.getViewModelListObservable();
     }
 
@@ -150,16 +153,16 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
         let partialForm: any = {
             name: ['', Validators.required],
             description: [''],
-            manager_ids: [[]],
-            member_ids: [[]],
-            organization_tag_ids: [[]]
+            organization_tag_ids: [[]],
+            user_ids: [[]]
         };
         if (!this.isCreateView) {
             partialForm = {
                 ...partialForm,
                 // template_meeting_id: [null], // TODO: Not yet
                 default_meeting_id: [null],
-                forward_to_committee_ids: [[]]
+                forward_to_committee_ids: [[]],
+                receive_from_committee_ids: [[]]
             };
         }
         this.committeeForm = this.formBuilder.group(partialForm);

--- a/client/src/app/management/components/committee-list/committee-list.component.html
+++ b/client/src/app/management/components/committee-list/committee-list.component.html
@@ -1,6 +1,6 @@
 <os-head-bar
     [customMenu]="true"
-    [hasMainButton]="true"
+    [hasMainButton]="operator.hasOrganizationPermissions(OML.can_manage_organisation)"
     [multiSelectMode]="isMultiSelect"
     (mainEvent)="createNewCommittee()"
 >
@@ -39,7 +39,7 @@
     [filterProps]="['name']"
 >
     <div *pblNgridCellDef="'name'; value as name; row as committee" class="cell-slot fill">
-        <a class="detail-link" [routerLink]="committee.id" *ngIf="!isMultiSelect"></a>
+        <a class="detail-link" [routerLink]="committee.id" *ngIf="!isMultiSelect && committee.canAccess()"></a>
         <div>
             {{ name }}
             <div class="subtitle" *ngIf="committee.description?.trim()">
@@ -103,6 +103,7 @@
 
     <div *pblNgridCellDef="'menu'; row as committee" class="cell-slot fill">
         <button
+            *osCmlPerms="CML.can_manage; committeeId: committee.id"
             mat-icon-button
             [disabled]="isMultiSelect"
             [matMenuTriggerFor]="singleCommitteeMenu"
@@ -149,20 +150,22 @@
             <span>{{ 'Deselect all' | translate }}</span>
         </button>
 
-        <mat-divider></mat-divider>
-        <button mat-menu-item (click)="forwardToCommittees()">
-            <mat-icon>swap_horiz</mat-icon>
-            <span>{{ 'Unforward/forward to committees' | translate }}</span>
-        </button>
-        <button mat-menu-item [disabled]="true">
-            <mat-icon>local_offer</mat-icon>
-            <span>{{ 'Tags' | translate }}</span>
-        </button>
-        <mat-divider></mat-divider>
+        <ng-container *osOmlPerms="OML.can_manage_organisation">
+            <mat-divider></mat-divider>
+            <button mat-menu-item (click)="forwardToCommittees()">
+                <mat-icon>swap_horiz</mat-icon>
+                <span>{{ 'Unforward/forward to committees' | translate }}</span>
+            </button>
+            <button mat-menu-item [disabled]="true">
+                <mat-icon>local_offer</mat-icon>
+                <span>{{ 'Tags' | translate }}</span>
+            </button>
+            <mat-divider></mat-divider>
 
-        <button mat-menu-item [disabled]="true" class="red-warning-text" (click)="deleteMultiple()">
-            <mat-icon>delete</mat-icon>
-            <span>{{ 'Delete' | translate }}</span>
-        </button>
+            <button mat-menu-item [disabled]="true" class="red-warning-text" (click)="deleteMultiple()">
+                <mat-icon>delete</mat-icon>
+                <span>{{ 'Delete' | translate }}</span>
+            </button>
+        </ng-container>
     </div>
 </mat-menu>

--- a/client/src/app/management/components/committee-list/committee-list.component.html
+++ b/client/src/app/management/components/committee-list/committee-list.component.html
@@ -1,6 +1,6 @@
 <os-head-bar
     [customMenu]="true"
-    [hasMainButton]="operator.hasOrganizationPermissions(OML.can_manage_organisation)"
+    [hasMainButton]="operator.hasOrganizationPermissions(OML.can_manage_organization)"
     [multiSelectMode]="isMultiSelect"
     (mainEvent)="createNewCommittee()"
 >
@@ -150,7 +150,7 @@
             <span>{{ 'Deselect all' | translate }}</span>
         </button>
 
-        <ng-container *osOmlPerms="OML.can_manage_organisation">
+        <ng-container *osOmlPerms="OML.can_manage_organization">
             <mat-divider></mat-divider>
             <button mat-menu-item (click)="forwardToCommittees()">
                 <mat-icon>swap_horiz</mat-icon>

--- a/client/src/app/management/components/committee-list/committee-list.component.ts
+++ b/client/src/app/management/components/committee-list/committee-list.component.ts
@@ -3,8 +3,12 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { PblColumnDefinition } from '@pebula/ngrid';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
+import { OperatorService } from 'app/core/core-services/operator.service';
+import { CML, OML } from 'app/core/core-services/organization-permission';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
@@ -19,7 +23,10 @@ import { BaseListViewComponent } from 'app/site/base/components/base-list-view.c
     styleUrls: ['./committee-list.component.scss']
 })
 export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee> implements OnInit {
-    public tableColumnDefinition: PblColumnDefinition[] = [
+    public readonly CML = CML;
+    public readonly OML = OML;
+
+    public readonly tableColumnDefinition: PblColumnDefinition[] = [
         {
             prop: 'name',
             width: 'auto'
@@ -49,6 +56,7 @@ export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee>
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
         public repo: CommitteeRepositoryService,
+        public operator: OperatorService,
         private router: Router,
         private route: ActivatedRoute,
         private promptService: PromptService,
@@ -115,7 +123,7 @@ export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee>
                     fieldset: 'list',
                     follow: [
                         {
-                            idField: 'manager_ids',
+                            idField: 'user_ids',
                             fieldset: 'shortName'
                         },
                         {

--- a/client/src/app/management/components/management-navigation/management-navigation.component.html
+++ b/client/src/app/management/components/management-navigation/management-navigation.component.html
@@ -1,5 +1,5 @@
 <span *ngFor="let entry of menuEntries">
-    <a *osPerms="entry.permission" mat-menu-item class="management-router-link" [routerLink]="entry.route">
+    <a *osOmlPerms="entry.permission" mat-menu-item class="management-router-link" [routerLink]="entry.route">
         <mat-icon>{{ entry.icon }}</mat-icon>
         <span>{{ entry.displayName | translate }}</span>
     </a>

--- a/client/src/app/management/components/management-navigation/management-navigation.component.ts
+++ b/client/src/app/management/components/management-navigation/management-navigation.component.ts
@@ -3,9 +3,17 @@ import { MatDialog } from '@angular/material/dialog';
 
 import { AccountDialogComponent } from '../account-dialog/account-dialog.component';
 import { AuthService } from 'app/core/core-services/auth.service';
-import { MainMenuEntry } from 'app/core/core-services/main-menu.service';
+import { OML } from 'app/core/core-services/organization-permission';
 import { OverlayService } from 'app/core/ui-services/overlay.service';
 import { largeDialogSettings } from 'app/shared/utils/dialog-settings';
+
+interface OrgaMenuEntry {
+    route: string;
+    displayName: string;
+    icon: string;
+    weight: number;
+    permission?: OML;
+}
 
 @Component({
     selector: 'os-management-navigation',
@@ -13,40 +21,35 @@ import { largeDialogSettings } from 'app/shared/utils/dialog-settings';
     styleUrls: ['./management-navigation.component.scss']
 })
 export class ManagementNavigationComponent {
-    public menuEntries: MainMenuEntry[] = [
+    public menuEntries: OrgaMenuEntry[] = [
         {
             route: '/',
             displayName: 'Dashboard',
             icon: 'dashboard',
-            // permission: Permission.coreCanSeeFrontpage,
             weight: 100
         },
         {
             route: '/committees',
             displayName: 'Committees',
             icon: 'account_balance',
-            // permission: Permission.coreCanSeeFrontpage,
             weight: 200
         },
         {
             route: '/organization-tags',
             displayName: 'Organization tags',
             icon: 'label',
-            // permission: Permission.coreCanSeeFrontpage,
             weight: 250
         },
         {
             route: '/members',
             displayName: 'Members',
             icon: 'group',
-            // permission: Permission.coreCanSeeFrontpage,
             weight: 300
         },
         {
             route: '/settings',
             displayName: 'Settings',
             icon: 'settings',
-            // permission: Permission.coreCanSeeFrontpage,
             weight: 400
         }
     ];

--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.html
@@ -54,6 +54,21 @@
         </mat-form-field>
 
         <mat-form-field>
+            <mat-label> {{ 'Participants' | translate }}</mat-label>
+            <os-search-value-selector
+                formControlName="userIds"
+                [multiple]="true"
+                placeholder="{{ 'Participants' | translate }}"
+                [inputListValues]="committee?.users"
+            ></os-search-value-selector>
+        </mat-form-field>
+
+        <!-- server bug -->
+        <!-- <mat-checkbox disabled formControlName="set_as_template">Set as template</mat-checkbox> -->
+
+        <!-- Permission: CML.can_manage (implicit or OML.can_manage_organisation or higher) -->
+        <!-- Only check for CML.can_manage -> this includes check for OML.can_manage_organisation or higher -->
+        <mat-form-field *osCmlPerms="CML.can_manage; committeeId: committee?.id">
             <mat-label>{{ 'Organization tags' | translate }}</mat-label>
             <os-search-repo-selector
                 [repo]="orgaTagRepo"
@@ -68,18 +83,24 @@
             </os-search-repo-selector>
         </mat-form-field>
 
-        <mat-form-field>
-            <mat-label> {{ 'Participants' | translate }}</mat-label>
-            <os-search-value-selector
-                formControlName="userIds"
-                [multiple]="true"
-                placeholder="{{ 'Participants' | translate }}"
-                [inputListValues]="committee?.members"
-            ></os-search-value-selector>
-        </mat-form-field>
-
-        <!-- server bug -->
-        <!-- <mat-checkbox disabled formControlName="set_as_template">Set as template</mat-checkbox> -->
+        <!-- Permission: OML.superadmin -->
+        <ng-container *osOmlPerms="OML.superadmin">
+            <!-- Jitsi domain -->
+            <mat-form-field>
+                <mat-label>{{ 'Jitsi domain' | translate }}</mat-label>
+                <input matInput formControlName="jitsi_domain" />
+            </mat-form-field>
+            <!-- Jitsi room-name -->
+            <mat-form-field>
+                <mat-label>{{ 'Jitsi room name' | translate }}</mat-label>
+                <input matInput formControlName="jitsi_room_name" />
+            </mat-form-field>
+            <!-- Jitsi room-password -->
+            <mat-form-field>
+                <mat-label>{{ 'Jitsi room password' | translate }}</mat-label>
+                <input matInput formControlName="jitsi_room_password" />
+            </mat-form-field>
+        </ng-container>
 
         <mat-checkbox formControlName="enable_anonymous">Enable anonymous</mat-checkbox>
     </form>

--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.html
@@ -66,8 +66,8 @@
         <!-- server bug -->
         <!-- <mat-checkbox disabled formControlName="set_as_template">Set as template</mat-checkbox> -->
 
-        <!-- Permission: CML.can_manage (implicit or OML.can_manage_organisation or higher) -->
-        <!-- Only check for CML.can_manage -> this includes check for OML.can_manage_organisation or higher -->
+        <!-- Permission: CML.can_manage (implicit or OML.can_manage_organization or higher) -->
+        <!-- Only check for CML.can_manage -> this includes check for OML.can_manage_organization or higher -->
         <mat-form-field *osCmlPerms="CML.can_manage; committeeId: committee?.id">
             <mat-label>{{ 'Organization tags' | translate }}</mat-label>
             <os-search-repo-selector

--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.ts
@@ -4,12 +4,10 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { MeetingAction } from 'app/core/actions/meeting-action';
-import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
 import { OperatorService } from 'app/core/core-services/operator.service';
+import { CML, OML } from 'app/core/core-services/organization-permission';
 import { Id } from 'app/core/definitions/key-types';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { MeetingRepositoryService } from 'app/core/repositories/management/meeting-repository.service';
@@ -21,7 +19,6 @@ import { ViewCommittee } from 'app/management/models/view-committee';
 import { ViewMeeting } from 'app/management/models/view-meeting';
 import { Identifiable } from 'app/shared/models/base/identifiable';
 import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
-import { ViewUser } from 'app/site/users/models/view-user';
 
 const AddMeetingLabel = _('New meeting');
 const EditMeetingLabel = _('Edit meeting');
@@ -32,6 +29,9 @@ const EditMeetingLabel = _('Edit meeting');
     styleUrls: ['./meeting-edit.component.scss']
 })
 export class MeetingEditComponent extends BaseModelContextComponent implements OnInit {
+    public readonly CML = CML;
+    public readonly OML = OML;
+
     public addMeetingLabel = AddMeetingLabel;
     public editMeetingLabel = EditMeetingLabel;
 
@@ -93,7 +93,7 @@ export class MeetingEditComponent extends BaseModelContextComponent implements O
             // to the committee.
             const addedUsers = userIds.filter(id => !this.editMeeting.user_ids.includes(id));
             const removedUsers = this.editMeeting.user_ids.filter(
-                id => this.committee.member_ids.includes(id) && !userIds.includes(id)
+                id => this.committee.user_ids.includes(id) && !userIds.includes(id)
             );
 
             const payload: MeetingAction.UpdatePayload = this.meetingForm.value;
@@ -168,7 +168,7 @@ export class MeetingEditComponent extends BaseModelContextComponent implements O
             {
                 viewModelCtor: ViewCommittee,
                 ids: [this.committeeId],
-                follow: [{ idField: 'member_ids', fieldset: 'shortName' }],
+                follow: [{ idField: 'user_ids', fieldset: 'shortName' }],
                 fieldset: 'list'
             },
             'committee'
@@ -198,8 +198,10 @@ export class MeetingEditComponent extends BaseModelContextComponent implements O
             end_time: [currentDate],
             enable_anonymous: [false],
             userIds: [[]],
-            guest_ids: [[]],
-            organization_tag_ids: [[]]
+            organization_tag_ids: [[]],
+            jitsi_domain: [''],
+            jitsi_room_name: [''],
+            jitsi_room_password: ['']
         });
     }
 

--- a/client/src/app/management/components/meeting-list/meeting-list.component.html
+++ b/client/src/app/management/components/meeting-list/meeting-list.component.html
@@ -2,7 +2,7 @@
     [customMenu]="true"
     prevUrl="/committees"
     [nav]="false"
-    [hasMainButton]="true"
+    [hasMainButton]="operator.hasCommitteePermissions(currentCommittee?.id, CML.can_manage)"
     (mainEvent)="onCreateMeeting()"
 >
     <!-- Title -->
@@ -16,7 +16,7 @@
     </div>
 
     <!-- Edit button -->
-    <div class="extra-controls-slot">
+    <div class="extra-controls-slot" *osCmlPerms="CML.can_manage; committeeId: currentCommittee?.id">
         <button mat-icon-button (click)="onEditCommittee()">
             <mat-icon>edit</mat-icon>
         </button>
@@ -67,7 +67,6 @@
     </div>
 
     <div *pblNgridCellDef="'users'; row as meeting" class="cell-slot fill">
-        <a class="detail-link" [routerLink]="meeting.getUrl()" *ngIf="!isMultiSelect"></a>
         <div>
             <os-icon-container iconTooltip="{{ 'Participants' | translate }}" icon="group">
                 {{ meeting.userAmount }}
@@ -97,7 +96,13 @@
             </span>
         </button>
 
-        <button mat-menu-item type="button" class="red-warning-text" (click)="deleteSingle(meeting)">
+        <button
+            mat-menu-item
+            type="button"
+            class="red-warning-text"
+            (click)="deleteSingle(meeting)"
+            *osCmlPerms="CML.can_manage"
+        >
             <mat-icon>delete</mat-icon>
             <span>
                 {{ 'Delete' | translate }}

--- a/client/src/app/management/components/meeting-list/meeting-list.component.ts
+++ b/client/src/app/management/components/meeting-list/meeting-list.component.ts
@@ -1,10 +1,12 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { PblColumnDefinition } from '@pebula/ngrid';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
+import { OperatorService } from 'app/core/core-services/operator.service';
+import { CML } from 'app/core/core-services/organization-permission';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { MeetingRepositoryService } from 'app/core/repositories/management/meeting-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
@@ -23,7 +25,7 @@ import { BaseListViewComponent } from 'app/site/base/components/base-list-view.c
     styleUrls: ['./meeting-list.component.scss']
 })
 export class MeetingListComponent extends BaseListViewComponent<ViewOrganization> {
-    private committeeId: number;
+    public readonly CML = CML;
 
     public currentCommittee: ViewCommittee;
 
@@ -46,10 +48,13 @@ export class MeetingListComponent extends BaseListViewComponent<ViewOrganization
         return this.meetingsSubject.asObservable();
     }
 
+    private committeeId: number;
+
     private readonly meetingsSubject = new BehaviorSubject<ViewMeeting[]>([]);
 
     public constructor(
         public meetingRepo: MeetingRepositoryService,
+        public operator: OperatorService,
         private committeeRepo: CommitteeRepositoryService,
         protected componentServiceCollector: ComponentServiceCollector,
         private router: Router,

--- a/client/src/app/management/components/member-edit/member-edit.component.html
+++ b/client/src/app/management/components/member-edit/member-edit.component.html
@@ -135,7 +135,7 @@
             <div>
                 <mat-form-field>
                     <os-search-repo-selector
-                        formControlName="committee_as_member_ids"
+                        formControlName="committee_ids"
                         [multiple]="true"
                         placeholder="{{ 'Member in committees' | translate }}"
                         [repo]="committeeRepo"

--- a/client/src/app/management/components/member-edit/member-edit.component.ts
+++ b/client/src/app/management/components/member-edit/member-edit.component.ts
@@ -188,7 +188,7 @@ export class MemberEditComponent extends BaseModelContextComponent implements On
             last_name: [undefined],
             gender: [undefined],
             email: [undefined, Validators.email],
-            committee_as_member_ids: [[]],
+            committee_ids: [[]],
             last_email_send: [undefined],
             default_password: [undefined],
             default_structure_level: [undefined],

--- a/client/src/app/management/components/member-list/member-list.component.html
+++ b/client/src/app/management/components/member-list/member-list.component.html
@@ -50,9 +50,9 @@
             <os-icon-container
                 icon="account_balance"
                 iconTooltip="{{ 'Committees' | translate }}"
-                [showIcon]="!!user.committee_as_member_ids?.length"
+                [showIcon]="!!user.committee_ids?.length"
             >
-                <span *ngFor="let committee of user.committees_as_member; last as last">
+                <span *ngFor="let committee of user.committees; last as last">
                     {{ committee.name | translate }}<span *ngIf="!last">,&nbsp;</span>
                 </span>
             </os-icon-container>

--- a/client/src/app/management/components/member-list/member-list.component.ts
+++ b/client/src/app/management/components/member-list/member-list.component.ts
@@ -92,11 +92,7 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
                 viewModelCtor: ViewUser,
                 ids: userIds,
                 fieldset: 'orgaList',
-                follow: [
-                    { idField: 'committee_as_manager_ids' },
-                    { idField: 'committee_as_member_ids' },
-                    { idField: 'is_present_in_meeting_ids' }
-                ]
+                follow: [{ idField: 'committee_ids' }, { idField: 'is_present_in_meeting_ids' }]
             };
             this.requestModels(request, 'load_users');
         } catch (e) {

--- a/client/src/app/management/components/orga-settings/orga-settings.component.html
+++ b/client/src/app/management/components/orga-settings/orga-settings.component.html
@@ -47,5 +47,23 @@
 
         <mat-label>{{ 'Privacy Policy' | translate }}</mat-label>
         <editor formControlName="privacy_policy" [init]="tinyMceSettings"></editor>
+
+        <!-- custom translations -->
+        <!-- <os-custom-translation></os-custom-translation> -->
+
+        <ng-container *osOmlPerms="OML.superadmin">
+            <!-- electronic voting -->
+            <section>
+                <mat-checkbox formControlName="enable_electronic_voting">
+                    {{ 'Enable electronic voting' | translate }}
+                </mat-checkbox>
+            </section>
+            <!-- Reset password verbose errors -->
+            <section>
+                <mat-checkbox formControlName="reset_password_verbose_errors">
+                    {{ 'Reset password verbose errors' | translate }}
+                </mat-checkbox>
+            </section>
+        </ng-container>
     </form>
 </mat-card>

--- a/client/src/app/management/components/orga-settings/orga-settings.component.ts
+++ b/client/src/app/management/components/orga-settings/orga-settings.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 
 import { OrganizationAction } from 'app/core/actions/organization-action';
+import { OML } from 'app/core/core-services/organization-permission';
 import { OrganizationRepositoryService } from 'app/core/repositories/management/organization-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { Themes } from 'app/core/ui-services/theme.service';
@@ -16,6 +17,8 @@ import { BaseModelContextComponent } from 'app/site/base/components/base-model-c
     styleUrls: ['./orga-settings.component.scss']
 })
 export class OrgaSettingsComponent extends BaseModelContextComponent implements OnInit {
+    public readonly OML = OML;
+
     public pageTitle = _('Settings');
     private currentOrgaSettings: ViewOrganization;
 
@@ -63,7 +66,10 @@ export class OrgaSettingsComponent extends BaseModelContextComponent implements 
                 legal_notice: [this.currentOrgaSettings.legal_notice],
                 privacy_policy: [this.currentOrgaSettings.privacy_policy],
                 login_text: [this.currentOrgaSettings.login_text],
-                theme: [this.currentOrgaSettings.theme]
+                theme: [this.currentOrgaSettings.theme],
+                custom_translations: [this.currentOrgaSettings.custom_translations],
+                enable_electronic_voting: [this.currentOrgaSettings.enable_electronic_voting],
+                reset_password_verbose_errors: [this.currentOrgaSettings.reset_password_verbose_errors]
             });
         } else {
             console.warn('no Organization loaded');

--- a/client/src/app/management/models/view-committee.ts
+++ b/client/src/app/management/models/view-committee.ts
@@ -18,14 +18,13 @@ export class ViewCommittee extends BaseViewModel<Committee> {
     }
 
     public get memberAmount(): number {
-        return this.member_ids?.length || 0;
+        return this.user_ids?.length || 0;
     }
 }
 interface ICommitteeRelations {
     meetings: ViewMeeting[];
     default_meeting: ViewMeeting;
-    members: ViewUser[];
-    managers: ViewUser[];
+    users: ViewUser[];
     forward_to_committees: ViewCommittee[];
     receive_forwardings_from_committees: ViewCommittee[];
     organization: ViewOrganization;

--- a/client/src/app/shared/directives/base-perms.directive.ts
+++ b/client/src/app/shared/directives/base-perms.directive.ts
@@ -1,0 +1,131 @@
+import { Directive, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+
+import { Subscription } from 'rxjs';
+
+import { OperatorService } from 'app/core/core-services/operator.service';
+
+@Directive()
+export abstract class BasePermsDirective<P> implements OnInit, OnDestroy {
+    /**
+     * Holds required permissions to access a feature
+     */
+    protected permissions: P[] = [];
+
+    /**
+     * Holds the value of the last permission check. Therefore one can check, if the
+     * permission has changes, to save unnecessary view updates, if not.
+     */
+    private lastPermissionCheckResult: boolean | null = null; // take null to also catch a first "false" update
+
+    /**
+     * Alternative to the permissions. Used in special case where a combination
+     * with *ngIf would be required.
+     *
+     * # Example:
+     *
+     * The div will render if the permission `user.can_manage` is set
+     * or if `this.ownPage` is `true`
+     * ```html
+     * <div *osPerms="'users.can_manage';or:ownPage"> something </div>
+     * ```
+     */
+    private alternative: boolean;
+
+    /**
+     * Switch, to invert the result of checkPermission. Usefull for using osPerms as if-else:
+     * For one element you can use `*osPerms="'perm'"` and for the else-element use
+     * `*osPerms="'perm';complement: true"`.
+     */
+    private complement: boolean;
+
+    /**
+     * Add a true-false-condition additional to osPerms
+     * `*osPerms="permission.mediafilesCanManage; and: !isMultiSelect"`
+     */
+    private and = true;
+
+    private operatorSubscription: Subscription | null = null;
+
+    /**
+     * Constructs the directive once. Observes the operator for it's groups so the
+     * directive can perform changes dynamically
+     *
+     * @param template inner part of the HTML container
+     * @param viewContainer outer part of the HTML container (for example a `<div>`)
+     * @param operator OperatorService
+     */
+    public constructor(
+        protected template: TemplateRef<any>,
+        protected viewContainer: ViewContainerRef,
+        protected operator: OperatorService
+    ) {}
+
+    public ngOnInit(): void {
+        // observe groups of operator, so the directive can actively react to changes
+        this.operatorSubscription = this.operator.operatorUpdatedEvent.subscribe(() => {
+            this.updateView();
+        });
+    }
+
+    public ngOnDestroy(): void {
+        if (this.operatorSubscription) {
+            this.operatorSubscription.unsubscribe();
+            this.operatorSubscription = null;
+        }
+    }
+
+    protected setPermissions(value: P | P[]): void {
+        if (!value) {
+            value = [];
+        } else if (!Array.isArray(value)) {
+            value = [value];
+        }
+        this.permissions = value;
+        this.updateView();
+    }
+
+    protected setOrCondition(value: boolean): void {
+        this.alternative = value;
+        this.updateView();
+    }
+
+    protected setComplementCondition(value: boolean): void {
+        this.complement = value;
+        this.updateView();
+    }
+
+    protected setAndCondition(value: boolean): void {
+        this.and = value;
+        this.updateView();
+    }
+
+    /**
+     * Triggers to check, if the operator has still the required permissions.
+     */
+    protected updateView(): void {
+        const hasPerms = this._hasPermissions();
+        const permsChanged = hasPerms !== this.lastPermissionCheckResult;
+
+        if ((hasPerms && permsChanged) || this.alternative) {
+            // clean up and add the template
+            this.viewContainer.clear();
+            this.viewContainer.createEmbeddedView(this.template);
+        } else if (!hasPerms) {
+            // will remove the content of the container
+            this.viewContainer.clear();
+        }
+        this.lastPermissionCheckResult = hasPerms;
+    }
+
+    protected abstract hasPermissions(): boolean;
+
+    private _hasPermissions(): boolean {
+        const hasPerms = this.and ? !this.permissions.length || this.hasPermissions() : false;
+
+        if (this.complement) {
+            return !hasPerms;
+        } else {
+            return hasPerms;
+        }
+    }
+}

--- a/client/src/app/shared/directives/cml-perms.directive.ts
+++ b/client/src/app/shared/directives/cml-perms.directive.ts
@@ -1,0 +1,42 @@
+import { Directive, Input } from '@angular/core';
+
+import { CML } from 'app/core/core-services/organization-permission';
+import { Id } from 'app/core/definitions/key-types';
+import { BasePermsDirective } from './base-perms.directive';
+
+@Directive({
+    selector: '[osCmlPerms]'
+})
+export class CmlPermsDirective extends BasePermsDirective<CML> {
+    @Input()
+    public set osCmlPerms(perms: CML | CML[]) {
+        this.setPermissions(perms);
+    }
+
+    @Input('osCmlPermsCommitteeId')
+    public set osCmlPermsCommitteeId(id: Id) {
+        this.committeeId = id;
+        this.updateView();
+    }
+
+    @Input('osCmlPermsAnd')
+    public set osCmlPermsAnd(value: boolean) {
+        this.setAndCondition(value);
+    }
+
+    @Input('osCmlPermsOr')
+    public set osCmlPermsOr(value: boolean) {
+        this.setOrCondition(value);
+    }
+
+    @Input('osCmlPermsComplement')
+    public set osCmlPermsComplement(value: boolean) {
+        this.setComplementCondition(value);
+    }
+
+    private committeeId: Id | undefined = undefined;
+
+    protected hasPermissions(): boolean {
+        return this.operator.hasCommitteePermissions(this.committeeId, ...this.permissions);
+    }
+}

--- a/client/src/app/shared/directives/oml-perms.directive.ts
+++ b/client/src/app/shared/directives/oml-perms.directive.ts
@@ -1,0 +1,33 @@
+import { Directive, Input } from '@angular/core';
+
+import { OML } from 'app/core/core-services/organization-permission';
+import { BasePermsDirective } from './base-perms.directive';
+
+@Directive({
+    selector: '[osOmlPerms]'
+})
+export class OmlPermsDirective extends BasePermsDirective<OML> {
+    @Input()
+    public set osOmlPerms(perms: OML | OML[]) {
+        this.setPermissions(perms);
+    }
+
+    @Input('osOmlPermsAnd')
+    public set osOmlPermsAnd(value: boolean) {
+        this.setAndCondition(value);
+    }
+
+    @Input('osOmlPermsOr')
+    public set osOmlPermsOr(value: boolean) {
+        this.setOrCondition(value);
+    }
+
+    @Input('osOmlPermsComplement')
+    public set osOmlPermsComplement(value: boolean) {
+        this.setComplementCondition(value);
+    }
+
+    protected hasPermissions(): boolean {
+        return this.operator.hasOrganizationPermissions(...this.permissions);
+    }
+}

--- a/client/src/app/shared/directives/perms.directive.ts
+++ b/client/src/app/shared/directives/perms.directive.ts
@@ -1,9 +1,7 @@
-import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Directive, Input } from '@angular/core';
 
-import { Subscription } from 'rxjs';
-
-import { OperatorService } from 'app/core/core-services/operator.service';
 import { Permission } from 'app/core/core-services/permission';
+import { BasePermsDirective } from './base-perms.directive';
 
 /**
  * Directive to check if the {@link OperatorService} has the correct permissions to access certain functions
@@ -14,149 +12,44 @@ import { Permission } from 'app/core/core-services/permission';
 @Directive({
     selector: '[osPerms]'
 })
-export class PermsDirective implements OnInit, OnDestroy {
+export class PermsDirective extends BasePermsDirective<Permission> {
     /**
-     * Holds the required permissions the access a feature
-     */
-    private permissions: Permission[] = [];
-
-    /**
-     * Holds the value of the last permission check. Therefore one can check, if the
-     * permission has changes, to save unnecessary view updates, if not.
-     */
-    private lastPermissionCheckResult: boolean | null = null; // take null to also catch a first "false" update
-
-    /**
-     * Alternative to the permissions. Used in special case where a combination
-     * with *ngIf would be required.
-     *
-     * # Example:
-     *
-     * The div will render if the permission `user.can_manage` is set
-     * or if `this.ownPage` is `true`
-     * ```html
-     * <div *osPerms="'users.can_manage';or:ownPage"> something </div>
-     * ```
-     */
-    private alternative: boolean;
-
-    /**
-     * Switch, to invert the result of checkPermission. Usefull for using osPerms as if-else:
-     * For one element you can use `*osPerms="'perm'"` and for the else-element use
-     * `*osPerms="'perm';complement: true"`.
-     */
-    private complement: boolean;
-
-    /**
-     * Add a true-false-condition additional to osPerms
-     * `*osPerms="permission.mediafilesCanManage; and: !isMultiSelect"`
-     */
-    private and = true;
-
-    private operatorSubscription: Subscription | null;
-
-    /**
-     * Constructs the directive once. Observes the operator for it's groups so the
-     * directive can perform changes dynamically
-     *
-     * @param template inner part of the HTML container
-     * @param viewContainer outer part of the HTML container (for example a `<div>`)
-     * @param operator OperatorService
-     */
-    public constructor(
-        private template: TemplateRef<any>,
-        private viewContainer: ViewContainerRef,
-        private operator: OperatorService
-    ) {}
-
-    public ngOnInit(): void {
-        // observe groups of operator, so the directive can actively react to changes
-        this.operatorSubscription = this.operator.operatorUpdatedEvent.subscribe(() => {
-            this.updateView();
-        });
-    }
-
-    public ngOnDestroy(): void {
-        if (this.operatorSubscription) {
-            this.operatorSubscription.unsubscribe();
-        }
-    }
-
-    /**
-     * Comes directly from the view.
      * The value defines the requires permissions as an array or a single permission.
      */
     @Input()
     public set osPerms(value: Permission | Permission[]) {
-        if (!value) {
-            value = [];
-        } else if (!Array.isArray(value)) {
-            value = [value];
-        }
-        this.permissions = value;
-        this.updateView();
+        this.setPermissions(value);
     }
 
     /**
-     * Comes from the view.
-     * `;or:` turns into osPermsOr during runtime.
+     * `*osPerms="...; or:..."` turns into osPermsOr during runtime.
      */
     @Input('osPermsOr')
     public set osPermsAlt(value: boolean) {
-        this.alternative = value;
-        this.updateView();
+        this.setOrCondition(value);
     }
 
     /**
-     * Comes from the view.
+     * `*osPerms="...; complement:..."` turns into osPermsComplement during runtime.
      */
     @Input('osPermsComplement')
     public set osPermsComplement(value: boolean) {
-        this.complement = value;
-        this.updateView();
+        this.setComplementCondition(value);
     }
 
     /**
-     * Comes from the view.
-     * `;and:` turns into osPermsAnd during runtime.
+     * `*osPerms="...; and:..."` turns into osPermsAnd during runtime.
      */
     @Input('osPermsAnd')
     public set osPermsAnd(value: boolean) {
-        this.and = value;
-        this.updateView();
-    }
-
-    /**
-     * Shows or hides certain content in the view.
-     */
-    private updateView(): void {
-        const hasPerms = this.checkPermissions();
-        const permsChanged = hasPerms !== this.lastPermissionCheckResult;
-
-        if ((hasPerms && permsChanged) || this.alternative) {
-            // clean up and add the template
-            this.viewContainer.clear();
-            this.viewContainer.createEmbeddedView(this.template);
-        } else if (!hasPerms) {
-            // will remove the content of the container
-            this.viewContainer.clear();
-        }
-        this.lastPermissionCheckResult = hasPerms;
+        this.setAndCondition(value);
     }
 
     /**
      * Compare the required permissions with the users permissions.
      * Returns true if the users permissions fit.
      */
-    private checkPermissions(): boolean {
-        const hasPerms = this.and
-            ? this.permissions.length === 0 || this.operator.hasPerms(...this.permissions)
-            : false;
-
-        if (this.complement) {
-            return !hasPerms;
-        } else {
-            return hasPerms;
-        }
+    protected hasPermissions(): boolean {
+        return this.operator.hasPerms(...this.permissions);
     }
 }

--- a/client/src/app/shared/models/event-management/committee.ts
+++ b/client/src/app/shared/models/event-management/committee.ts
@@ -11,8 +11,7 @@ export class Committee extends BaseModel<Committee> {
     public meeting_ids: Id[]; // (meeting/committee_id)[];
     public default_meeting_id: Id; // meeting/default_meeting_for_committee_id;
     public template_meeting_id: Id; // meeting/template_meeting_for_committee_id;
-    public member_ids: Id[]; // (user/committee_as_memeber_ids)[];
-    public manager_ids: Id[]; // (user/committee_as_manager_ids)[];
+    public user_ids: Id[]; // (user/committee_ids)[];
     public forward_to_committee_ids: Id[]; // (committee/receive_forwardings_from_committee_ids)[];
     public receive_forwardings_from_committee_ids: Id[]; // (committee/forward_to_committee_ids)[];
     public organization_id: Id; // organization/committee_ids;

--- a/client/src/app/shared/models/users/user.ts
+++ b/client/src/app/shared/models/users/user.ts
@@ -1,5 +1,6 @@
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 
+import { CML } from 'app/core/core-services/organization-permission';
 import { Id } from 'app/core/definitions/key-types';
 import { BaseDecimalModel } from '../base/base-decimal-model';
 import { HasProjectionIds } from '../base/has-projectable-ids';
@@ -39,8 +40,7 @@ export class User extends BaseDecimalModel<User> {
 
     // Meeting and committee
     public is_present_in_meeting_ids: Id[]; // (meeting/present_user_ids)[];
-    public committee_as_member_ids: Id[]; // (committee/member_ids)[];
-    public committee_as_manager_ids: Id[]; // (committee/manager_ids)[];
+    public committee_ids: Id[]; // (committee/user_ids)[];
 
     public group_$_ids: string[]; // (group/user_ids)[];
     public speaker_$_ids: string[]; // (speaker/user_id)[];
@@ -60,6 +60,7 @@ export class User extends BaseDecimalModel<User> {
     public current_projector_$_ids: any[];
 
     public organization_management_level: string;
+    public committee_$_management_level: Id[];
 
     public get isVoteWeightOne(): boolean {
         throw new Error('TODO');
@@ -159,6 +160,10 @@ export class User extends BaseDecimalModel<User> {
 
     public vote_delegations_from_ids(meetingId: Id): Id[] {
         return this[`vote_delegations_$${meetingId}_from_ids`] || [];
+    }
+
+    public committee_management_level(committeeId: Id): CML {
+        return this[`committee_$${committeeId}_management_level`];
     }
 
     protected getDecimalFields(): (keyof User)[] {

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -107,6 +107,8 @@ import { UserDetailViewComponent } from './components/user-detail-view/user-deta
 import { SelectionTreeComponent } from './components/selection-tree/selection-tree.component';
 import { ChipComponent } from './components/chip/chip.component';
 import { ChipListComponent } from './components/chip-list/chip-list.component';
+import { OmlPermsDirective } from './directives/oml-perms.directive';
+import { CmlPermsDirective } from './directives/cml-perms.directive';
 
 const declarations = [
     PermsDirective,
@@ -181,7 +183,9 @@ const declarations = [
     UserDetailViewComponent,
     SelectionTreeComponent,
     ChipComponent,
-    ChipListComponent
+    ChipListComponent,
+    CmlPermsDirective,
+    OmlPermsDirective
 ];
 
 const sharedModules = [

--- a/client/src/app/site/motions/modules/shared-motion/shared-motion.module.ts
+++ b/client/src/app/site/motions/modules/shared-motion/shared-motion.module.ts
@@ -8,7 +8,7 @@ import { MotionMultiselectActionsComponent } from './motion-multiselect-actions/
 
 @NgModule({
     imports: [CommonModule, SharedModule, RouterModule],
-    exports: [MotionExportDialogComponent],
+    exports: [MotionExportDialogComponent, MotionMultiselectActionsComponent],
     declarations: [MotionExportDialogComponent, MotionMultiselectActionsComponent]
 })
 export class SharedMotionModule {}

--- a/client/src/app/site/users/models/view-user.ts
+++ b/client/src/app/site/users/models/view-user.ts
@@ -202,8 +202,7 @@ interface IUserRelations {
     is_present_in_meetings: ViewMeeting[];
     meeting?: ViewMeeting;
     guest_meetings: ViewMeeting[];
-    committees_as_member: ViewCommittee[];
-    committees_as_manager: ViewCommittee[];
+    committees: ViewCommittee[];
     groups: UserManyStructuredRelation<ViewGroup>;
     speakers: UserManyStructuredRelation<ViewSpeaker>;
     personal_notes: UserManyStructuredRelation<ViewPersonalNote>;


### PR DESCRIPTION
Fixes #174 

Adds also permission-checks to some views. 

There are two remaining questions:
1. Who has access to committees? Every user, who has one of the permissions `[CML.can_manage, OML.can_manage_users, OML.can_manage_organisation, OML.superadmin]`?
2. Who is authorized to "edit" a meeting? Every user, who has one of the permissions `[CML.can_manage (if committee-ids match), OML.can_manage_users, OML.can_manage_organisation, OML.superadmin]`?