### PR TITLE
Some fixes for the orga-layer

### DIFF
--- a/client/src/app/core/actions/committee-action.ts
+++ b/client/src/app/core/actions/committee-action.ts
@@ -6,7 +6,7 @@ export namespace CommitteeAction {
     export const UPDATE = 'committee.update';
     export const DELETE = 'committee.delete';
 
-    interface PartialPayload {
+    export interface PartialPayload {
         description?: UnsafeHtml;
         // For UPDATE: Required permission: OML.can_manage_organization
         user_ids?: Id[];
@@ -30,7 +30,6 @@ export namespace CommitteeAction {
         // Required permission: CML.can_manage
         name?: string;
         template_meeting_id?: Id;
-        default_meeting_id?: Id;
         // Required permission: OML.can_manage_organization
         forward_to_committee_ids?: Id[];
         receive_forwardings_from_committee_ids?: Id[];

--- a/client/src/app/core/repositories/management/meeting-repository.service.ts
+++ b/client/src/app/core/repositories/management/meeting-repository.service.ts
@@ -99,10 +99,9 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
         return viewModel;
     }
 
-    public create(meetingPayload: Partial<MeetingAction.CreatePayload>, addedUserIds?: Id[]): Promise<Identifiable> {
+    public create(meetingPayload: Partial<MeetingAction.CreatePayload>): Promise<Identifiable> {
         meetingPayload.start_time = this.anyDateToUnix(meetingPayload.start_time);
         meetingPayload.end_time = this.anyDateToUnix(meetingPayload.end_time);
-        console.log('TODO: added users, see https://github.com/OpenSlides/openslides-backend/issues/710', addedUserIds);
         return this.sendActionToBackend(MeetingAction.CREATE, meetingPayload);
     }
 

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -87,7 +87,7 @@
                 <mat-form-field>
                     <mat-label>{{ 'Can receive forwarding from committees' | translate }}</mat-label>
                     <os-search-repo-selector
-                        formControlName="receive_from_committee_ids"
+                        formControlName="receive_forwardings_from_committee_ids"
                         [multiple]="true"
                         [repo]="committeeRepo"
                         [pipeFn]="getPipeFilterFn()"

--- a/client/src/app/management/components/committee-edit/committee-edit.component.ts
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.ts
@@ -162,7 +162,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
                 // template_meeting_id: [null], // TODO: Not yet
                 default_meeting_id: [null],
                 forward_to_committee_ids: [[]],
-                receive_from_committee_ids: [[]]
+                receive_forwardings_from_committee_ids: [[]]
             };
         }
         this.committeeForm = this.formBuilder.group(partialForm);

--- a/client/src/app/management/components/committee-list/committee-list.component.html
+++ b/client/src/app/management/components/committee-list/committee-list.component.html
@@ -35,6 +35,7 @@
     [(selectedRows)]="selectedRows"
     (dataSourceChange)="onDataSourceChange($event)"
     [filterProps]="['name']"
+    [hiddenInMobile]="['forwarding', 'managers']"
 >
     <div *pblNgridCellDef="'name'; value as name; row as committee" class="cell-slot fill">
         <a class="detail-link" [routerLink]="committee.id" *ngIf="!isMultiSelect && committee.canAccess()"></a>

--- a/client/src/app/management/components/committee-list/committee-list.component.ts
+++ b/client/src/app/management/components/committee-list/committee-list.component.ts
@@ -109,7 +109,7 @@ export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee>
 
         const confirmed = await this.promptService.open(title);
         if (confirmed) {
-            await this.repo.bulkDelete(this.selectedRows);
+            await this.repo.delete(...this.selectedRows);
         }
     }
 

--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.html
@@ -48,7 +48,7 @@
             <mat-datepicker #endDatePicker></mat-datepicker>
         </mat-form-field>
 
-        <mat-form-field *ngIf="isCreateView">
+        <mat-form-field>
             <mat-label> {{ 'Participants' | translate }}</mat-label>
             <os-search-value-selector
                 formControlName="user_ids"

--- a/client/src/app/shared/overload-js-functions.ts
+++ b/client/src/app/shared/overload-js-functions.ts
@@ -5,7 +5,21 @@ declare global {
      */
     interface Array<T> {
         flatMap<U>(callbackFn: (currentValue: T, index: number, array: T[]) => U, thisArg?: any): U;
-        intersect(a: T[]): T[];
+        /**
+         * Compares each element of two arrays, which element is included in both. It returns a new array containing all
+         * elements, that are included in the arrays.
+         *
+         * @param other Another array, which elements are compared to the original ones.
+         */
+        intersect(other: T[]): T[];
+        /**
+         * Compares each element of two arrays to check, which elements are included in one array but not in the other.
+         * It returns a new array, containing all elements, that are included only one of them.
+         *
+         * @param other Another array, which elements are compared to the original ones.
+         * @param symmetric If all elements from both arrays, that are included only in one of them, should be returned.
+         */
+        difference(other: T[], symmetric?: boolean): T[];
         mapToObject(f: (item: T) => { [key: string]: any }): { [key: string]: any };
     }
 
@@ -63,11 +77,26 @@ function overloadArrayFunctions(): void {
         value: function <T>(other: T[]): T[] {
             let a = this;
             let b = other;
-            // indexOf to loop over shorter
-            if (b.length > a.length) {
+            if (b.length < a.length) {
                 [a, b] = [b, a];
             }
-            return a.filter(e => b.indexOf(e) > -1);
+            const intersect = new Set<T>(b);
+            return a.filter((element: T) => intersect.has(element));
+        },
+        enumerable: false
+    });
+
+    Object.defineProperty(Array.prototype, 'difference', {
+        value: function <T>(other: T[], symmetric: boolean = false): T[] {
+            const difference = new Set<T>(this);
+            for (const entry of other) {
+                if (difference.has(entry)) {
+                    difference.delete(entry);
+                } else if (symmetric) {
+                    difference.add(entry);
+                }
+            }
+            return Array.from(difference);
         },
         enumerable: false
     });


### PR DESCRIPTION
- [x] "receive_from_committee_ids" -> "receive_forwardings_from_committee_ids"
- [x] When editing a meeting a user can also edit its participants
- [x] The name of a committee is in the `committee-list` visible, if staying on small screens
- [x] Removed `default_meeting_id`

Should be merged after merging #273.