### PR TITLE
Adds the meeting's name at the site-navigation

### DIFF
--- a/client/src/app/shared/components/user-menu/user-menu.component.html
+++ b/client/src/app/shared/components/user-menu/user-menu.component.html
@@ -44,12 +44,6 @@
                 <span class="menu-text">{{ 'Change password' | translate }}</span>
             </a>
 
-            <!-- To manage view -->
-            <a routerLink="/" mat-list-item>
-                <mat-icon class="menu-icon">dashboard</mat-icon>
-                <span>{{ 'Dashboard' | translate }}</span>
-            </a>
-
             <!-- logout -->
             <a (click)="logout()" mat-list-item>
                 <mat-icon class="menu-icon">exit_to_app</mat-icon>

--- a/client/src/app/site/common/common.config.ts
+++ b/client/src/app/site/common/common.config.ts
@@ -5,6 +5,12 @@ export const CommonAppConfig: AppConfig = {
     name: 'common',
     mainMenuEntries: [
         {
+            route: '/',
+            displayName: 'Dashboard',
+            icon: 'dashboard',
+            weight: 0
+        },
+        {
             route: '.',
             displayName: 'Home',
             icon: 'home',

--- a/client/src/app/site/site.component.html
+++ b/client/src/app/site/site.component.html
@@ -17,9 +17,10 @@
     >
         <div class="nav-toolbar">
             <!-- logo -->
-            <a routerLink="/" (click)="mobileAutoCloseNav()">
+            <a [routerLink]="['/', meeting?.id]" (click)="mobileAutoCloseNav()">
                 <os-logo class="os-logo-container"></os-logo>
             </a>
+            <h2>{{ meeting?.name }}</h2>
         </div>
 
         <!-- User Menu -->
@@ -35,7 +36,7 @@
                     (click)="mobileAutoCloseNav()"
                     [routerLink]="entry.route"
                     routerLinkActive="active"
-                    [routerLinkActiveOptions]="{ exact: isStartPage(entry.route) }"
+                    [routerLinkActiveOptions]="{ exact: isRouteExact(entry.route) }"
                 >
                     <mat-icon>{{ entry.icon }}</mat-icon>
                     <span>{{ entry.displayName | translate }}</span>

--- a/client/src/app/site/site.component.scss
+++ b/client/src/app/site/site.component.scss
@@ -43,8 +43,16 @@ mat-sidenav-container {
     display: flex;
     margin: auto;
     width: 250px;
-    height: 80px;
+    margin-bottom: 10px;
+    justify-content: space-evenly;
     align-items: center;
+    flex-direction: column;
+
+    h2 {
+        font-weight: lighter;
+        margin: 0;
+        text-align: center;
+    }
 }
 
 // CSS for the toggle button
@@ -94,8 +102,7 @@ mat-sidenav-container {
 .os-logo-container {
     margin: auto;
     width: 230px !important;
-    margin-left: 10px;
-    max-height: 80px;
+    height: 80px;
     display: flex;
 }
 

--- a/client/src/app/site/site.component.ts
+++ b/client/src/app/site/site.component.ts
@@ -8,6 +8,7 @@ import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 import { navItemAnim } from '../shared/animations';
+import { ActiveMeetingService } from 'app/core/core-services/active-meeting.service';
 import { HistoryService } from 'app/core/core-services/history.service';
 import { OfflineBroadcastService } from 'app/core/core-services/offline-broadcast.service';
 import { TimeTravelService } from 'app/core/core-services/time-travel.service';
@@ -15,6 +16,7 @@ import { PollRepositoryService } from 'app/core/repositories/polls/poll-reposito
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { SuperSearchService } from 'app/core/ui-services/super-search.service';
 import { UpdateService } from 'app/core/ui-services/update.service';
+import { ViewMeeting } from 'app/management/models/view-meeting';
 import { BaseComponent } from 'app/site/base/components/base.component';
 import { MainMenuEntry, MainMenuService } from '../core/core-services/main-menu.service';
 import { ViewportService } from '../core/ui-services/viewport.service';
@@ -64,6 +66,10 @@ export class SiteComponent extends BaseComponent implements OnInit {
         return this.mainMenuService.entries;
     }
 
+    public get meeting(): ViewMeeting {
+        return this.activeMeeting.meeting;
+    }
+
     /**
      * Constructor
      * @param route
@@ -78,6 +84,7 @@ export class SiteComponent extends BaseComponent implements OnInit {
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
         _offlineBroadcastService: OfflineBroadcastService,
+        private activeMeeting: ActiveMeetingService,
         private updateService: UpdateService,
         private router: Router,
         public vp: ViewportService,
@@ -167,8 +174,8 @@ export class SiteComponent extends BaseComponent implements OnInit {
         }
     }
 
-    public isStartPage(route: string): boolean {
-        return route === '.';
+    public isRouteExact(route: string): boolean {
+        return route === '.' || route === '/';
     }
 
     /**


### PR DESCRIPTION
- Also adds the route to the dashboard as menu-entry (not for the user-menu)
- The logo leads to the startpage of the current meeting (not to the dashboard)

Fixes #369 