### PR TITLE
Fixes editing of a projector

### DIFF
--- a/client/src/app/shared/components/projector/projector.component.ts
+++ b/client/src/app/shared/components/projector/projector.component.ts
@@ -180,7 +180,7 @@ export class ProjectorComponent extends BaseComponent implements OnDestroy {
             return;
         }
 
-        this.slides = projector.current_projections.map(projection => {
+        this.slides = (projector.current_projections || []).map(projection => {
             const slideData: SlideData<any> = {
                 collection: collectionFromFqid(projection.content_object_id),
                 data: projection.content,

--- a/client/src/app/site/projector/components/projector-edit-dialog/projector-edit-dialog.component.ts
+++ b/client/src/app/site/projector/components/projector-edit-dialog/projector-edit-dialog.component.ts
@@ -156,9 +156,8 @@ export class ProjectorEditDialogComponent extends BaseComponent implements OnIni
      */
     public onChangeForm(): void {
         if (this.previewProjector && this.projector && this.updateForm.valid) {
-            Object.assign(this.previewProjector, this.updateForm.value);
-            throw new Error('TODO');
-            // this.preview.setProjector(this.previewProjector);
+            const copy = new Projector(this.previewProjector);
+            this.previewProjector = Object.assign(copy, this.updateForm.value);
             this.cd.markForCheck();
         }
     }


### PR DESCRIPTION
This also fixes getting autoupdates for creating or removing a projector, but that fix must be reverted (see `projector.component.ts#19`). There is an issue for that at the [autoupdate-service#230](https://github.com/OpenSlides/openslides-autoupdate-service/issues/230).