### PR TITLE
Point Of Order in Statistics

### DIFF
--- a/client/src/app/core/repositories/agenda/list-of-speakers-repository.service.ts
+++ b/client/src/app/core/repositories/agenda/list-of-speakers-repository.service.ts
@@ -36,7 +36,10 @@ export class ListOfSpeakersRepositoryService extends BaseRepositoryWithActiveMee
     }
 
     public getFieldsets(): Fieldsets<ListOfSpeakers> {
-        return { [DEFAULT_FIELDSET]: ['closed', 'content_object_id', 'speaker_ids'] };
+        const defaultFieldset: (keyof ListOfSpeakers)[] = ['closed', 'content_object_id', 'speaker_ids'];
+        return {
+            [DEFAULT_FIELDSET]: defaultFieldset
+        };
     }
 
     public getVerboseName = (plural: boolean = false) => {
@@ -85,24 +88,6 @@ export class ListOfSpeakersRepositoryService extends BaseRepositoryWithActiveMee
 
     public isFirstContribution(speaker: ViewSpeaker): boolean {
         return !this.getViewModelList().some(list => list.hasSpeakerSpoken(speaker));
-    }
-
-    /**
-     * List every speaker only once, who has spoken
-     *
-     * @returns A list with all different speakers.
-     */
-    public getAllFirstContributions(): ViewSpeaker[] {
-        const speakers: ViewSpeaker[] = this.getViewModelList().flatMap(
-            (los: ViewListOfSpeakers) => los.finishedSpeakers
-        );
-        const firstContributions: ViewSpeaker[] = [];
-        for (const speaker of speakers) {
-            if (!firstContributions.find(s => s.user_id === speaker.user_id)) {
-                firstContributions.push(speaker);
-            }
-        }
-        return firstContributions;
     }
 
     /**

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -331,7 +331,7 @@ export const RELATIONS: Relation[] = [
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewSpeaker,
-        OField: 'speaker_ids',
+        OField: 'speakers',
         MField: 'meeting'
     }),
     ...makeM2O({

--- a/client/src/app/shared/models/agenda/speaker.ts
+++ b/client/src/app/shared/models/agenda/speaker.ts
@@ -43,6 +43,10 @@ export class Speaker extends BaseModel<Speaker> {
     public list_of_speakers_id: Id; // list_of_speakers/speaker_ids;
     public user_id: Id; // user/speaker_$<meeting_id>_ids;
 
+    public get speakingTime(): number {
+        return this.end_time - this.begin_time || 0;
+    }
+
     public constructor(input?: any) {
         super(Speaker.COLLECTION, input);
     }

--- a/client/src/app/site/agenda/models/view-speaker.ts
+++ b/client/src/app/site/agenda/models/view-speaker.ts
@@ -31,6 +31,10 @@ export class ViewSpeaker extends BaseViewModel<Speaker> {
         }
     }
 
+    public get isFinished(): boolean {
+        return this.state === SpeakerState.FINISHED;
+    }
+
     public get name(): string {
         return this.user ? this.user.full_name : '';
     }

--- a/client/src/app/site/common/components/user-statistics/user-statistics.component.html
+++ b/client/src/app/site/common/components/user-statistics/user-statistics.component.html
@@ -8,19 +8,24 @@
     <table class="user-statistics-table">
         <tr>
             <td>{{ 'Number of all requests to speak' | translate }}</td>
-            <td>{{ numberOfWordRequests }}</td>
+            <td>{{ (finishedSpeakers | async).length }}</td>
+        </tr>
+        <tr>
+            <td>{{ 'Thereof point of orders' | translate }}</td>
+            <td>{{ (pointOfOrders | async).length }}</td>
         </tr>
         <tr>
             <td>{{ 'Unique speakers' | translate }}</td>
-            <td>{{ numberOfUniqueSpeakers }}</td>
+            <td>{{ (uniqueSpeakers | async).length }}</td>
         </tr>
         <tr>
             <td>{{ 'Duration of all requests to speak' | translate }}</td>
-            <td>{{ totalDuration }}</td>
+            <!-- I believe we had a pipe fot that, but could not find it -->
+            <td>{{ parseDuration(totalSpeakingTime | async) }}</td>
         </tr>
     </table>
     <os-list-view-table
-        class="user-statistics-table--virtual-scroll "
+        class="user-statistics-table--virtual-scroll"
         [listObservable]="statisticsByStructureLevelObservable"
         [columns]="columnDefinition"
         [filterProps]="filterProps"


### PR DESCRIPTION
Add number of point of order to speaker statistics.
Cleaned up speaker statistics component to simply hold observers instead of recalculating unique speakers, total speakers and speaking time. Did not alter statisticsByStructureLevelObservable 