### PR TITLE
Fix dynamically loaded choices in settings

### DIFF
--- a/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.ts
+++ b/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.ts
@@ -248,6 +248,12 @@ export class MeetingSettingsFieldComponent extends BaseComponent implements OnIn
                 // convert to an actual integer
                 value = +value;
                 break;
+            case 'choice':
+                // if choicesFunc is set, the keys are ids and therefore need to be converted to ints
+                if (this.setting.choicesFunc) {
+                    value = +value;
+                }
+                break;
         }
         this.sendUpdate(value);
         this.cd.detectChanges();


### PR DESCRIPTION
It seems that often the client does not load the meeting settings and just displays the default. Seems to be a timing issue (happens when I reload on a specific settings page). For other settings, it happens sometimes, for these lists (e.g. default workflow) it happens always, it seems. @tsiegleauq maybe you can check if this is reproducible and what's the reason behind this. Saving works now, anyway.