### PR TITLE
Updates the orga- and user-management

### DIFF
--- a/client/src/app/core/actions/committee-action.ts
+++ b/client/src/app/core/actions/committee-action.ts
@@ -12,6 +12,9 @@ export namespace CommitteeAction {
         user_ids?: Id[];
         // For UPDATE: Required permission: CML.can_manage || OML.can_manage_organization
         organization_tag_ids?: Id[];
+        // Required permission: OML.can_manage_organization
+        forward_to_committee_ids?: Id[];
+        receive_forwardings_from_committee_ids?: Id[];
     }
 
     /**
@@ -30,9 +33,6 @@ export namespace CommitteeAction {
         // Required permission: CML.can_manage
         name?: string;
         template_meeting_id?: Id;
-        // Required permission: OML.can_manage_organization
-        forward_to_committee_ids?: Id[];
-        receive_forwardings_from_committee_ids?: Id[];
     }
 
     export interface DeletePayload extends Identifiable {}

--- a/client/src/app/core/core-services/operator.service.ts
+++ b/client/src/app/core/core-services/operator.service.ts
@@ -419,7 +419,7 @@ export class OperatorService {
      */
     public hasCommitteePermissions(committeeId: Id | undefined, ...permissionsToCheck: CML[]): boolean {
         // If a user can manage an entire organization, they can also manage every committee.
-        if (!this.CML || !committeeId) {
+        if (!this.CML) {
             return false;
         }
         if (this.hasOrganizationPermissions(OML.superadmin, OML.can_manage_organization)) {

--- a/client/src/app/core/core-services/organization-permission.ts
+++ b/client/src/app/core/core-services/organization-permission.ts
@@ -1,23 +1,47 @@
+export interface OMLMapping {
+    superadmin: number;
+    can_manage_organization: number;
+    can_manage_users: number;
+}
+
+export interface CMLMapping {
+    can_manage: number;
+}
+
 export enum CML {
-    can_manage = 'can_manage',
-    default = 'default'
+    can_manage = 'can_manage'
 }
 
 export enum OML {
     superadmin = 'superadmin',
     can_manage_organization = 'can_manage_organization',
-    can_manage_users = 'can_manage_users',
-    default = 'default'
+    can_manage_users = 'can_manage_users'
 }
 
-export const omlNameMapping = {
+export const omlNameMapping: OMLMapping = {
     superadmin: 3,
     can_manage_organization: 2,
-    can_manage_users: 1,
-    default: 0
+    can_manage_users: 1
 };
 
 export const cmlNameMapping = {
-    can_manage: 1,
-    default: 0
+    can_manage: 1
 };
+
+export const cmlVerbose = {
+    can_manage: 'Can manage'
+};
+
+export const omlVerbose = {
+    superadmin: 'Superadmin',
+    can_manage_organization: 'Can manage organization',
+    can_manage_users: 'Can manage users'
+};
+
+export function getOmlVerboseName(omlKey: keyof OMLMapping): string {
+    return omlVerbose[omlKey];
+}
+
+export function getCmlVerboseName(cmlKey: keyof CMLMapping): string {
+    return cmlVerbose[cmlKey];
+}

--- a/client/src/app/core/repositories/management/committee-repository.service.ts
+++ b/client/src/app/core/repositories/management/committee-repository.service.ts
@@ -65,8 +65,6 @@ export class CommitteeRepositoryService
     public update(update: Partial<Committee>, committee: ViewCommittee): Promise<void> {
         const payload: CommitteeAction.UpdatePayload = {
             id: committee.id,
-            forward_to_committee_ids: update.forward_to_committee_ids,
-            receive_forwardings_from_committee_ids: update.receive_forwardings_from_committee_ids,
             ...this.getPartialCommitteePayload(update)
         };
         return this.sendActionToBackend(CommitteeAction.UPDATE, payload);
@@ -91,7 +89,9 @@ export class CommitteeRepositoryService
     public bulkUnforwardToCommittees(committees: ViewCommittee[], committeeIds: Id[]): Promise<void> {
         const payload: CommitteeAction.UpdatePayload[] = committees.map(committee => ({
             id: committee.id,
-            forward_to_committee_ids: (committee.forward_to_committee_ids || []).filter(id => committeeIds.includes(id))
+            forward_to_committee_ids: (committee.forward_to_committee_ids || []).filter(
+                id => !committeeIds.includes(id)
+            )
         }));
         return this.sendBulkActionToBackend(CommitteeAction.UPDATE, payload);
     }
@@ -127,7 +127,9 @@ export class CommitteeRepositoryService
         return {
             description: committee.description,
             organization_tag_ids: committee.organization_tag_ids,
-            user_ids: committee.user_ids
+            user_ids: committee.user_ids,
+            forward_to_committee_ids: committee.forward_to_committee_ids,
+            receive_forwardings_from_committee_ids: committee.receive_forwardings_from_committee_ids
         };
     }
 }

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -119,7 +119,11 @@ export class UserRepositoryService
         ]);
         const detailFields = listFields.concat(['username', 'about_me', 'comment', 'default_password']);
         const orgaListFields = listFields.concat(['committee_ids']);
-        const orgaEditFields = orgaListFields.concat(['default_password']);
+        const orgaEditFields = orgaListFields.concat([
+            'default_password',
+            'organization_management_level',
+            { templateField: 'committee_$_management_level' }
+        ]);
 
         return {
             [DEFAULT_FIELDSET]: detailFields,

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -35,7 +35,7 @@
             ></os-search-value-selector>
         </mat-form-field>
 
-        <mat-form-field>
+        <mat-form-field *osCmlPerms="CML.can_manage; committeeId: editCommittee?.id">
             <mat-label>{{ 'Organization tags' | translate }}</mat-label>
             <os-search-repo-selector
                 formControlName="organization_tag_ids"
@@ -44,13 +44,41 @@
                 [showNotFoundButton]="true"
                 (clickNotFound)="onOrgaTagNotFound($event)"
                 placeholder="{{ 'Organization tags' | translate }}"
-            ></os-search-repo-selector>
+            >
+                <ng-container notFoundDescription>
+                    {{ 'Add new organization tag' | translate }}
+                </ng-container>
+            </os-search-repo-selector>
         </mat-form-field>
 
         <mat-form-field>
             <mat-label>{{ 'Description' | translate }}</mat-label>
             <input matInput formControlName="description" />
         </mat-form-field>
+
+        <ng-container *osOmlPerms="OML.can_manage_organization">
+            <mat-form-field>
+                <mat-label>{{ 'Can forward motions to committee' | translate }}</mat-label>
+                <os-search-repo-selector
+                    formControlName="forward_to_committee_ids"
+                    [multiple]="true"
+                    [repo]="committeeRepo"
+                    [pipeFn]="getPipeFilterFn()"
+                    [showChips]="false"
+                ></os-search-repo-selector>
+            </mat-form-field>
+
+            <mat-form-field>
+                <mat-label>{{ 'Can receive forwarding from committees' | translate }}</mat-label>
+                <os-search-repo-selector
+                    formControlName="receive_forwardings_from_committee_ids"
+                    [multiple]="true"
+                    [repo]="committeeRepo"
+                    [pipeFn]="getPipeFilterFn()"
+                    [showChips]="false"
+                ></os-search-repo-selector>
+            </mat-form-field>
+        </ng-container>
 
         <ng-container *ngIf="!isCreateView">
             <!-- TODO: Not yet -->
@@ -62,39 +90,6 @@
                     [inputListValues]="meetingsObservable"
                 ></os-search-value-selector>
             </mat-form-field> -->
-
-            <mat-form-field>
-                <mat-label>{{ 'Default meeting' | translate }}</mat-label>
-                <os-search-value-selector
-                    formControlName="default_meeting_id"
-                    [multiple]="false"
-                    [inputListValues]="meetingsObservable"
-                ></os-search-value-selector>
-            </mat-form-field>
-
-            <ng-container *osOmlPerms="OML.can_manage_users">
-                <mat-form-field>
-                    <mat-label>{{ 'Can forward motions to committee' | translate }}</mat-label>
-                    <os-search-repo-selector
-                        formControlName="forward_to_committee_ids"
-                        [multiple]="true"
-                        [repo]="committeeRepo"
-                        [pipeFn]="getPipeFilterFn()"
-                        [showChips]="false"
-                    ></os-search-repo-selector>
-                </mat-form-field>
-
-                <mat-form-field>
-                    <mat-label>{{ 'Can receive forwarding from committees' | translate }}</mat-label>
-                    <os-search-repo-selector
-                        formControlName="receive_forwardings_from_committee_ids"
-                        [multiple]="true"
-                        [repo]="committeeRepo"
-                        [pipeFn]="getPipeFilterFn()"
-                        [showChips]="false"
-                    ></os-search-repo-selector>
-                </mat-form-field>
-            </ng-container>
         </ng-container>
     </form>
 </mat-card>

--- a/client/src/app/management/components/committee-edit/committee-edit.component.ts
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.ts
@@ -8,7 +8,8 @@ import { Observable, OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { MemberService } from 'app/core/core-services/member.service';
-import { OML } from 'app/core/core-services/organization-permission';
+import { CML, OML } from 'app/core/core-services/organization-permission';
+import { ORGANIZATION_ID } from 'app/core/core-services/organization.service';
 import { Id } from 'app/core/definitions/key-types';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { MeetingRepositoryService } from 'app/core/repositories/management/meeting-repository.service';
@@ -34,6 +35,7 @@ const EditCommitteeLabel = _('Edit committee');
 })
 export class CommitteeEditComponent extends BaseModelContextComponent implements OnInit {
     public readonly OML = OML;
+    public readonly CML = CML;
 
     public addCommitteeLabel = AddCommitteeLabel;
     public editCommitteeLabel = EditCommitteeLabel;
@@ -43,7 +45,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
     public organizationMembers: Observable<ViewUser[]>;
     public meetingsObservable: Observable<ViewMeeting[]>;
 
-    private editCommittee: ViewCommittee;
+    public editCommittee: ViewCommittee;
 
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
@@ -78,7 +80,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
 
     public getPipeFilterFn(): OperatorFunction<ViewCommittee[], ViewCommittee[]> {
         return map((committees: ViewCommittee[]) =>
-            committees.filter(committee => committee.id !== this.editCommittee.id)
+            committees.filter(committee => committee.id !== this.editCommittee?.id)
         );
     }
 
@@ -154,15 +156,14 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
             name: ['', Validators.required],
             description: [''],
             organization_tag_ids: [[]],
-            user_ids: [[]]
+            user_ids: [[]],
+            forward_to_committee_ids: [[]],
+            receive_forwardings_from_committee_ids: [[]]
         };
         if (!this.isCreateView) {
             partialForm = {
-                ...partialForm,
+                ...partialForm
                 // template_meeting_id: [null], // TODO: Not yet
-                default_meeting_id: [null],
-                forward_to_committee_ids: [[]],
-                receive_forwardings_from_committee_ids: [[]]
             };
         }
         this.committeeForm = this.formBuilder.group(partialForm);
@@ -176,7 +177,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
         this.requestModels(
             {
                 viewModelCtor: ViewOrganization,
-                ids: [1],
+                ids: [ORGANIZATION_ID],
                 follow: [
                     {
                         idField: 'committee_ids',

--- a/client/src/app/management/components/management-navigation/management-navigation.component.ts
+++ b/client/src/app/management/components/management-navigation/management-navigation.component.ts
@@ -38,18 +38,21 @@ export class ManagementNavigationComponent {
             route: '/organization-tags',
             displayName: 'Organization tags',
             icon: 'label',
+            permission: OML.can_manage_organization,
             weight: 250
         },
         {
             route: '/members',
             displayName: 'Members',
             icon: 'group',
+            permission: OML.can_manage_users,
             weight: 300
         },
         {
             route: '/settings',
             displayName: 'Settings',
             icon: 'settings',
+            permission: OML.can_manage_organization,
             weight: 400
         }
     ];

--- a/client/src/app/management/components/meeting-list/meeting-list.component.html
+++ b/client/src/app/management/components/meeting-list/meeting-list.component.html
@@ -99,7 +99,7 @@
             type="button"
             class="red-warning-text"
             (click)="deleteSingle(meeting)"
-            *osCmlPerms="CML.can_manage"
+            *osCmlPerms="CML.can_manage; committeeId: currentCommittee.id"
         >
             <mat-icon>delete</mat-icon>
             <span>

--- a/client/src/app/management/components/member-edit/member-edit.component.html
+++ b/client/src/app/management/components/member-edit/member-edit.component.html
@@ -3,7 +3,7 @@
     [hasMainButton]="true"
     mainButtonIcon="edit"
     (mainEvent)="isEditingUser = !isEditingUser"
-    [goBack]="true"
+    [goBack]="false"
     [nav]="false"
     [editMode]="isEditingUser"
     [isSaveButtonEnabled]="isFormValid"
@@ -16,9 +16,24 @@
         <h2 *ngIf="!isNewUser">{{ user?.full_name }}</h2>
     </div>
 
+    <!-- Navigation -->
     <ng-container class="custom-menu-slot">
         <os-management-navigation></os-management-navigation>
     </ng-container>
+
+    <!-- Menu -->
+    <ng-container class="menu-slot">
+        <button type="button" mat-icon-button [matMenuTriggerFor]="userExtraMenu">
+            <mat-icon>more_vert</mat-icon>
+        </button>
+    </ng-container>
+
+    <mat-menu #userExtraMenu="matMenu">
+        <button mat-menu-item [routerLink]="['/', 'members', 'password', user?.id]">
+            <mat-icon>security</mat-icon>
+            <span>{{ 'Change password' | translate }}</span>
+        </button>
+    </mat-menu>
 </os-head-bar>
 
 <os-user-detail-view
@@ -93,7 +108,7 @@
                     <mat-label>{{ 'Organization management level' | translate }}</mat-label>
                     <mat-select formControlName="organization_management_level">
                         <mat-option *ngFor="let level of organizationManagementLevels" [value]="level">
-                            {{ level }}
+                            {{ getOmlVerboseName(level) | translate }}
                         </mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -130,7 +145,7 @@
         <!-- Organization management level -->
         <div *ngIf="user.organization_management_level">
             <h4>{{ 'Organization management level' | translate }}</h4>
-            <span>{{ user.organization_management_level | translate }}</span>
+            <span>{{ getOmlVerboseName(user.organization_management_level) | translate }}</span>
         </div>
     </ng-template>
 </os-user-detail-view>

--- a/client/src/app/management/components/member-edit/member-edit.component.ts
+++ b/client/src/app/management/components/member-edit/member-edit.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { OperatorService } from 'app/core/core-services/operator.service';
-import { OML } from 'app/core/core-services/organization-permission';
+import { getOmlVerboseName, OML, OMLMapping } from 'app/core/core-services/organization-permission';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
@@ -90,6 +90,10 @@ export class MemberEditComponent extends BaseModelContextComponent implements On
      */
     public getRandomPassword(): string {
         return this.repo.getRandomPassword();
+    }
+
+    public getOmlVerboseName(omlKey: keyof OMLMapping): string {
+        return getOmlVerboseName(omlKey);
     }
 
     /**

--- a/client/src/app/management/components/member-password/member-password.component.html
+++ b/client/src/app/management/components/member-password/member-password.component.html
@@ -10,6 +10,11 @@
     <div class="title-slot">
         <h2>{{ 'Change password' | translate }}</h2>
     </div>
+
+    <!-- Navigation -->
+    <ng-container class="custom-menu-slot">
+        <os-management-navigation></os-management-navigation>
+    </ng-container>
 </os-head-bar>
 <os-user-change-password
     [user]="user"

--- a/client/src/app/management/components/member-password/member-password.component.spec.ts
+++ b/client/src/app/management/components/member-password/member-password.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MemberPasswordComponent } from './member-password.component';
+
+describe('MemberPasswordComponent', () => {
+    let component: MemberPasswordComponent;
+    let fixture: ComponentFixture<MemberPasswordComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [MemberPasswordComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(MemberPasswordComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/management/components/member-password/member-password.component.ts
+++ b/client/src/app/management/components/member-password/member-password.component.ts
@@ -1,0 +1,95 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { OperatorService } from 'app/core/core-services/operator.service';
+import { OML } from 'app/core/core-services/organization-permission';
+import { Id } from 'app/core/definitions/key-types';
+import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
+import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PasswordForm } from 'app/shared/components/change-password/change-password.component';
+import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
+import { ViewUser } from 'app/site/users/models/view-user';
+
+@Component({
+    selector: 'os-member-password',
+    templateUrl: './member-password.component.html',
+    styleUrls: ['./member-password.component.scss']
+})
+export class MemberPasswordComponent extends BaseModelContextComponent implements OnInit {
+    public isValid = false;
+    public passwordForm: PasswordForm | string = '';
+    public user?: ViewUser;
+    public canManage = false;
+    public isOwnPage = false;
+
+    private userId?: Id;
+
+    public constructor(
+        componentServiceCollector: ComponentServiceCollector,
+        private route: ActivatedRoute,
+        private router: Router,
+        private operator: OperatorService,
+        public repo: UserRepositoryService
+    ) {
+        super(componentServiceCollector);
+    }
+
+    public ngOnInit(): void {
+        this.subscriptions.push(
+            this.route.params.subscribe(params => {
+                if (params.id) {
+                    this.userId = +params.id;
+                    this.loadUser();
+                }
+            }),
+            this.operator.operatorUpdatedEvent.subscribe(() => this.updatePermissions())
+        );
+    }
+
+    /**
+     * Triggered by the "x" Button of the Form
+     */
+    public goBack(): void {
+        this.router.navigate(['members', this.user.id]);
+    }
+
+    /**
+     * Handles the whole save routine for every possible event
+     */
+    public async save(): Promise<void> {
+        if (!this.isValid) {
+            return;
+        }
+        // can Manage, but not own Page (a.k.a. Admin)
+        try {
+            if (this.canManage && !this.isOwnPage) {
+                const password = this.passwordForm as string;
+                await this.repo.setPassword(this.user, password);
+            } else if (this.isOwnPage) {
+                const { oldPassword, newPassword }: PasswordForm = this.passwordForm as PasswordForm;
+                await this.repo.setPasswordSelf(this.user, oldPassword, newPassword);
+            }
+            this.router.navigate(['members', this.user.id]);
+        } catch (e) {
+            this.raiseError(e);
+        }
+    }
+
+    private loadUser(): void {
+        this.requestModels({
+            viewModelCtor: ViewUser,
+            ids: [this.userId]
+        });
+        this.subscriptions.push(
+            this.repo.getViewModelObservable(this.userId).subscribe(user => {
+                this.user = user;
+                this.updatePermissions();
+            })
+        );
+    }
+
+    private updatePermissions(): void {
+        this.isOwnPage = this.userId === this.operator.operatorId;
+        this.canManage = this.operator.hasOrganizationPermissions(OML.can_manage_users);
+    }
+}

--- a/client/src/app/management/management-routing.module.ts
+++ b/client/src/app/management/management-routing.module.ts
@@ -10,6 +10,7 @@ import { MeetingEditComponent } from './components/meeting-edit/meeting-edit.com
 import { MeetingListComponent } from './components/meeting-list/meeting-list.component';
 import { MemberEditComponent } from './components/member-edit/member-edit.component';
 import { MemberListComponent } from './components/member-list/member-list.component';
+import { MemberPasswordComponent } from './components/member-password/member-password.component';
 import { OrgaSettingsComponent } from './components/orga-settings/orga-settings.component';
 import { OrganizationTagListComponent } from './components/organization-tag-list/organization-tag-list.component';
 
@@ -29,6 +30,10 @@ const routes: Route[] = [
                     {
                         path: 'create',
                         component: MemberEditComponent
+                    },
+                    {
+                        path: 'password/:id',
+                        component: MemberPasswordComponent
                     },
                     {
                         path: ':id',

--- a/client/src/app/management/management.module.ts
+++ b/client/src/app/management/management.module.ts
@@ -13,6 +13,7 @@ import { MeetingEditComponent } from './components/meeting-edit/meeting-edit.com
 import { MeetingListComponent } from './components/meeting-list/meeting-list.component';
 import { MemberEditComponent } from './components/member-edit/member-edit.component';
 import { MemberListComponent } from './components/member-list/member-list.component';
+import { MemberPasswordComponent } from './components/member-password/member-password.component';
 import { OrgaSettingsComponent } from './components/orga-settings/orga-settings.component';
 import { OrganizationTagDialogComponent } from './components/organization-tag-dialog/organization-tag-dialog.component';
 import { OrganizationTagListComponent } from './components/organization-tag-list/organization-tag-list.component';
@@ -32,7 +33,8 @@ import { OrganizationTagListComponent } from './components/organization-tag-list
         OrgaSettingsComponent,
         AccountDialogComponent,
         OrganizationTagListComponent,
-        OrganizationTagDialogComponent
+        OrganizationTagDialogComponent,
+        MemberPasswordComponent
     ]
 })
 export class ManagementModule {}

--- a/client/src/app/shared/components/user-change-password/user-change-password.component.html
+++ b/client/src/app/shared/components/user-change-password/user-change-password.component.html
@@ -1,0 +1,62 @@
+<mat-card class="os-card">
+    <div *ngIf="!canManage && !isOwnPage">
+        <!-- no Admin, cannot Manage (a.k.a Attack Prevention) -->
+        <span>{{ 'You are not supposed to be here...' | translate }}</span>
+    </div>
+    <div *ngIf="canManage && !isOwnPage">
+        <!-- can Manage, but not own Page (a.k.a. Admin) -->
+        <div *ngIf="user">
+            <h1>
+                <span>{{ 'Change password for' | translate }}</span> {{ user.full_name }}
+            </h1>
+            <os-icon-container icon="warning" size="large">
+                <span>{{ 'You override the personally set password!' | translate }}</span>
+            </os-icon-container>
+        </div>
+        <br />
+        <form [formGroup]="adminPasswordForm" (keydown)="onKeyDown($event)">
+            <mat-form-field>
+                <input
+                    [type]="hidePassword ? 'password' : 'text'"
+                    matInput
+                    formControlName="newPassword"
+                    placeholder="{{ 'New password' | translate }}"
+                    required
+                />
+                <mat-icon
+                    class="pointer"
+                    matSuffix
+                    mat-icon-button
+                    matTooltip="{{ hidePassword ? ('Show password' | translate) : ('Hide password' | translate) }}"
+                    (click)="hidePassword = !hidePassword"
+                >
+                    {{ hidePassword ? 'visibility' : 'visibility_off' }}
+                </mat-icon>
+                <mat-icon
+                    class="pointer spacer-left-10"
+                    matSuffix
+                    mat-icon-button
+                    matTooltip="{{ 'Generate password' | translate }}"
+                    (click)="generatePassword()"
+                >
+                    settings
+                </mat-icon>
+            </mat-form-field>
+        </form>
+        <br />
+        <div *ngIf="user">
+            <span>{{ 'Initial password' | translate }}</span
+            >: {{ user.default_password }}<br />
+            <span>{{ 'Username' | translate }}</span
+            >: {{ user.username }}
+        </div>
+    </div>
+
+    <div *ngIf="isOwnPage" (keydown)="onKeyDown($event)">
+        <!-- can not Manage, but own Page (a.k.a. User) -->
+        <os-change-password
+            (validEvent)="isUserPasswordValid = $event"
+            (changeEvent)="userPasswordForm = $event"
+        ></os-change-password>
+    </div>
+</mat-card>

--- a/client/src/app/shared/components/user-change-password/user-change-password.component.scss
+++ b/client/src/app/shared/components/user-change-password/user-change-password.component.scss
@@ -1,0 +1,11 @@
+h1 {
+    margin-bottom: 10px;
+}
+
+mat-form-field {
+    width: 100%;
+}
+
+.pointer {
+    cursor: pointer;
+}

--- a/client/src/app/shared/components/user-change-password/user-change-password.component.spec.ts
+++ b/client/src/app/shared/components/user-change-password/user-change-password.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserChangePasswordComponent } from './user-change-password.component';
+
+describe('UserChangePasswordComponent', () => {
+    let component: UserChangePasswordComponent;
+    let fixture: ComponentFixture<UserChangePasswordComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [UserChangePasswordComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(UserChangePasswordComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/shared/components/user-change-password/user-change-password.component.ts
+++ b/client/src/app/shared/components/user-change-password/user-change-password.component.ts
@@ -1,0 +1,110 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+import { Subscription } from 'rxjs';
+
+import { OperatorService } from 'app/core/core-services/operator.service';
+import { ViewUser } from 'app/site/users/models/view-user';
+import { PasswordForm } from '../change-password/change-password.component';
+
+@Component({
+    selector: 'os-user-change-password',
+    templateUrl: './user-change-password.component.html',
+    styleUrls: ['./user-change-password.component.scss']
+})
+export class UserChangePasswordComponent implements OnInit, OnDestroy {
+    @Input()
+    public canManage = false;
+
+    @Input()
+    public user?: ViewUser;
+
+    @Input()
+    public generatePasswordFn?: () => string;
+
+    @Output()
+    public save = new EventEmitter<void>();
+
+    @Output()
+    public valueChanged = new EventEmitter<PasswordForm | string>();
+
+    @Output()
+    public validStateChanged = new EventEmitter<boolean>();
+
+    public get isOwnPage(): boolean {
+        return this.operator.operatorId === this.user?.id;
+    }
+
+    /**
+     * formGroup for the admin user
+     */
+    public adminPasswordForm: FormGroup;
+
+    /**
+     * Value of the formGroup for a user.
+     */
+    public set userPasswordForm(form: PasswordForm) {
+        this.valueChanged.emit(form);
+    }
+
+    /**
+     * If the value of a new password for a user is valid.
+     */
+    public set isUserPasswordValid(is: boolean) {
+        this.validStateChanged.emit(is);
+    }
+
+    /**
+     * if all password inputs is hidden
+     */
+    public hidePassword = true;
+
+    /**
+     * if the old password should be shown
+     */
+    public hideOldPassword = true;
+
+    private passwordFormSubscription: Subscription | null = null;
+
+    public constructor(private operator: OperatorService, private fb: FormBuilder) {}
+
+    public ngOnInit(): void {
+        this.adminPasswordForm = this.fb.group({
+            newPassword: ['', Validators.required]
+        });
+        this.passwordFormSubscription = this.adminPasswordForm.valueChanges.subscribe(value => {
+            this.valueChanged.emit(value.newPassword);
+            this.validStateChanged.emit(this.adminPasswordForm.valid);
+        });
+    }
+
+    public ngOnDestroy(): void {
+        if (this.passwordFormSubscription) {
+            this.passwordFormSubscription.unsubscribe();
+            this.passwordFormSubscription = null;
+        }
+    }
+
+    /**
+     * clicking Shift and Enter will save automatically
+     *
+     * @param event has the code
+     */
+    public onKeyDown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' && event.shiftKey) {
+            this.save.emit();
+        }
+    }
+
+    /**
+     * Takes generated password and puts it into admin PW field
+     * and displays it
+     */
+    public generatePassword(): void {
+        const randomPassword = this.generatePasswordFn ? this.generatePasswordFn() : '';
+        this.adminPasswordForm.patchValue({
+            newPassword: randomPassword
+        });
+        this.hidePassword = false;
+    }
+}

--- a/client/src/app/shared/components/user-multiselect-actions/user-multiselect-actions.component.html
+++ b/client/src/app/shared/components/user-multiselect-actions/user-multiselect-actions.component.html
@@ -1,0 +1,32 @@
+<button mat-menu-item (click)="selectAll.emit()">
+    <mat-icon>done_all</mat-icon>
+    <span>{{ 'Select all' | translate }}</span>
+</button>
+
+<button mat-menu-item [disabled]="!selectedUsers.length" (click)="deselectAll.emit()">
+    <mat-icon>clear</mat-icon>
+    <span>{{ 'Deselect all' | translate }}</span>
+</button>
+
+<ng-container *ngIf="canManage">
+    <mat-divider></mat-divider>
+
+    <ng-content></ng-content>
+
+    <button mat-menu-item [disabled]="!selectedUsers.length" (click)="resetPasswordsToDefaultSelected()">
+        <mat-icon>vpn_key</mat-icon>
+        <span>{{ 'Reset passwords to the default ones' | translate }}</span>
+    </button>
+
+    <button mat-menu-item [disabled]="!selectedUsers.length" (click)="generateNewPasswordsPasswordsSelected()">
+        <mat-icon>vpn_key</mat-icon>
+        <span>{{ 'Generate new passwords' | translate }}</span>
+    </button>
+
+    <mat-divider></mat-divider>
+
+    <button mat-menu-item class="red-warning-text" [disabled]="!selectedUsers.length" (click)="deleteSelected()">
+        <mat-icon>delete</mat-icon>
+        <span>{{ 'Delete' | translate }}</span>
+    </button>
+</ng-container>

--- a/client/src/app/shared/components/user-multiselect-actions/user-multiselect-actions.component.spec.ts
+++ b/client/src/app/shared/components/user-multiselect-actions/user-multiselect-actions.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserMultiselectActionsComponent } from './user-multiselect-actions.component';
+
+describe('UserMultiselectActionsComponent', () => {
+    let component: UserMultiselectActionsComponent;
+    let fixture: ComponentFixture<UserMultiselectActionsComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [UserMultiselectActionsComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(UserMultiselectActionsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/shared/components/user-multiselect-actions/user-multiselect-actions.component.ts
+++ b/client/src/app/shared/components/user-multiselect-actions/user-multiselect-actions.component.ts
@@ -1,0 +1,92 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
+import { OperatorService } from 'app/core/core-services/operator.service';
+import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
+import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PromptService } from 'app/core/ui-services/prompt.service';
+import { BaseComponent } from 'app/site/base/components/base.component';
+import { ViewUser } from 'app/site/users/models/view-user';
+
+@Component({
+    selector: 'os-user-multiselect-actions',
+    templateUrl: './user-multiselect-actions.component.html',
+    styleUrls: ['./user-multiselect-actions.component.scss']
+})
+export class UserMultiselectActionsComponent extends BaseComponent implements OnInit {
+    @Input()
+    public selectedUsers: ViewUser[] = [];
+
+    @Input()
+    public canManage = true;
+
+    @Output()
+    public selectAll = new EventEmitter<void>();
+
+    @Output()
+    public deselectAll = new EventEmitter<void>();
+
+    public constructor(
+        componentServiceCollector: ComponentServiceCollector,
+        private operator: OperatorService,
+        private promptService: PromptService,
+        public repo: UserRepositoryService
+    ) {
+        super(componentServiceCollector);
+    }
+
+    public ngOnInit(): void {}
+
+    /**
+     * Handler for bulk resetting passwords to the default ones. Needs multiSelect mode.
+     */
+    public async resetPasswordsToDefaultSelected(): Promise<void> {
+        const title = this.translate.instant('Are you sure you want to reset all passwords to the default ones?');
+        if (!(await this.promptService.open(title))) {
+            return;
+        }
+
+        if (this.selectedUsers.find(row => row.user.id === this.operator.operatorId)) {
+            this.raiseError(
+                this.translate.instant(
+                    'Note: Your own password was not changed. Please use the password change dialog instead.'
+                )
+            );
+        }
+        this.repo.bulkResetPasswordsToDefault(this.selectedUsers).catch(this.raiseError);
+    }
+
+    /**
+     * Handler for bulk generating new passwords. Needs multiSelect mode.
+     */
+    public async generateNewPasswordsPasswordsSelected(): Promise<void> {
+        const title = this.translate.instant(
+            'Are you sure you want to generate new passwords for all selected participants?'
+        );
+        const content = this.translate.instant(
+            'Note, that the default password will be changed to the new generated one.'
+        );
+        if (!(await this.promptService.open(title, content))) {
+            return;
+        }
+
+        if (this.selectedUsers.find(row => row.user.id === this.operator.operatorId)) {
+            this.raiseError(
+                this.translate.instant(
+                    'Note: Your own password was not changed. Please use the password change dialog instead.'
+                )
+            );
+        }
+        const rows = this.selectedUsers.filter(row => row.user.id !== this.operator.operatorId);
+        this.repo.bulkGenerateNewPasswords(rows);
+    }
+
+    /**
+     * Bulk deletes users. Needs multiSelect mode to fill selectedRows
+     */
+    public async deleteSelected(): Promise<void> {
+        const title = this.translate.instant('Are you sure you want to delete all selected participants?');
+        if (await this.promptService.open(title)) {
+            this.repo.bulkDelete(this.selectedUsers).catch(this.raiseError);
+        }
+    }
+}

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -112,6 +112,8 @@ import { CmlPermsDirective } from './directives/cml-perms.directive';
 import { BasicListViewTableComponent } from './components/basic-list-view-table/basic-list-view-table.component';
 import { PointOfOrderDialogComponent } from './components/point-of-order-dialog/point-of-order-dialog.component';
 import { CustomTranslationComponent } from './components/custom-translation/custom-translation.component';
+import { UserMultiselectActionsComponent } from './components/user-multiselect-actions/user-multiselect-actions.component';
+import { UserChangePasswordComponent } from './components/user-change-password/user-change-password.component';
 
 const declarations = [
     PermsDirective,
@@ -191,7 +193,9 @@ const declarations = [
     OmlPermsDirective,
     BasicListViewTableComponent,
     PointOfOrderDialogComponent,
-    CustomTranslationComponent
+    CustomTranslationComponent,
+    UserMultiselectActionsComponent,
+    UserChangePasswordComponent
 ];
 
 const sharedModules = [

--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -1,4 +1,4 @@
-<os-head-bar [hasMainButton]="canAddUser" (mainEvent)="onPlusButton()" [multiSelectMode]="isMultiSelect">
+<os-head-bar [hasMainButton]="canManage" (mainEvent)="onPlusButton()" [multiSelectMode]="isMultiSelect">
     <!-- Title -->
     <div class="title-slot">
         <h2>{{ 'Participants' | translate }}</h2>
@@ -209,76 +209,42 @@
         </div>
     </div>
     <div *ngIf="isMultiSelect">
-        <button mat-menu-item (click)="selectAll()">
-            <mat-icon>done_all</mat-icon>
-            <span>{{ 'Select all' | translate }}</span>
-        </button>
-
-        <button mat-menu-item [disabled]="!selectedRows.length" (click)="deselectAll()">
-            <mat-icon>clear</mat-icon>
-            <span>{{ 'Deselect all' | translate }}</span>
-        </button>
-
-        <div *osPerms="permission.usersCanManage">
+        <os-user-multiselect-actions
+            [selectedUsers]="selectedRows"
+            [canManage]="canManage"
+            (selectAll)="selectAll()"
+            (deselectAll)="deselectAll()"
+        >
             <mat-divider></mat-divider>
             <button mat-menu-item [disabled]="!selectedRows.length" (click)="setGroupSelected()">
                 <mat-icon>people</mat-icon>
                 <span>{{ 'Add/remove groups ...' | translate }}</span>
             </button>
 
-            <div *osPerms="permission.usersCanManage">
-                <mat-divider></mat-divider>
+            <mat-divider></mat-divider>
 
-                <button mat-menu-item [disabled]="!selectedRows.length" (click)="setStateSelected('is_active')">
-                    <mat-icon>block</mat-icon>
-                    <span>{{ 'Enable/disable account ...' | translate }}</span>
-                </button>
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setStateSelected('is_active')">
+                <mat-icon>block</mat-icon>
+                <span>{{ 'Enable/disable account ...' | translate }}</span>
+            </button>
 
-                <button mat-menu-item [disabled]="!selectedRows.length" (click)="setStateSelected('is_present')">
-                    <mat-icon>check_box</mat-icon>
-                    <span>{{ 'Set presence ...' | translate }}</span>
-                </button>
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setStateSelected('is_present')">
+                <mat-icon>check_box</mat-icon>
+                <span>{{ 'Set presence ...' | translate }}</span>
+            </button>
 
-                <button
-                    mat-menu-item
-                    [disabled]="!selectedRows.length"
-                    (click)="setStateSelected('is_physical_person')"
-                >
-                    <mat-icon>account_balance</mat-icon>
-                    <span>{{ 'Set physical person ...' | translate }}</span>
-                </button>
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="setStateSelected('is_physical_person')">
+                <mat-icon>account_balance</mat-icon>
+                <span>{{ 'Set physical person ...' | translate }}</span>
+            </button>
 
-                <mat-divider></mat-divider>
+            <mat-divider></mat-divider>
 
-                <button mat-menu-item [disabled]="!selectedRows.length" (click)="sendInvitationEmailSelected()">
-                    <mat-icon>mail</mat-icon>
-                    <span>{{ 'Send invitation email' | translate }}</span>
-                </button>
-
-                <button mat-menu-item [disabled]="!selectedRows.length" (click)="resetPasswordsToDefaultSelected()">
-                    <mat-icon>vpn_key</mat-icon>
-                    <span>{{ 'Reset passwords to the default ones' | translate }}</span>
-                </button>
-                <button
-                    mat-menu-item
-                    [disabled]="!selectedRows.length"
-                    (click)="generateNewPasswordsPasswordsSelected()"
-                >
-                    <mat-icon>vpn_key</mat-icon>
-                    <span>{{ 'Generate new passwords' | translate }}</span>
-                </button>
-                <mat-divider></mat-divider>
-                <button
-                    mat-menu-item
-                    class="red-warning-text"
-                    [disabled]="!selectedRows.length"
-                    (click)="deleteSelected()"
-                >
-                    <mat-icon>delete</mat-icon>
-                    <span>{{ 'Delete' | translate }}</span>
-                </button>
-            </div>
-        </div>
+            <button mat-menu-item [disabled]="!selectedRows.length" (click)="sendInvitationEmailSelected()">
+                <mat-icon>mail</mat-icon>
+                <span>{{ 'Send invitation email' | translate }}</span>
+            </button>
+        </os-user-multiselect-actions>
     </div>
 </mat-menu>
 

--- a/client/src/app/site/users/components/user-list/user-list.component.ts
+++ b/client/src/app/site/users/components/user-list/user-list.component.ts
@@ -120,7 +120,7 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
      *
      * @returns true if the user should be able to create users
      */
-    public get canAddUser(): boolean {
+    public get canManage(): boolean {
         return this.operator.hasPerms(Permission.usersCanManage);
     }
 
@@ -360,16 +360,6 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
     }
 
     /**
-     * Bulk deletes users. Needs multiSelect mode to fill selectedRows
-     */
-    public async deleteSelected(): Promise<void> {
-        const title = this.translate.instant('Are you sure you want to delete all selected participants?');
-        if (await this.promptService.open(title)) {
-            this.repo.bulkDelete(this.selectedRows).catch(this.raiseError);
-        }
-    }
-
-    /**
      * Opens a dialog and sets the group(s) for all selected users.
      * SelectedRows is only filled with data in multiSelect mode
      */
@@ -443,50 +433,6 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
             return this.translate.instant('No email sent');
         }
         return this.repo.lastSentEmailTimeString(user);
-    }
-
-    /**
-     * Handler for bulk resetting passwords to the default ones. Needs multiSelect mode.
-     */
-    public async resetPasswordsToDefaultSelected(): Promise<void> {
-        const title = this.translate.instant('Are you sure you want to reset all passwords to the default ones?');
-        if (!(await this.promptService.open(title))) {
-            return;
-        }
-
-        if (this.selectedRows.find(row => row.user.id === this.operator.operatorId)) {
-            this.raiseError(
-                this.translate.instant(
-                    'Note: Your own password was not changed. Please use the password change dialog instead.'
-                )
-            );
-        }
-        this.repo.bulkResetPasswordsToDefault(this.selectedRows).catch(this.raiseError);
-    }
-
-    /**
-     * Handler for bulk generating new passwords. Needs multiSelect mode.
-     */
-    public async generateNewPasswordsPasswordsSelected(): Promise<void> {
-        const title = this.translate.instant(
-            'Are you sure you want to generate new passwords for all selected participants?'
-        );
-        const content = this.translate.instant(
-            'Note, that the default password will be changed to the new generated one.'
-        );
-        if (!(await this.promptService.open(title, content))) {
-            return;
-        }
-
-        if (this.selectedRows.find(row => row.user.id === this.operator.operatorId)) {
-            this.raiseError(
-                this.translate.instant(
-                    'Note: Your own password was not changed. Please use the password change dialog instead.'
-                )
-            );
-        }
-        const rows = this.selectedRows.filter(row => row.user.id !== this.operator.operatorId);
-        this.repo.bulkGenerateNewPasswords(rows);
     }
 
     /**


### PR DESCRIPTION
- [x] Removes "default_meeting_id" from committee-create/-update
- [x] Adds (un-) forward to committees to committee-create
- [x] Fixes unforward in committee-multiselect-view
- [x] One can set a new password in the user-detail-view at orga-level
- [x] OML and CML are loaded in the user-detail-view at orga-level
- [x] Adds permissions to the management-navigation depending on the OML of users