### PR TITLE
Some further fixes for motions, settings and assignments...

### DIFF
--- a/client/src/app/core/repositories/management/meeting-settings-definition.ts
+++ b/client/src/app/core/repositories/management/meeting-settings-definition.ts
@@ -2,6 +2,7 @@ import { ValidatorFn, Validators } from '@angular/forms';
 
 import dedent from 'ts-dedent';
 
+import { OrganizationSettingsService } from 'app/core/ui-services/organization-settings.service';
 import { AgendaItemType } from 'app/shared/models/agenda/agenda-item';
 import { Settings } from 'app/shared/models/event-management/meeting';
 import { MotionWorkflow } from 'app/shared/models/motions/motion-workflow';
@@ -59,6 +60,14 @@ export interface SettingsItem {
     // groups/translations: []
     helpText?: string; // default: ""
     validators?: ValidatorFn[]; // default: []
+    /**
+     * A function to restrict some values of a settings-item depending on used organization's settings
+     *
+     * @param orgaSettings: The `OrganizationSettingsService` has to be passed, because it is not injected in the
+     * settings definitions
+     * @param value: The value used...
+     */
+    restrictionFn?: <T>(orgaSettings: OrganizationSettingsService, value: T) => T;
 }
 
 export interface SettingsGroup {
@@ -70,6 +79,13 @@ export interface SettingsGroup {
     }[];
 }
 
+/**
+ * Switches the keys and values from one object.
+ *
+ * @param object An original object to transform
+ *
+ * @returns An object, which keys are the values of the original object
+ */
 function switchKeyValue(object: { [key: string]: string }): { [key: string]: string } {
     return Object.entries(object).reduce((res, [key, value]) => {
         res[value] = key;
@@ -598,7 +614,14 @@ export const meetingSettings: SettingsGroup[] = [
                         key: 'motion_poll_default_type',
                         label: 'Default voting type',
                         type: 'choice',
-                        choices: switchKeyValue(PollTypeVerbose)
+                        choices: switchKeyValue(PollTypeVerbose),
+                        restrictionFn: (orgaSettings, value: any) => {
+                            const isElectronicVotingEnabled = orgaSettings.instant('enable_electronic_voting');
+                            if (!isElectronicVotingEnabled && typeof value !== 'string') {
+                                return { analog: 'analog' };
+                            }
+                            return value;
+                        }
                     },
                     {
                         key: 'motion_poll_default_100_percent_base',
@@ -684,7 +707,14 @@ export const meetingSettings: SettingsGroup[] = [
                         key: 'assignment_poll_default_type',
                         label: 'Default voting type',
                         type: 'choice',
-                        choices: switchKeyValue(PollTypeVerbose)
+                        choices: switchKeyValue(PollTypeVerbose),
+                        restrictionFn: (orgaSettings, value: any) => {
+                            const isElectronicVotingEnabled = orgaSettings.instant('enable_electronic_voting');
+                            if (!isElectronicVotingEnabled && typeof value !== 'string') {
+                                return { analog: 'analog' };
+                            }
+                            return value;
+                        }
                     },
                     {
                         key: 'assignment_poll_default_100_percent_base',

--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -399,7 +399,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
      * @param viewMotion target motion
      */
     public async support(viewMotion: ViewMotion): Promise<void> {
-        const nextSupporterIds = [...viewMotion.supporter_ids, this.operator.operatorId];
+        const nextSupporterIds = [...(viewMotion.supporter_ids || []), this.operator.operatorId];
         return this.update({ supporter_ids: nextSupporterIds }, viewMotion);
     }
 

--- a/client/src/app/management/components/orga-settings/orga-settings.component.ts
+++ b/client/src/app/management/components/orga-settings/orga-settings.component.ts
@@ -67,7 +67,7 @@ export class OrgaSettingsComponent extends BaseModelContextComponent implements 
                 privacy_policy: [this.currentOrgaSettings.privacy_policy],
                 login_text: [this.currentOrgaSettings.login_text],
                 theme: [this.currentOrgaSettings.theme],
-                custom_translations: [this.currentOrgaSettings.custom_translations],
+                // custom_translations: [this.currentOrgaSettings.custom_translations],
                 enable_electronic_voting: [this.currentOrgaSettings.enable_electronic_voting],
                 reset_password_verbose_errors: [this.currentOrgaSettings.reset_password_verbose_errors]
             });

--- a/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.ts
+++ b/client/src/app/site/assignments/components/assignment-detail/assignment-detail.component.ts
@@ -239,7 +239,7 @@ export class AssignmentDetailComponent extends BaseModelContextComponent impleme
                 // Get all available groups in an active meeting.
                 viewModelCtor: ViewMeeting,
                 ids: [this.activeMeetingId],
-                follow: [{ idField: 'group_ids' }]
+                follow: [{ idField: 'group_ids' }, { idField: 'user_ids', fieldset: 'shortName' }]
             },
             'groups'
         );

--- a/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.html
+++ b/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.html
@@ -26,9 +26,9 @@
 
                 <ng-template #select ngProjectAs="mat-select">
                     <mat-select formControlName="value" [errorStateMatcher]="matcher">
-                        <ng-container *ngIf="setting.choices">
+                        <ng-container *ngIf="getRestrictedValue(setting.choices)">
                             <mat-option
-                                *ngFor="let choice of setting.choices | keyvalue: keepEntryOrder"
+                                *ngFor="let choice of getRestrictedValue(setting.choices) | keyvalue: keepEntryOrder"
                                 [value]="choice.value"
                             >
                                 {{ choice.key | translate }}

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-change-recommendation-dialog/motion-change-recommendation-dialog.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-change-recommendation-dialog/motion-change-recommendation-dialog.component.html
@@ -1,7 +1,7 @@
 <h1 mat-dialog-title>{{ 'New change recommendation' | translate }}</h1>
 <div mat-dialog-content>
     <form class="motion-content" [formGroup]="contentForm" (ngSubmit)="submitChanges()">
-        <mat-radio-group #rGroup formControlName="diffType">
+        <mat-radio-group #rGroup formControlName="type">
             <mat-radio-button *ngFor="let radio of replacementTypes" [value]="radio.value">{{
                 radio.title
             }}</mat-radio-button>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-change-recommendation-dialog/motion-change-recommendation-dialog.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-change-recommendation-dialog/motion-change-recommendation-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { MotionChangeRecommendationRepositoryService } from 'app/core/repositories/motions/motion-change-recommendation-repository.service';
@@ -76,20 +76,17 @@ export class MotionChangeRecommendationDialogComponent extends BaseChangeRecomme
         dialogRef: MatDialogRef<MotionChangeRecommendationDialogComponent>
     ) {
         super(componentServiceCollector, data, formBuilder, repo, dialogRef);
-        console.log('dialog data', data);
     }
 
     /**
      * Creates the forms for the Motion and the MotionVersion
      */
     protected createForm(): void {
-        console.log('changeReco', this.changeReco, this.changeReco.text);
         this.contentForm = this.formBuilder.group({
             text: [this.changeReco.text, Validators.required],
-            diffType: [this.changeReco.type, Validators.required],
+            type: [this.changeReco.type, Validators.required],
             public: [!this.changeReco.internal]
         });
-        console.log('this.contentForm', this.contentForm);
     }
 
     protected initializeDialogData(): void {

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail-diff/motion-detail-diff.component.ts
@@ -314,9 +314,8 @@ export class MotionDetailDiffComponent extends BaseComponent implements AfterVie
         $event.preventDefault();
         const title = this.translate.instant('Are you sure you want to delete this change recommendation?');
         if (await this.promptService.open(title)) {
-            // this.recoRepo.delete(reco).catch(this.raiseError);
+            await this.recoRepo.delete(reco).catch(this.raiseError);
         }
-        throw new Error('TODO!');
     }
 
     /**

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-highlight-form/motion-highlight-form.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-highlight-form/motion-highlight-form.component.html
@@ -8,6 +8,7 @@
                 placeholder="{{ 'Go to line' | translate }}"
                 osAutofocus
                 osOnlyNumber
+                (keydown)="onKeyDown($event)"
                 [(ngModel)]="highlightedLineTyping"
             />
             <mat-error *ngIf="highlightedLineTyping > 10">{{ 'Invalid line number' | translate }}</mat-error>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-highlight-form/motion-highlight-form.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-highlight-form/motion-highlight-form.component.ts
@@ -56,7 +56,7 @@ export class MotionHighlightFormComponent extends BaseMotionDetailChildComponent
     /**
      * Holds the model for the typed line number
      */
