### PR TITLE
stop-voting shows prompt

### DIFF
--- a/client/src/app/core/repositories/polls/poll-repository.service.ts
+++ b/client/src/app/core/repositories/polls/poll-repository.service.ts
@@ -352,4 +352,21 @@ export class PollRepositoryService extends BaseRepositoryWithActiveMeeting<ViewP
         };
         return this.sendActionToBackend(PollAction.VOTE, payload);
     }
+
+    public async changePollState(poll: Poll, targetState: PollState): Promise<void> {
+        switch (targetState) {
+            case PollState.Created:
+                await this.resetPoll(poll);
+                break;
+            case PollState.Started:
+                await this.startPoll(poll);
+                break;
+            case PollState.Finished:
+                await this.stopPoll(poll);
+                break;
+            case PollState.Published:
+                return this.publishPoll(poll);
+                break;
+        }
+    }
 }

--- a/client/src/app/shared/components/choice-dialog/choice-dialog.component.ts
+++ b/client/src/app/shared/components/choice-dialog/choice-dialog.component.ts
@@ -1,8 +1,8 @@
-import { Component, Inject, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, Inject, ViewEncapsulation } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Identifiable } from 'app/shared/models/base/identifiable';
 import { Displayable } from 'app/site/base/displayable';

--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.html
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.html
@@ -48,7 +48,7 @@
                 <button
                     mat-stroked-button
                     [ngClass]="pollStateActions[poll.state].css"
-                    (click)="changeState(poll.nextState)"
+                    (click)="nextPollState()"
                     [disabled]="stateChangePending"
                 >
                     <mat-icon> {{ pollStateActions[poll.state].icon }}</mat-icon>

--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.ts
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { OperatorService } from 'app/core/core-services/operator.service';
 import { Id } from 'app/core/definitions/key-types';
 import { PollRepositoryService } from 'app/core/repositories/polls/poll-repository.service';
+import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { VotingService } from 'app/core/ui-services/voting.service';
@@ -75,6 +76,7 @@ export class AssignmentPollComponent extends BasePollComponent<ViewAssignment> i
         componentServiceCollector: ComponentServiceCollector,
         dialog: MatDialog,
         promptService: PromptService,
+        choiceService: ChoiceService,
         repo: PollRepositoryService,
         pollDialog: AssignmentPollDialogService,
         private pollService: AssignmentPollService,
@@ -83,7 +85,7 @@ export class AssignmentPollComponent extends BasePollComponent<ViewAssignment> i
         private operator: OperatorService,
         private votingService: VotingService
     ) {
-        super(componentServiceCollector, dialog, promptService, repo, pollDialog);
+        super(componentServiceCollector, dialog, promptService, choiceService, repo, pollDialog);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
@@ -50,7 +50,7 @@
         <button
             mat-stroked-button
             [ngClass]="pollStateActions[poll.state].css"
-            (click)="changeState(poll.nextState)"
+            (click)="nextPollState()"
             [disabled]="stateChangePending"
         >
             <mat-icon> {{ pollStateActions[poll.state].icon }}</mat-icon>

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.ts
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.ts
@@ -5,6 +5,7 @@ import { OperatorService } from 'app/core/core-services/operator.service';
 import { Permission } from 'app/core/core-services/permission';
 import { Id } from 'app/core/definitions/key-types';
 import { PollRepositoryService } from 'app/core/repositories/polls/poll-repository.service';
+import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { VotingPrivacyWarningComponent } from 'app/shared/components/voting-privacy-warning/voting-privacy-warning.component';
@@ -65,6 +66,7 @@ export class MotionPollComponent extends BasePollComponent {
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
         promptService: PromptService,
+        choiceService: ChoiceService,
         pollDialog: MotionPollDialogService,
         dialog: MatDialog,
         pollRepo: PollRepositoryService,
@@ -72,7 +74,7 @@ export class MotionPollComponent extends BasePollComponent {
         private pdfService: MotionPollPdfService,
         private operator: OperatorService
     ) {
-        super(componentServiceCollector, dialog, promptService, pollRepo, pollDialog);
+        super(componentServiceCollector, dialog, promptService, choiceService, pollRepo, pollDialog);
     }
 
     public openVotingWarning(): void {


### PR DESCRIPTION
Stop voting shows options to either simply stop, publish directly or
abort. Was done using choice service.
Alter vote repo to simply choose with voting state to adress rather than
calculate the next state