### PR TITLE
Fixes update in motion-list

### DIFF
--- a/client/src/app/core/core-services/model-request-builder.service.ts
+++ b/client/src/app/core/core-services/model-request-builder.service.ts
@@ -67,8 +67,17 @@ export interface Follow extends BaseSimplifiedModelRequest {
 export type AdditionalField = Field | ISpecificStructuredField | IAllStructuredFields;
 
 interface BaseSimplifiedModelRequest {
+    /**
+     * Sub-fields can be specified, which fieldset will be loaded, too.
+     */
     follow?: FollowList;
+    /**
+     * The fieldset, which should be loaded.
+     */
     fieldset?: Fieldset;
+    /**
+     * Additional fields to be loaded. They will never be followed.
+     */
     additionalFields?: AdditionalField[];
 }
 

--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -155,9 +155,15 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
         recommendationId: Id,
         viewMotion: ViewMotion
     ): Promise<void> {
-        return this.sendActionsToBackend([
-            { action: MotionAction.UPDATE, data: [this.getUpdatePayload(update, viewMotion)] },
-            {
+        const actions = [];
+        if (update) {
+            actions.push({ action: MotionAction.UPDATE, data: [this.getUpdatePayload(update, viewMotion)] });
+        }
+        if (stateId && stateId !== viewMotion.state_id) {
+            actions.push({ action: MotionAction.SET_STATE, data: [{ id: viewMotion.id, state_id: stateId }] });
+        }
+        if (recommendationId) {
+            actions.push({
                 action: MotionAction.SET_RECOMMENDATION,
                 data: [
                     {
@@ -165,9 +171,9 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
                         recommendation_id: recommendationId
                     }
                 ]
-            },
-            { action: MotionAction.SET_STATE, data: [{ id: viewMotion.id, state_id: stateId }] }
-        ]);
+            });
+        }
+        return this.sendActionsToBackend(actions);
     }
 
     public delete(viewMotion: ViewMotion): Promise<void> {


### PR DESCRIPTION
This fixes an error, if someone updates only a motion's category (for example) and not the motion's state by the `motion-list.component`. 