### PR TITLE
Clears meeting-models in related repos

### DIFF
--- a/client/src/app/core/core-services/communication-manager.service.ts
+++ b/client/src/app/core/core-services/communication-manager.service.ts
@@ -55,7 +55,7 @@ export class CommunicationManagerService {
 
     public async connect<T>(
         endpointName: string,
-        messageHandler: (message: T, streamId: number) => void,
+        messageHandler: (message: T, streamId: number, isFirstResponse: boolean) => void,
         body: HttpBodyGetter,
         params: HttpParamsGetter,
         description: string
@@ -82,7 +82,7 @@ export class CommunicationManagerService {
 
     private getStreamContainer<T>(
         endpoint: EndpointConfiguration,
-        messageHandler: (message: T, streamId: number) => void,
+        messageHandler: (message: T, streamId: number, isFirstResponse: boolean) => void,
         body: HttpBodyGetter,
         params?: HttpParamsGetter,
         description?: string

--- a/client/src/app/core/core-services/data-store.service.ts
+++ b/client/src/app/core/core-services/data-store.service.ts
@@ -276,14 +276,14 @@ export class DataStoreService {
     /**
      * Observable subject for changed or deleted models in the datastore.
      */
-    private readonly clearEvent: EventEmitter<void> = new EventEmitter<void>();
+    private readonly clearEvent: EventEmitter<string[]> = new EventEmitter<string[]>();
 
     /**
      * Observe the datastore for changes and deletions.
      *
      * @return an observable for changed and deleted objects.
      */
-    public get clearObservable(): Observable<void> {
+    public get clearObservable(): Observable<string[]> {
         return this.clearEvent.asObservable();
     }
 
@@ -323,15 +323,15 @@ export class DataStoreService {
      * Deletes all models that belong to a meeting.
      */
     public async clearMeetingModels(): Promise<void> {
+        const removedCollections = [];
         for (const collection of Object.keys(this.modelStore)) {
             if (this.modelMapper.isMeetingSpecificCollection(collection)) {
-                this.remove(
-                    collection,
-                    Object.keys(this.modelStore[collection]).map(id => +id)
-                );
                 delete this.modelStore[collection];
+                removedCollections.push(collection);
+                this.triggerModifiedObservable();
             }
         }
+        this.clearEvent.emit(removedCollections);
     }
 
     /**

--- a/client/src/app/core/core-services/http-stream.service.ts
+++ b/client/src/app/core/core-services/http-stream.service.ts
@@ -22,22 +22,22 @@ export class StreamContainer<T> {
     public hasErroredAmount = 0;
     public errorHandler: (type: ErrorType, error: CommunicationError, message: string) => void = null;
 
-    public messageHandler: (message: T) => void;
+    public messageHandler: (message: T, isFirstResponse: boolean) => void;
     public stream?: Stream<T>;
 
     public constructor(
         public endpoint: EndpointConfiguration,
-        messageHandler: (message: T, streamId: number) => void,
+        messageHandler: (message: T, streamId: number, isFirstResponse: boolean) => void,
         public params: () => Params,
         public body: () => any,
         public description: string
     ) {
-        this.messageHandler = (message: T) => {
+        this.messageHandler = (message: T, isFirstResponse: boolean) => {
             if (this.hasErroredAmount > 0) {
                 console.log(`resetting error amount for ${this.endpoint} since there was a connect message`);
                 this.hasErroredAmount = 0;
             }
-            messageHandler(message, this.id);
+            messageHandler(message, this.id, isFirstResponse);
         };
     }
 }

--- a/client/src/app/core/core-services/model-request-builder.service.ts
+++ b/client/src/app/core/core-services/model-request-builder.service.ts
@@ -111,7 +111,9 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
         this.loaded.resolve();
     }
 
-    public async build(simplifiedModelRequest: SimplifiedModelRequest): Promise<ModelRequest> {
+    public async build(
+        simplifiedModelRequest: SimplifiedModelRequest
+    ): Promise<{ request: ModelRequest; collectionsToUpdate: Collection[] }> {
         await this.loaded;
         const collection = simplifiedModelRequest.viewModelCtor.COLLECTION;
         const request: ModelRequest = {
@@ -121,8 +123,9 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
         };
 
         this.addFields(collection, request.fields, simplifiedModelRequest);
+        const collectionsToUpdate = [];
 
-        return request;
+        return { request, collectionsToUpdate };
     }
 
     private addFields(collection: Collection, fields: Fields, request: BaseSimplifiedModelRequest): void {
@@ -234,7 +237,8 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
         const descriptor: RelationFieldDescriptor = {
             type: relation.many ? 'relation-list' : 'relation',
             collection: foreignCollection,
-            fields: {}
+            fields: {},
+            isFullList: relation.isFullList
         };
         this.addFields(foreignCollection, descriptor.fields, follow);
         return descriptor;
@@ -243,7 +247,8 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
     private getGenericRelationFieldDescriptor(relation: Relation, follow: Follow): GenericRelationFieldDecriptor {
         const descriptor: GenericRelationFieldDecriptor = {
             type: relation.many ? 'generic-relation-list' : 'generic-relation',
-            fields: {}
+            fields: {},
+            isFullList: relation.isFullList
         };
         this.addGenericRelation(relation.foreignViewModelPossibilities, descriptor.fields, follow);
         return descriptor;
@@ -251,7 +256,8 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
 
     private getStructuredFieldDescriptor(relation: Relation, follow: Follow): StructuredFieldDecriptor {
         const descriptor: StructuredFieldDecriptor = {
-            type: 'template'
+            type: 'template',
+            isFullList: relation.isFullList
         };
 
         if (relation.generic) {

--- a/client/src/app/core/core-services/model-request-builder.service.ts
+++ b/client/src/app/core/core-services/model-request-builder.service.ts
@@ -83,11 +83,39 @@ interface BaseSimplifiedModelRequest {
     additionalFields?: AdditionalField[];
 }
 
+interface DescriptorResponse<T extends FieldDescriptor> {
+    descriptor: T;
+    collectionsToUpdate: Collection[];
+}
+
 export interface Fieldsets<M extends BaseModel> {
     [name: string]: (keyof M | IAllStructuredFields)[];
 }
 
 export const DEFAULT_FIELDSET = 'detail';
+
+class ModelRequestObject {
+    public readonly ids: Id[] | undefined;
+    public readonly collectionsToUpdate: Set<Collection>;
+
+    public constructor(
+        public readonly collection: Collection,
+        public readonly simplifiedRequest: BaseSimplifiedModelRequest,
+        public readonly fields: Fields,
+        public readonly args: { ids?: Id[] } = {}
+    ) {
+        this.ids = args.ids;
+        this.collectionsToUpdate = new Set();
+    }
+
+    public getModelRequest(): ModelRequest {
+        return {
+            collection: this.collection,
+            ids: this.ids,
+            fields: this.fields
+        };
+    }
+}
 
 @Injectable({
     providedIn: 'root'
@@ -116,43 +144,39 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
     ): Promise<{ request: ModelRequest; collectionsToUpdate: Collection[] }> {
         await this.loaded;
         const collection = simplifiedModelRequest.viewModelCtor.COLLECTION;
-        const request: ModelRequest = {
+
+        const modelRequestObject = new ModelRequestObject(
             collection,
-            ids: simplifiedModelRequest.ids,
-            fields: {}
+            simplifiedModelRequest,
+            {},
+            { ids: simplifiedModelRequest.ids }
+        );
+        this.addFields(modelRequestObject);
+
+        return {
+            request: modelRequestObject.getModelRequest(),
+            collectionsToUpdate: Array.from(modelRequestObject.collectionsToUpdate)
         };
-
-        this.addFields(collection, request.fields, simplifiedModelRequest);
-        const collectionsToUpdate = [];
-
-        return { request, collectionsToUpdate };
     }
 
-    private addFields(collection: Collection, fields: Fields, request: BaseSimplifiedModelRequest): void {
+    private addFields(modelRequestObject: ModelRequestObject): void {
         // Add datafields
-        this.addDataFields(fields, collection, request.fieldset, request.additionalFields);
+        this.addDataFields(modelRequestObject);
 
         // Add relations
-        if (request.follow) {
-            this.addFollowedRelations(collection, request.follow, fields);
+        if (modelRequestObject.simplifiedRequest.follow) {
+            this.addFollowedRelations(modelRequestObject);
         }
     }
 
     // fields is modified as a side effect
-    private addDataFields(
-        fields: Fields,
-        collection: Collection,
-        fieldset?: Fieldset,
-        additionalFields?: AdditionalField[]
-    ): void {
-        if (!fieldset) {
-            fieldset = DEFAULT_FIELDSET;
-        }
+    private addDataFields(modelRequestObject: ModelRequestObject): void {
+        const fieldset = modelRequestObject.simplifiedRequest.fieldset || DEFAULT_FIELDSET;
         let fieldsetFields: AdditionalField[];
         if (typeof fieldset === 'string') {
-            const registeredFieldsets = this.fieldsets[collection];
+            const registeredFieldsets = this.fieldsets[modelRequestObject.collection];
             if (!registeredFieldsets || !registeredFieldsets[fieldset]) {
-                throw new Error(`Unregistered fieldset ${fieldset} for collection ${collection}`);
+                throw new Error(`Unregistered fieldset ${fieldset} for collection ${modelRequestObject.collection}`);
             }
             fieldsetFields = registeredFieldsets[fieldset] as (
                 | Field
@@ -163,31 +187,31 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
             fieldsetFields = fieldset;
         }
 
-        fieldsetFields.push('id'); // Important: The id is used to detect, if a model was deleted, becuase this issues
+        fieldsetFields.push('id'); // Important: The id is used to detect, if a model was deleted, because this issues
         // an autoupdate with id=null
 
-        if (additionalFields) {
-            fieldsetFields = fieldsetFields.concat(additionalFields);
+        if (modelRequestObject.simplifiedRequest.additionalFields) {
+            fieldsetFields = fieldsetFields.concat(modelRequestObject.simplifiedRequest.additionalFields);
         }
 
         // insert the fieldsetFields into fields
         for (const f of fieldsetFields) {
             if (typeof f === 'string') {
-                fields[f] = null;
+                modelRequestObject.fields[f] = null;
             } else if (isAllStructuredFields(f)) {
-                fields[f.templateField] = {
+                modelRequestObject.fields[f.templateField] = {
                     type: 'template'
                     // no `values` here: Do not follow these, just resolve them.
                 };
             } else {
                 // Specific structured field
-                fields[fillTemplateValueInTemplateField(f.templateIdField, f.templateValue)] = null;
+                modelRequestObject.fields[fillTemplateValueInTemplateField(f.templateIdField, f.templateValue)] = null;
             }
         }
     }
 
-    private addFollowedRelations(collection: Collection, followList: FollowList, fields: Fields): void {
-        for (const entry of followList) {
+    private addFollowedRelations(modelRequestObject: ModelRequestObject): void {
+        for (const entry of modelRequestObject.simplifiedRequest.follow) {
             let follow: Follow;
             if (typeof entry === 'string') {
                 follow = {
@@ -196,11 +220,11 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
             } else {
                 follow = entry;
             }
-            this.getFollowedRelation(collection, follow, fields);
+            this.getFollowedRelation(modelRequestObject, follow);
         }
     }
 
-    private getFollowedRelation(collection: Collection, follow: Follow, fields: Fields): void {
+    private getFollowedRelation(modelRequestObject: ModelRequestObject, follow: Follow): void {
         let effectiveIdField: Field; // the id field of the model. For specific structured fields
         // it is the structured field, not template field, e.g. group_$1_ids instead of group_$_ids.
         let queryIdField: Field; // The field to query the relation for. For specific structured relations
@@ -213,60 +237,80 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
         }
         const isSpecificStructuredField = queryIdField !== effectiveIdField;
 
-        const relation: Relation | null = this.relationManager.findRelation(collection, queryIdField);
+        const relation: Relation | null = this.relationManager.findRelation(
+            modelRequestObject.collection,
+            queryIdField
+        );
         if (!relation) {
             throw new Error(
-                `Relation with ownIdField ${queryIdField} (effective ${effectiveIdField}) in collection ${collection} unknown!`
+                `Relation with ownIdField ${queryIdField} (effective ${effectiveIdField}) in collection ${modelRequestObject.collection} unknown!`
             );
         }
 
-        let descriptor: FieldDescriptor;
+        let response: DescriptorResponse<
+            RelationFieldDescriptor | GenericRelationFieldDecriptor | StructuredFieldDecriptor
+        >;
         if (!relation.generic && (!relation.structured || isSpecificStructuredField)) {
-            descriptor = this.getRelationFieldDescriptor(relation, follow);
+            response = this.getRelationFieldDescriptor(relation, follow);
         } else if (relation.generic) {
-            descriptor = this.getGenericRelationFieldDescriptor(relation, follow);
+            response = this.getGenericRelationFieldDescriptor(relation, follow);
         } else {
-            descriptor = this.getStructuredFieldDescriptor(relation, follow);
+            response = this.getStructuredFieldDescriptor(relation, follow);
         }
 
-        fields[effectiveIdField] = descriptor;
+        modelRequestObject.fields[effectiveIdField] = response.descriptor;
+        response.collectionsToUpdate.forEach(collection => modelRequestObject.collectionsToUpdate.add(collection));
     }
 
-    private getRelationFieldDescriptor(relation: Relation, follow: Follow): RelationFieldDescriptor {
+    private getRelationFieldDescriptor(
+        relation: Relation,
+        follow: Follow
+    ): DescriptorResponse<RelationFieldDescriptor> {
         const foreignCollection = relation.foreignViewModel.COLLECTION;
-        const descriptor: RelationFieldDescriptor = {
-            type: relation.many ? 'relation-list' : 'relation',
-            collection: foreignCollection,
-            fields: {},
-            isFullList: relation.isFullList
+        const modelRequestObject = new ModelRequestObject(foreignCollection, follow, {});
+        if (relation.isFullList) {
+            modelRequestObject.collectionsToUpdate.add(foreignCollection);
+        }
+        this.addFields(modelRequestObject);
+        return {
+            descriptor: {
+                type: relation.many ? 'relation-list' : 'relation',
+                collection: foreignCollection,
+                fields: modelRequestObject.fields
+            },
+            collectionsToUpdate: Array.from(modelRequestObject.collectionsToUpdate)
         };
-        this.addFields(foreignCollection, descriptor.fields, follow);
-        return descriptor;
     }
 
-    private getGenericRelationFieldDescriptor(relation: Relation, follow: Follow): GenericRelationFieldDecriptor {
+    private getGenericRelationFieldDescriptor(
+        relation: Relation,
+        follow: Follow
+    ): DescriptorResponse<GenericRelationFieldDecriptor> {
         const descriptor: GenericRelationFieldDecriptor = {
             type: relation.many ? 'generic-relation-list' : 'generic-relation',
-            fields: {},
-            isFullList: relation.isFullList
+            fields: {}
         };
         this.addGenericRelation(relation.foreignViewModelPossibilities, descriptor.fields, follow);
-        return descriptor;
+        return { descriptor, collectionsToUpdate: [] };
     }
 
-    private getStructuredFieldDescriptor(relation: Relation, follow: Follow): StructuredFieldDecriptor {
+    private getStructuredFieldDescriptor(
+        relation: Relation,
+        follow: Follow
+    ): DescriptorResponse<StructuredFieldDecriptor> {
         const descriptor: StructuredFieldDecriptor = {
-            type: 'template',
-            isFullList: relation.isFullList
+            type: 'template'
         };
 
+        let response: DescriptorResponse<RelationFieldDescriptor | GenericRelationFieldDecriptor>;
         if (relation.generic) {
-            descriptor.values = this.getGenericRelationFieldDescriptor(relation, follow);
+            response = this.getGenericRelationFieldDescriptor(relation, follow);
         } else {
-            descriptor.values = this.getRelationFieldDescriptor(relation, follow);
+            response = this.getRelationFieldDescriptor(relation, follow);
         }
+        descriptor.values = response.descriptor;
 
-        return descriptor;
+        return { descriptor, collectionsToUpdate: response.collectionsToUpdate };
     }
 
     private addGenericRelation(
@@ -283,7 +327,8 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
         // Add datafields
         for (const viewModel of possibleViewModels) {
             try {
-                this.addDataFields(fields, viewModel.COLLECTION, request.fieldset, request.additionalFields);
+                const modelRequestObject = new ModelRequestObject(viewModel.COLLECTION, request, fields);
+                this.addDataFields(modelRequestObject);
             } catch (e) {
                 console.warn(e);
             }
@@ -294,7 +339,8 @@ export class ModelRequestBuilderService implements OnAfterAppsLoaded {
             for (const viewModel of possibleViewModels) {
                 try {
                     // The last to write to fields will win...
-                    this.addFollowedRelations(viewModel.COLLECTION, request.follow, fields);
+                    const modelRequestObject = new ModelRequestObject(viewModel.COLLECTION, request, fields);
+                    this.addFollowedRelations(modelRequestObject);
                 } catch (e) {
                     console.warn(e);
                 }

--- a/client/src/app/core/core-services/stream.ts
+++ b/client/src/app/core/core-services/stream.ts
@@ -31,6 +31,10 @@ export class Stream<T> {
         return this._errorContent;
     }
 
+    public get hasFirstResponse(): boolean {
+        return this.gotFirstResponse.wasResolved;
+    }
+
     public readonly gotFirstResponse = new Deferred<boolean>();
 
     /**
@@ -52,7 +56,7 @@ export class Stream<T> {
 
     public constructor(
         observable: Observable<HttpEvent<string>>,
-        private messageHandler: (message: T) => void,
+        private messageHandler: (message: T, isFirstResponse: boolean) => void,
         private errorHandler: ErrorHandler
     ) {
         this.subscription = observable.subscribe(
@@ -124,9 +128,10 @@ export class Stream<T> {
                     }
                     return;
                 } else {
+                    const isFirstResponse = !this.hasFirstResponse;
                     this.gotFirstResponse.resolve(this.hasError);
                     // console.log('received', parsedContent);
-                    this.messageHandler(parsedContent);
+                    this.messageHandler(parsedContent, isFirstResponse);
                 }
             } else {
                 this.checkedUntilIndex = event.loaded;

--- a/client/src/app/core/definitions/relations.ts
+++ b/client/src/app/core/definitions/relations.ts
@@ -17,6 +17,7 @@ export interface Relation {
     ownIdFieldDefaultAttribute?: 'active-meeting'; // may be given if structured=true
     ownIdFieldPrefix?: string; // given, if structured=true
     ownIdFieldSuffix?: string; // given, if structured=true
+    isFullList?: boolean; // if this relation requests a full-list of view-models in a specific repo.
 }
 
 export function makeO2O<A extends BaseViewModel, B extends BaseViewModel>(args: {
@@ -59,6 +60,7 @@ export function makeM2O<O extends BaseViewModel, M extends BaseViewModel>(args: 
     OIdField?: keyof O & string;
     MIdField?: keyof M & string;
     order?: keyof M & string;
+    isFullList?: boolean;
 }): Relation[] {
     return [
         // M -> O
@@ -80,7 +82,8 @@ export function makeM2O<O extends BaseViewModel, M extends BaseViewModel>(args: 
             many: true,
             generic: false,
             structured: false,
-            order: args.order
+            order: args.order,
+            isFullList: args.isFullList
         }
     ];
 }
@@ -94,6 +97,8 @@ export function makeM2M<A extends BaseViewModel, B extends BaseViewModel>(args: 
     BIdField?: keyof B & string;
     AOrder?: keyof A & string;
     BOrder?: keyof B & string;
+    AisFullList?: boolean;
+    BisFullList?: boolean;
 }): Relation[] {
     return [
         // A -> B
@@ -105,7 +110,8 @@ export function makeM2M<A extends BaseViewModel, B extends BaseViewModel>(args: 
             many: true,
             generic: false,
             structured: false,
-            order: args.BOrder
+            order: args.BOrder,
+            isFullList: args.BisFullList
         },
         // B -> A
         {
@@ -116,7 +122,8 @@ export function makeM2M<A extends BaseViewModel, B extends BaseViewModel>(args: 
             many: true,
             generic: false,
             structured: false,
-            order: args.AOrder
+            order: args.AOrder,
+            isFullList: args.AisFullList
         }
     ];
 }

--- a/client/src/app/core/repositories/base-repository.ts
+++ b/client/src/app/core/repositories/base-repository.ts
@@ -1,10 +1,9 @@
 import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { auditTime, filter } from 'rxjs/operators';
+import { auditTime } from 'rxjs/operators';
 
 import { ActionRequest, ActionService } from '../core-services/action.service';
 import { Collection } from 'app/shared/models/base/collection';
-import { AuthService } from '../core-services/auth.service';
 import { BaseModel, ModelConstructor } from '../../shared/models/base/base-model';
 import { BaseViewModel, ViewModelConstructor } from '../../site/base/base-view-model';
 import { CollectionMapperService } from '../core-services/collection-mapper.service';
@@ -143,7 +142,15 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
 
     public onAfterAppsLoaded(): void {
         this.baseViewModelCtor = this.collectionMapperService.getViewModelConstructor(this.collection);
-        this.DS.clearObservable.subscribe(() => this.clear());
+        this.DS.clearObservable.subscribe(removedCollections => {
+            if (
+                !removedCollections ||
+                (Array.isArray(removedCollections) && removedCollections.includes(this.collection))
+            ) {
+                // "removedCollections" is available if collections to be cleared are specified.
+                this.clear();
+            }
+        });
         this.translate.onLangChange.subscribe(change => {
             this.languageCollator = new Intl.Collator(change.lang);
             if (this.unsafeViewModelListSubject.value) {
@@ -351,6 +358,15 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         modelIds.forEach(id => {
             this.updateViewModelObservable(id);
         });
+    }
+
+    /**
+     * Maps the id from every view-model in this repo into a list.
+     *
+     * @returns A list with ids from all view-models stored in this repo.
+     */
+    protected getViewModelIdList(): Id[] {
+        return this.getViewModelList().map(model => model.id);
     }
 
     protected raiseError = (error: string | Error) => {

--- a/client/src/app/core/repositories/base-repository.ts
+++ b/client/src/app/core/repositories/base-repository.ts
@@ -360,15 +360,6 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         });
     }
 
-    /**
-     * Maps the id from every view-model in this repo into a list.
-     *
-     * @returns A list with ids from all view-models stored in this repo.
-     */
-    protected getViewModelIdList(): Id[] {
-        return this.getViewModelList().map(model => model.id);
-    }
-
     protected raiseError = (error: string | Error) => {
         this.repositoryServiceCollector.errorService.showError(error);
         throw error;

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -117,19 +117,22 @@ export const RELATIONS: Relation[] = [
         OViewModel: ViewOrganization,
         MViewModel: ViewCommittee,
         OField: 'committees',
-        MField: 'organization'
+        MField: 'organization',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewOrganization,
         MViewModel: ViewResource,
         OField: 'resources',
-        MField: 'organization'
+        MField: 'organization',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewOrganization,
         MViewModel: ViewOrganizationTag,
         OField: 'organization_tags',
-        MField: 'organization'
+        MField: 'organization',
+        isFullList: true
     }),
     // ########## User
     ...makeManyStructuredUsers2MRelation({
@@ -312,21 +315,24 @@ export const RELATIONS: Relation[] = [
         OViewModel: ViewMeeting,
         MViewModel: ViewTag,
         OField: 'tags',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewAgendaItem,
         OField: 'agenda_items',
         MField: 'meeting',
-        order: 'weight'
+        order: 'weight',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewListOfSpeakers,
         OField: 'lists_of_speakers',
         OIdField: 'list_of_speakers_ids',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
@@ -338,43 +344,50 @@ export const RELATIONS: Relation[] = [
         OViewModel: ViewMeeting,
         MViewModel: ViewTopic,
         OField: 'topics',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewGroup,
         OField: 'groups',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewPersonalNote,
         OField: 'personal_notes',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMediafile,
         OField: 'mediafiles',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotion,
         OField: 'motions',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionCommentSection,
         OField: 'motion_comment_sections',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionComment,
         OField: 'motion_comments',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
@@ -382,73 +395,85 @@ export const RELATIONS: Relation[] = [
         OField: 'motion_categories',
         OIdField: 'motion_category_ids',
         MField: 'meeting',
-        order: 'weight'
+        order: 'weight',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionBlock,
         OField: 'motion_blocks',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionSubmitter,
         OField: 'motion_submitters',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionChangeRecommendation,
         OField: 'motion_change_recommendations',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionWorkflow,
         OField: 'motion_workflows',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionState,
         OField: 'motion_states',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewMotionStatuteParagraph,
         OField: 'motion_statute_paragraphs',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewPoll,
         OField: 'polls',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewOption,
         OField: 'options',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewVote,
         OField: 'votes',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewAssignment,
         OField: 'assignments',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewAssignmentCandidate,
         OField: 'assignment_candidates',
-        MField: 'meeting'
+        MField: 'meeting',
+        isFullList: true
     }),
     ...makeM2M({
         AViewModel: ViewMeeting,
@@ -548,7 +573,8 @@ export const RELATIONS: Relation[] = [
         ownIdField: 'user_ids',
         many: true,
         generic: false,
-        structured: false
+        structured: false,
+        isFullList: true
     },
     // ########## Personal notes
     ...makeGenericO2M<ViewPersonalNote>({

--- a/client/src/app/shared/overload-js-functions.ts
+++ b/client/src/app/shared/overload-js-functions.ts
@@ -14,7 +14,9 @@ declare global {
         intersect(other: T[]): T[];
         /**
          * Compares each element of two arrays to check, which elements are included in one array but not in the other.
-         * It returns a new array, containing all elements, that are included only one of them.
+         * It returns a new array, containing all elements, that are included only one of them. If `symmetric` is equals
+         * to `false`, only the elements, that are included in the first array and not in the second one will be
+         * returned.
          *
          * @param other Another array, which elements are compared to the original ones.
          * @param symmetric If all elements from both arrays, that are included only in one of them, should be returned.


### PR DESCRIPTION
@FinnStutzenstein please review. I have noticed, that the lifecycle-fix (3979734) deletes models in the `datastore.service`, but it does not delete models in the related repos. Therefore, the models was still seen in view-model-lists.

With this PR the described behavior will be prevented.