### PR TITLE
Add own font for chyron

### DIFF
--- a/client/src/app/core/ui-services/load-font.service.ts
+++ b/client/src/app/core/ui-services/load-font.service.ts
@@ -36,15 +36,27 @@ export class LoadFontService {
      * Falls back to the normal OSFont when no custom  font was set.
      */
     private loadCustomFont(): void {
-        this.mediaManageService.getFontUrlObservable('regular').subscribe(url => {
-            if (url) {
-                this.setCustomProjectorFont(url, 400);
+        this.mediaManageService.getFontUrlObservable('regular').subscribe(regular => {
+            if (regular) {
+                this.setCustomProjectorFont(regular, 400);
             }
         });
 
-        this.mediaManageService.getFontUrlObservable('bold').subscribe(url => {
-            if (url) {
-                this.setCustomProjectorFont(url, 500);
+        this.mediaManageService.getFontUrlObservable('bold').subscribe(bold => {
+            if (bold) {
+                this.setCustomProjectorFont(bold, 500);
+            }
+        });
+
+        this.mediaManageService.getFontUrlObservable('monospace').subscribe(mono => {
+            if (mono) {
+                this.setNewFontFace('OSFont Monospace', mono);
+            }
+        });
+
+        this.mediaManageService.getFontUrlObservable('chyron_speaker_name').subscribe(chyronFont => {
+            if (chyronFont) {
+                this.setNewFontFace('OSFont ChyronName', chyronFont);
             }
         });
     }
@@ -53,18 +65,25 @@ export class LoadFontService {
      * Sets a new font for the custom projector. Weight is required to
      * differentiate between bold and normal fonts
      *
-     * @param url the font url
+     * @param fonturl the font object from the config service
      * @param weight the desired weight of the font
      */
-    private setCustomProjectorFont(url: string, weight: number): void {
-        const fontFace = new FontFace('customProjectorFont', `url(${url})`, { weight: weight });
-        fontFace
+    private setCustomProjectorFont(fonturl: string, weight: number): void {
+        if (!fonturl) {
+            return;
+        }
+        this.setNewFontFace('customProjectorFont', fonturl, weight);
+    }
+
+    private setNewFontFace(fontName: string, fontPath: string, weight: number = 400): void {
+        const customFont = new FontFace(fontName, `url(${fontPath})`, { weight: weight });
+        customFont
             .load()
             .then(res => {
                 (document as FontDocument).fonts.add(res);
             })
             .catch(error => {
-                console.error(error);
+                console.error(`Error setting font "${fontName}" with path "${fontPath}" :: `, error);
             });
     }
 }

--- a/client/src/app/core/ui-services/media-manage.service.ts
+++ b/client/src/app/core/ui-services/media-manage.service.ts
@@ -28,20 +28,22 @@ export const LogoDisplayNames: { [place in LogoPlace]: string } = {
     pdf_ballot_paper: 'PDF ballot paper logo'
 };
 
-export type FontPlace = 'regular' | 'italic' | 'bold' | 'bold_italic' | 'monospace';
+export type FontPlace = 'regular' | 'italic' | 'bold' | 'bold_italic' | 'monospace' | 'chyron_speaker_name';
 export const FontDisplayNames: { [place in FontPlace]: string } = {
     regular: 'Font regular',
     italic: 'Font italic',
     bold: 'Font bold',
     bold_italic: 'Font bold italic',
-    monospace: 'Font monospace'
+    monospace: 'Font monospace',
+    chyron_speaker_name: 'Chyron speaker name'
 };
 export const FontDefaults: { [place in FontPlace]: string } = {
     regular: 'assets/fonts/fira-sans-latin-400.woff',
     italic: 'assets/fonts/fira-sans-latin-400italic.woff',
     bold: 'assets/fonts/fira-sans-latin-500.woff',
     bold_italic: 'assets/fonts/fira-sans-latin-500italic.woff',
-    monospace: 'assets/fonts/roboto-condensed-bold.woff'
+    monospace: 'assets/fonts/roboto-condensed-bold.woff',
+    chyron_speaker_name: 'assets/fonts/fira-sans-latin-400.woff'
 };
 
 /**
@@ -67,7 +69,7 @@ export class MediaManageService {
     }
 
     public get allFontPlaces(): FontPlace[] {
-        return ['regular', 'italic', 'bold', 'bold_italic', 'monospace'];
+        return ['regular', 'italic', 'bold', 'bold_italic', 'monospace', 'chyron_speaker_name'];
     }
 
     private readonly logoUrlSubjects: { [place in LogoPlace]?: BehaviorSubject<string | null> } = {};

--- a/client/src/app/shared/components/contdown-time/countdown-time.component.ts
+++ b/client/src/app/shared/components/contdown-time/countdown-time.component.ts
@@ -1,7 +1,6 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 
 import { ServertimeService } from 'app/core/core-services/servertime.service';
-import { MediaManageService } from 'app/core/ui-services/media-manage.service';
 
 declare let FontFace: any;
 
@@ -18,7 +17,7 @@ interface CountdownData {
     templateUrl: './countdown-time.component.html',
     styleUrls: ['./countdown-time.component.scss']
 })
-export class CountdownTimeComponent implements OnInit, OnDestroy {
+export class CountdownTimeComponent implements OnDestroy {
     /**
      * The time in seconds to make the countdown orange, is the countdown is below this value.
      */
@@ -95,23 +94,7 @@ export class CountdownTimeComponent implements OnInit, OnDestroy {
         return this._countdown;
     }
 
-    public constructor(private servertimeService: ServertimeService, private mediaManageService: MediaManageService) {}
-
-    public ngOnInit(): void {
-        this.mediaManageService.getFontUrlObservable('monospace').subscribe(path => {
-            if (path) {
-                const customFont = new FontFace('OSFont Monospace', `url(${path})`);
-                customFont
-                    .load()
-                    .then(res => {
-                        (document as any).fonts.add(res);
-                    })
-                    .catch(error => {
-                        console.log(error);
-                    });
-            }
-        });
-    }
+    public constructor(private servertimeService: ServertimeService) {}
 
     /**
      * Updates the countdown time and string format it.

--- a/client/src/app/shared/models/mediafiles/mediafile.ts
+++ b/client/src/app/shared/models/mediafiles/mediafile.ts
@@ -40,7 +40,8 @@ export class Mediafile extends BaseModel<Mediafile> {
     }
 
     public used_as_logo_in_meeting_id(place: string): Id | null {
-        return this[`used_as_logo_$${place}_in_meeting_id`] || null;
+        const path = `used_as_logo_$${place}_in_meeting_id`;
+        return this[path] || null;
     }
 
     public used_as_font_in_meeting_id(place: string): Id | null {

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.html
@@ -131,6 +131,11 @@
         </div>
     </div>
 
+    <!-- Mimetype (usually hidden) -->
+    <div *pblNgridCellDef="'minetype'; row as mediafile" class="fill clickable">
+        {{ mediafile.mimetype }}
+    </div>
+
     <!-- Info column -->
     <div *pblNgridCellDef="'info'; row as mediafile" class="fill clickable" (click)="onEditFile(mediafile)">
         <os-icon-container *ngIf="mediafile.access_groups.length" icon="group">

--- a/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
+++ b/client/src/app/site/mediafiles/components/mediafile-list/mediafile-list.component.ts
@@ -144,6 +144,17 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
             width: 'auto',
             minWidth: 60
         },
+        /**
+         * Shows the mimetype of files,
+         * Useful for debugging certain behavior
+         */
+        /*
+        {
+             prop: 'mimetype',
+             width: 'auto',
+             minWidth: 60
+        },
+        */
         {
             prop: 'info',
             width: '20%',
@@ -270,6 +281,17 @@ export class MediafileListComponent extends BaseListViewComponent<ViewMediafile>
 
     public getDateFromTimestamp(timestamp: string): string {
         return new Date(timestamp).toLocaleString(this.translate.currentLang);
+    }
+
+    public isFileUsed(file: ViewMediafile, place: string): boolean {
+        if (file.isImage()) {
+            const used = file.used_as_logo_in_meeting_id(place);
+            return !!used;
+        } else if (file.isFont()) {
+            const used = file.used_as_font_in_meeting_id(place);
+            return !!used;
+        }
+        return false;
     }
 
     /**

--- a/client/src/app/site/mediafiles/models/view-mediafile.ts
+++ b/client/src/app/site/mediafiles/models/view-mediafile.ts
@@ -11,7 +11,7 @@ import { Searchable } from 'app/site/base/searchable';
 import { ViewGroup } from 'app/site/users/models/view-group';
 
 export const IMAGE_MIMETYPES = ['image/png', 'image/jpeg', 'image/gif'];
-export const FONT_MIMETYPES = ['font/ttf', 'font/woff', 'application/font-woff', 'application/font-sfnt'];
+export const FONT_MIMETYPES = ['font/ttf', 'font/woff', 'font/woff2'];
 export const PDF_MIMETYPES = ['application/pdf'];
 export const VIDEO_MIMETYPES = [
     'video/quicktime',

--- a/client/src/app/site/projector/services/current-speaker-chyron-slide.service.ts
+++ b/client/src/app/site/projector/services/current-speaker-chyron-slide.service.ts
@@ -63,6 +63,6 @@ export class CurrentSpeakerChyronSlideService {
         if (!descriptor) {
             return;
         }
-        this.projectorRepo.project(descriptor, [projector]);
+        this.projectorRepo.toggle(descriptor, [projector]);
     }
 }

--- a/client/src/app/slides/current-speaker-chyron/current-speaker-chyron-slide.component.scss
+++ b/client/src/app/slides/current-speaker-chyron/current-speaker-chyron-slide.component.scss
@@ -21,10 +21,9 @@
         height: 60px;
         display: table-cell;
 
-        /* TODO
         #inner-name {
             font-family: $font-chyronname;
-        }*/
+        }
 
         #inner-level {
             margin-top: 5px;

--- a/client/src/assets/styles/font-variables.scss
+++ b/client/src/assets/styles/font-variables.scss
@@ -25,3 +25,8 @@ $font-weight-condensed-regular: 400;
 $font-monospace: 'OSFont Monospace';
 $font-monospace-src: url('../fonts/roboto-condensed-bold.woff') format('woff');
 $font-weight-monospace: 400;
+
+/** Special Chyron Name Font */
+$font-chyronname: 'OSFont ChyronName';
+$font-chyronname-src: url('../fonts/fira-sans-latin-400.woff') format('woff');
+$font-weight-chyronname: 400;

--- a/client/src/assets/styles/fonts.scss
+++ b/client/src/assets/styles/fonts.scss
@@ -53,3 +53,12 @@
     font-weight: $font-weight-monospace;
     src: $font-monospace-src;
 }
+
+/** Chyron Name */
+@font-face {
+    font-family: $font-chyronname;
+    font-style: normal;
+    font-display: swap;
+    font-weight: $font-weight-chyronname;
+    src: $font-chyronname-src;
+}


### PR DESCRIPTION
Alters Current Speakery Chyron, optionally shows the structure level in
a new line (slightly smaler, faint)
Font for user name in chyron can be configured
Support way more font mime types
Adds an own font for chyron (server, client)
Extends loads-font service
Cleanup countdown-time component from font loading

as:
https://github.com/OpenSlides/OpenSlides/pull/6063