### PR TITLE
Fixes a request to get updates for polls

### DIFF
--- a/client/src/app/site/polls/components/base-poll-detail.component.ts
+++ b/client/src/app/site/polls/components/base-poll-detail.component.ts
@@ -194,12 +194,7 @@ export abstract class BasePollDetailComponentDirective<V extends ViewPoll<BaseVi
                 },
                 {
                     idField: 'voted_ids',
-                    follow: [
-                        {
-                            idField: 'user_id',
-                            fieldset: 'singleVotes'
-                        }
-                    ]
+                    fieldset: 'singleVotes'
                 },
                 {
                     idField: 'option_ids',


### PR DESCRIPTION
- The client sent a wrong request, why the <*-poll-detail />-view crashed
- The `voted_ids` is already a relation to ViewUsers