### PR TITLE
Better filtering through 'MotionRepo.updateWithStateAndRecommendation'

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -156,19 +156,19 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
     }
 
     public updateWithStateAndRecommendation(
-        update: any,
+        update: Partial<MotionAction.UpdatePayload>,
         stateId: Id,
         recommendationId: Id,
         viewMotion: ViewMotion
     ): Promise<void> {
         const actions = [];
-        if (update) {
+        if (update && Object.values(update).filter(value => !!value).length) {
             actions.push({ action: MotionAction.UPDATE, data: [this.getUpdatePayload(update, viewMotion)] });
         }
         if (stateId && stateId !== viewMotion.state_id) {
             actions.push({ action: MotionAction.SET_STATE, data: [{ id: viewMotion.id, state_id: stateId }] });
         }
-        if (recommendationId) {
+        if (recommendationId && recommendationId !== viewMotion.recommendation_id) {
             actions.push({
                 action: MotionAction.SET_RECOMMENDATION,
                 data: [

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -369,7 +369,7 @@
     <div class="os-form-card-mobile" mat-dialog-content>
         <!-- Category -->
         <mat-form-field *ngIf="isCategoryAvailable()">
-            <mat-select placeholder="{{ 'Category' | translate }}" [(ngModel)]="infoDialog.category_id">
+            <mat-select placeholder="{{ 'Category' | translate }}" [(ngModel)]="infoDialog.update.category_id">
                 <mat-option [value]="null">-</mat-option>
                 <mat-option *ngFor="let category of categories" [value]="category.id">
                     {{ category.getTitle() | translate }}
@@ -378,7 +378,7 @@
         </mat-form-field>
         <!-- Motion block -->
         <mat-form-field *ngIf="isMotionBlockAvailable()">
-            <mat-select placeholder="{{ 'Motion block' | translate }}" [(ngModel)]="infoDialog.block_id">
+            <mat-select placeholder="{{ 'Motion block' | translate }}" [(ngModel)]="infoDialog.update.block_id">
                 <mat-option [value]="null">-</mat-option>
                 <mat-option *ngFor="let block of motionBlocks" [value]="block.id">
                     {{ block.getTitle() | translate }}
@@ -387,7 +387,7 @@
         </mat-form-field>
         <!-- Tag -->
         <mat-form-field *ngIf="isTagAvailable()">
-            <mat-select multiple placeholder="{{ 'Tags' | translate }}" [(ngModel)]="infoDialog.tag_ids">
+            <mat-select multiple placeholder="{{ 'Tags' | translate }}" [(ngModel)]="infoDialog.update.tag_ids">
                 <mat-option *ngFor="let tag of tags" [value]="tag.id">
                     {{ tag.getTitle() | translate }}
                 </mat-option>

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -64,20 +64,22 @@ interface InfoDialog {
      */
     title: string;
 
-    /**
-     * The motion block id
-     */
-    block_id: number;
+    update: {
+        /**
+         * The motion block id
+         */
+        block_id: number;
 
-    /**
-     * The category id
-     */
-    category_id: number;
+        /**
+         * The category id
+         */
+        category_id: number;
 
-    /**
-     * The motions tag ids
-     */
-    tag_ids: number[];
+        /**
+         * The motions tag ids
+         */
+        tag_ids: number[];
+    };
 
     /**
      * The id of the state
@@ -515,9 +517,7 @@ export class MotionListComponent extends BaseListViewComponent<ViewMotion> imple
         // The interface holding the current information from motion.
         this.infoDialog = {
             title: motion.title,
-            block_id: motion.block_id,
-            category_id: motion.category_id,
-            tag_ids: motion.tag_ids,
+            update: { block_id: motion.block_id, category_id: motion.category_id, tag_ids: motion.tag_ids },
             state_id: motion.state_id,
             recommendation_id: motion.recommendation_id
         };
@@ -533,7 +533,7 @@ export class MotionListComponent extends BaseListViewComponent<ViewMotion> imple
         if (result) {
             delete result.title; // Do not update the title!
             await this.motionRepo.updateWithStateAndRecommendation(
-                result,
+                result.update,
                 result.state_id,
                 result.recommendation_id,
                 motion


### PR DESCRIPTION
Since motion.set_state and motion.set_recommendation are dedicated actions, the state and the recommendation of motions cannot be updated through motion.update.
Filtering the values of the "update"-parameter in this function avoids an "empty" payload.