### PR TITLE
Motion history tree

### DIFF
--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -632,18 +632,17 @@ export const RELATIONS: Relation[] = [
         MViewModel: ViewMotion,
         OViewModel: ViewMotion,
         MField: 'origin',
-        OField: 'derived_motions'
+        OField: 'all_derived_motions'
     }),
-    // motion/forwarding_tree_motion_ids -> Motion
-    {
-        ownViewModels: [ViewMotion],
-        foreignViewModel: ViewMotion,
-        ownField: 'forwarding_tree_motions',
-        ownIdField: 'forwarding_tree_motion_ids',
-        many: true,
-        generic: false,
-        structured: false
-    },
+    // motion/all_origin_ids -> motion/derived_motion_ids
+    ...makeM2M({
+        AViewModel: ViewMotion,
+        BViewModel: ViewMotion,
+        AField: 'all_origins',
+        AIdField: 'all_origin_ids',
+        BField: 'derived_motions',
+        BIdField: 'derived_motion_ids'
+    }),
     ...makeM2O({
         MViewModel: ViewMotion,
         OViewModel: ViewMotionState,

--- a/client/src/app/shared/models/motions/motion.ts
+++ b/client/src/app/shared/models/motions/motion.ts
@@ -52,9 +52,9 @@ export class Motion extends BaseModel<Motion> implements MotionFormattingReprese
     public sort_child_ids: Id[]; // (motion/parent_id)[];
     // Note: The related motions in origin_id/derived_motion_ids may not be in the same meeting
     public origin_id: Id; // motion/derived_motion_ids;
-    public derived_motion_ids: Id[]; // (motion/origin_id)[];
-    public forwarding_tree_motion_ids: Id[]; // Calculated: All children (derived_motion_ids),
-    // grand children, ... and all parents (origin_id).
+    public derived_motion_ids: Id[]; // motion/all_origin_ids;
+    public all_derived_motion_ids: Id[]; // (motion/origin_id)[];
+    public all_origin_ids: Id[]; // motion/all_derived_motion_ids;
     public state_id: Id; // motion_state/motion_ids;
     public recommendation_id: Id; // motion_state/motion_recommendation_ids;
     public recommendation_extension_reference_ids: Fqid[]; // (*/referenced_in_motion_recommendation_extension_ids)[];

--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -351,8 +351,9 @@ interface IMotionRelations {
     sort_parent?: ViewMotion;
     sort_children: ViewMotion[];
     origin?: ViewMotion;
-    derived_motions: ViewMotion[];
-    forwarding_tree_motions: ViewMotion[];
+    derived_motions?: ViewMotion[];
+    all_derived_motions?: ViewMotion[];
+    all_origins?: ViewMotion[];
     state?: ViewMotionState;
     recommendation?: ViewMotionState;
     recommendation_extension_reference: (BaseViewModel & HasReferencedMotionsInRecommendationExtension)[];

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -404,6 +404,16 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
                 ids: [motionId],
                 follow: [
                     {
+                        idField: 'all_origin_ids',
+                        fieldset: 'title',
+                        follow: ['meeting_id']
+                    },
+                    {
+                        idField: 'derived_motion_ids',
+                        fieldset: 'title',
+                        follow: ['meeting_id']
+                    },
+                    {
                         idField: 'change_recommendation_ids'
                     },
                     {

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.html
@@ -217,12 +217,29 @@
     </mat-basic-chip>
 </div>
 
-<!-- Origin - display only -->
-<div *ngIf="motion?.origin">
+<!-- Origins - display only -->
+<div *ngIf="motion?.all_origins?.length">
     <h4>{{ 'Origin' | translate }}</h4>
-    <a [routerLink]="motion.origin.getDetailStateURL()">
-        {{ motion.origin.meeting?.name }}
-    </a>
+    <div class="origin-view">
+        <ng-container *ngFor="let origin of getOriginMotions(); let last = last">
+            <div>
+                <ng-container *ngTemplateOutlet="meetingLink; context: { motion: origin }"></ng-container>
+            </div>
+            <div class="flex-center">
+                <mat-icon *ngIf="!last">north</mat-icon>
+            </div>
+        </ng-container>
+    </div>
+</div>
+
+<!-- Forwardings - display only -->
+<div *ngIf="motion?.derived_motions?.length">
+    <h4>{{ 'Forwarding' | translate }}</h4>
+    <div>
+        <div *ngFor="let derived of motion.derived_motions; let last = last">
+            <ng-container *ngTemplateOutlet="meetingLink; context: { motion: derived }"></ng-container>
+        </div>
+    </div>
 </div>
 
 <!-- Amendments -->
@@ -242,3 +259,12 @@
 
 <!-- motion polls -->
 <os-motion-manage-polls [motion]="motion"></os-motion-manage-polls>
+
+<ng-template let-motion="motion" #meetingLink>
+    <a *ngIf="motion.meeting?.canAccess()" [routerLink]="motion.getDetailStateURL()">
+        {{ motion.meeting?.name }}
+    </a>
+    <div *ngIf="!motion.meeting?.canAccess()">
+        {{ motion.meeting?.name }}
+    </div>
+</ng-template>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.scss
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.scss
@@ -1,0 +1,3 @@
+div.origin-view {
+    display: inline-block;
+}

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.ts
@@ -220,6 +220,11 @@ export class MotionMetaDataComponent extends BaseMotionDetailChildComponent {
         return allStates.filter(state => state.recommendation_label);
     }
 
+    public getOriginMotions(): ViewMotion[] {
+        const copy = [...(this.motion.all_origins || [])];
+        return copy.reverse();
+    }
+
     protected getSubscriptions(): Subscription[] {
         return [
             this.repo.getAmendmentsByMotionAsObservable(this.motion.id).subscribe(value => (this.amendments = value)),


### PR DESCRIPTION
Fixes #354 

![Antragshistorie](https://user-images.githubusercontent.com/10206688/127503651-8057b68d-19e8-4104-bc56-a64779b9175c.png)

Maybe the ">"-arrows are not the best option to display this. As you can see, the meetings' names are breaking ugly.