-    public highlightedLineTyping: number;
+    public highlightedLineTyping: number | string;
 
     /**
      * The change recommendations to amendments to this motion
@@ -125,7 +125,7 @@ export class MotionHighlightFormComponent extends BaseMotionDetailChildComponent
         this.highlightedLine = line;
         // setTimeout necessary for DOM-operations to work
         window.setTimeout(() => {
-            const element = <HTMLElement>this.el.nativeElement;
+            const element = document.querySelector('mat-sidenav-content');
 
             // We only scroll if it's not in the screen already
             const bounding = element
@@ -227,6 +227,13 @@ export class MotionHighlightFormComponent extends BaseMotionDetailChildComponent
      */
     public setLineNumberingMode(mode: LineNumberingMode): void {
         this.viewService.lineNumberingModeSubject.next(mode);
+    }
+
+    public onKeyDown(event: KeyboardEvent): void {
+        if (event.key === 'Enter') {
+            this.gotoHighlightedLine(parseInt(this.highlightedLineTyping as string, 10));
+            this.highlightedLineTyping = '';
+        }
     }
 
     /**

--- a/client/src/app/site/motions/services/permissions.service.ts
+++ b/client/src/app/site/motions/services/permissions.service.ts
@@ -70,7 +70,7 @@ export class PermissionsService {
                     motion.state?.allow_support &&
                     (!motion.submitters ||
                         !motion.submitters.map(submitter => submitter.user_id).includes(this.operator.operatorId)) &&
-                    (!motion.supporters || motion.supporter_ids?.includes(this.operator.operatorId))
+                    (!motion.supporters || !motion.supporter_ids?.includes(this.operator.operatorId))
                 );
             }
             case 'unsupport': {
@@ -81,7 +81,7 @@ export class PermissionsService {
                     motion.state &&
                     motion.state.allow_support &&
                     motion.supporters &&
-                    motion.supporter_ids?.indexOf(this.operator.operatorId) !== -1
+                    !!motion.supporter_ids?.includes(this.operator.operatorId)
                 );
             }
             case 'createpoll': {


### PR DESCRIPTION
- [x] Meeting-settings depends on orga-settings. So, if electronic voting is disabled a user cannot choose electronic voting on the settings-page for any meeting
- [x] A change-recommendation can be of type `insertion` or `deletion`
- [x] Deleting a change-recommendation will work
- [x] Supporting and unsupporting a motion will work
- [x] In an election all users for a meeting will be loaded (to choose them as candidates)
- [x] "Jump to line" in motion-detail will work