### PR TITLE
Poll Slide

### DIFF
--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -248,12 +248,12 @@ export class UserRepositoryService
         const additions: string[] = [];
 
         // addition: add number and structure level
-        const structure_level = user.structure_level() || '';
+        const structure_level = user.structure_level ? user.structure_level() : null;
         if (structure_level) {
             additions.push(structure_level);
         }
 
-        const number = user.number() || '';
+        const number = user.number ? user.number() : null;
         if (number) {
             additions.push(`${this.translate.instant('No.')} ${number}`);
         }

--- a/client/src/app/shared/components/assignment-poll-detail-content/assignment-poll-detail-content.component.html
+++ b/client/src/app/shared/components/assignment-poll-detail-content/assignment-poll-detail-content.component.html
@@ -41,7 +41,7 @@
                     <div class="single-result" [ngClass]="getVoteClass(vote)">
                         <span>
                             <span *ngIf="vote.showPercent">
-                                {{ getVoteAmount(vote, row) | pollPercentBase: poll:'assignment' }}
+                                {{ getVoteAmount(vote, row) | pollPercentBase: poll }}
                             </span>
                             <span *ngIf="row.class === 'user'">
                                 {{ getVoteAmount(vote, row) | parsePollNumber }}
@@ -59,7 +59,7 @@
                 <td class="result">
                     <div class="single-result">
                         <span>
-                            {{ poll.entitled_users_at_stop.length | pollPercentBase: poll:'assignment' }}
+                            {{ poll.entitled_users_at_stop.length | pollPercentBase: poll }}
                         </span>
                         <span>
                             {{ poll.entitled_users_at_stop.length }}

--- a/client/src/app/shared/components/assignment-poll-detail-content/assignment-poll-detail-content.component.ts
+++ b/client/src/app/shared/components/assignment-poll-detail-content/assignment-poll-detail-content.component.ts
@@ -2,9 +2,8 @@ import { Component, Input } from '@angular/core';
 
 import { OperatorService } from 'app/core/core-services/operator.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PollData } from 'app/shared/models/poll/generic-poll';
 import { PollMethod, PollPercentBase, PollState } from 'app/shared/models/poll/poll-constants';
-import { ViewPoll } from 'app/shared/models/poll/view-poll';
-import { ViewAssignment } from 'app/site/assignments/models/view-assignment';
 import { AssignmentPollService } from 'app/site/assignments/modules/assignment-poll/services/assignment-poll.service';
 import { BaseComponent } from 'app/site/base/components/base.component';
 import { PollTableData, VotingResult } from 'app/site/polls/services/poll.service';
@@ -16,7 +15,7 @@ import { PollTableData, VotingResult } from 'app/site/polls/services/poll.servic
 })
 export class AssignmentPollDetailContentComponent extends BaseComponent {
     @Input()
-    public poll: ViewPoll<ViewAssignment>;
+    public poll: PollData;
 
     private get method(): string {
         return this.poll.pollmethod;

--- a/client/src/app/shared/components/motion-poll-detail-content/motion-poll-detail-content.component.html
+++ b/client/src/app/shared/components/motion-poll-detail-content/motion-poll-detail-content.component.html
@@ -21,7 +21,7 @@
                     <!-- Percent numbers -->
                     <td class="result-cell-definition">
                         <span *ngIf="row.value[0].showPercent">
-                            {{ row.value[0].amount | pollPercentBase: poll:'motion' }}
+                            {{ row.value[0].amount | pollPercentBase: poll }}
                         </span>
                     </td>
 
@@ -33,7 +33,7 @@
                 <tr *ngIf="isPercentBaseEntitled" class="entitled-users-row">
                     <td>{{ 'Entitled users' | translate }}</td>
                     <td class="result-cell-definition">
-                        {{ poll.entitled_users_at_stop.length | pollPercentBase: poll:'motion' }}
+                        {{ poll.entitled_users_at_stop.length | pollPercentBase: poll }}
                     </td>
                     <td class="result-cell-definition">
                         {{ poll.entitled_users_at_stop.length }}

--- a/client/src/app/shared/components/motion-poll-detail-content/motion-poll-detail-content.component.ts
+++ b/client/src/app/shared/components/motion-poll-detail-content/motion-poll-detail-content.component.ts
@@ -2,11 +2,11 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@a
 
 import { OperatorService } from 'app/core/core-services/operator.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
+import { PollData } from 'app/shared/models/poll/generic-poll';
 import { PollState } from 'app/shared/models/poll/poll-constants';
-import { ViewPoll } from 'app/shared/models/poll/view-poll';
 import { BaseComponent } from 'app/site/base/components/base.component';
 import { MotionPollService } from 'app/site/motions/services/motion-poll.service';
-import { PollData, PollTableData } from 'app/site/polls/services/poll.service';
+import { PollTableData } from 'app/site/polls/services/poll.service';
 import { ChartData } from '../charts/charts.component';
 
 @Component({
@@ -16,20 +16,20 @@ import { ChartData } from '../charts/charts.component';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MotionPollDetailContentComponent extends BaseComponent {
-    private _poll: ViewPoll | PollData;
+    private _poll: PollData;
 
     public chartData: ChartData;
     public tableData: PollTableData[];
 
     @Input()
-    public set poll(pollData: ViewPoll | PollData) {
+    public set poll(pollData: PollData) {
         this._poll = pollData;
         this.setTableData();
         this.setChartData();
         this.cd.markForCheck();
     }
 
-    public get poll(): ViewPoll | PollData {
+    public get poll(): PollData {
         return this._poll;
     }
 

--- a/client/src/app/shared/models/poll/generic-poll.ts
+++ b/client/src/app/shared/models/poll/generic-poll.ts
@@ -1,0 +1,33 @@
+import { EntitledUsersEntry, PollMethod, PollPercentBase, PollState, PollType } from './poll-constants';
+
+/**
+ * The main interface to describe everything related to polls
+ * This is a unification of the data received in the projector and ViewPoll; both
+ * use this interface, so the poll services can work on this shared view on the data.
+ */
+export interface PollData {
+    pollmethod: PollMethod;
+    state: PollState;
+    onehundred_percent_base: PollPercentBase;
+    votesvalid: number;
+    votesinvalid: number;
+    votescast: number;
+    type: PollType;
+    entitled_users_at_stop: EntitledUsersEntry[];
+    options: OptionData[];
+    global_option: OptionData;
+    getContentObjectTitle: () => string | null;
+}
+
+export interface OptionTitle {
+    title: string;
+    subtitle?: string;
+}
+
+export interface OptionData {
+    getOptionTitle: () => OptionTitle;
+    yes?: number;
+    no?: number;
+    abstain?: number;
+    weight?: number;
+}

--- a/client/src/app/shared/models/poll/option.ts
+++ b/client/src/app/shared/models/poll/option.ts
@@ -5,6 +5,7 @@ export class Option extends BaseDecimalModel<Option> {
     public static COLLECTION = 'option';
     public static readonly DECIMAL_FIELDS: (keyof Option)[] = ['yes', 'no', 'abstain'];
     public id: Id;
+    public text: string;
     public yes: number;
     public no: number;
     public abstain: number;

--- a/client/src/app/shared/models/poll/view-option.ts
+++ b/client/src/app/shared/models/poll/view-option.ts
@@ -1,15 +1,32 @@
 import { HasMeeting } from 'app/management/models/view-meeting';
 import { BaseViewModel } from 'app/site/base/base-view-model';
+import { ViewUser } from 'app/site/users/models/view-user';
+import { OptionData, OptionTitle } from './generic-poll';
 import { Option } from './option';
 import { ViewPoll } from './view-poll';
 import { ViewVote } from './view-vote';
 
-export class ViewOption<C extends BaseViewModel = any> extends BaseViewModel<Option> {
+export class ViewOption<C extends BaseViewModel = any> extends BaseViewModel<Option> implements OptionData {
     public static COLLECTION = Option.COLLECTION;
     protected _collection = Option.COLLECTION;
 
     public getContentObject(): C | undefined {
         return this.content_object;
+    }
+
+    public getOptionTitle(): OptionTitle {
+        if (this.text) {
+            return { title: this.text };
+        } else {
+            if (this.content_object instanceof ViewUser) {
+                return {
+                    title: this.content_object.getShortName(),
+                    subtitle: this.content_object.getLevelAndNumber()
+                };
+            } else {
+                return { title: this.content_object.getTitle() };
+            }
+        }
     }
 }
 

--- a/client/src/app/shared/models/poll/view-poll.ts
+++ b/client/src/app/shared/models/poll/view-poll.ts
@@ -6,6 +6,7 @@ import { ProjectionBuildDescriptor } from 'app/site/base/projection-build-descri
 import { ViewGroup } from 'app/site/users/models/view-group';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { BaseModel } from '../base/base-model';
+import { PollData } from './generic-poll';
 import { Poll } from './poll';
 import {
     AssignmentPollMethodVerbose,
@@ -22,7 +23,7 @@ import { ViewOption } from './view-option';
 
 export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
     extends BaseProjectableViewModel<Poll>
-    implements DetailNavigable {
+    implements DetailNavigable, PollData {
     public get poll(): Poll {
         return this._model;
     }
@@ -73,23 +74,15 @@ export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
         return this.user_has_voted;
     }
 
-    public get amount_global_yes(): number {
-        return this.global_option?.yes;
-    }
-
-    public get amount_global_no(): number {
-        return this.global_option?.no;
-    }
-
-    public get amount_global_abstain(): number {
-        return this.global_option?.abstain;
-    }
-
     /**
      * Is injected by the poll-repo
      * TODO: Can be removed, when OpenSlides/openslides-autoupdate-service#262 is resolved.
      */
     public operatorHasVoted: () => boolean;
+
+    public getContentObjectTitle(): string | null {
+        return this.content_object?.getTitle();
+    }
 
     public canBeVotedFor(): boolean {
         return this.isStarted;

--- a/client/src/app/shared/pipes/poll-percent-base.pipe.ts
+++ b/client/src/app/shared/pipes/poll-percent-base.pipe.ts
@@ -1,8 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { AssignmentPollService } from 'app/site/assignments/modules/assignment-poll/services/assignment-poll.service';
-import { MotionPollService } from 'app/site/motions/services/motion-poll.service';
-import { PollData } from 'app/site/polls/services/poll.service';
+import { PollService } from 'app/site/polls/services/poll.service';
+import { PollData } from '../models/poll/generic-poll';
 
 /**
  * Uses a number and a ViewPoll-object.
@@ -14,32 +13,20 @@ import { PollData } from 'app/site/polls/services/poll.service';
  *
  * @example
  * ```html
- * <span> {{ voteYes | pollPercentBase: poll:'assignment' }} </span>
+ * <span> {{ voteYes | pollPercentBase: poll }} </span>
  * ```
  */
 @Pipe({
     name: 'pollPercentBase'
 })
 export class PollPercentBasePipe implements PipeTransform {
-    public constructor(
-        private assignmentPollService: AssignmentPollService,
-        private motionPollService: MotionPollService
-    ) {}
+    public constructor(private pollService: PollService) {}
 
-    public transform(value: number, poll: PollData, type: 'motion' | 'assignment'): string | null {
+    public transform(value: number, poll: PollData): string | null {
         // logic handles over the pollService to avoid circular dependencies
         let voteValueInPercent: string;
 
-        /**
-         * PollData has not enough explicit information to simply guess the type correctly.
-         * This should not be a problem when PollData is a real model or a real type. Since
-         * we cannot expect the projector to work with real types for now, we need to provice the type
-         */
-        if (type === 'assignment') {
-            voteValueInPercent = this.assignmentPollService.getVoteValueInPercent(value, poll);
-        } else {
-            voteValueInPercent = this.motionPollService.getVoteValueInPercent(value, poll);
-        }
+        voteValueInPercent = this.pollService.getVoteValueInPercent(value, poll);
 
         if (voteValueInPercent) {
             return `(${voteValueInPercent})`;

--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.ts
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll/assignment-poll.component.ts
@@ -10,14 +10,11 @@ import { ComponentServiceCollector } from 'app/core/ui-services/component-servic
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { VotingService } from 'app/core/ui-services/voting.service';
 import { VotingPrivacyWarningComponent } from 'app/shared/components/voting-privacy-warning/voting-privacy-warning.component';
-import { PollState } from 'app/shared/models/poll/poll-constants';
-import { ViewPoll } from 'app/shared/models/poll/view-poll';
 import { infoDialogSettings } from 'app/shared/utils/dialog-settings';
 import { ViewAssignment } from 'app/site/assignments/models/view-assignment';
 import { BasePollComponent } from 'app/site/polls/components/base-poll.component';
 import { AssignmentPollDialogService } from '../../services/assignment-poll-dialog.service';
 import { AssignmentPollPdfService } from '../../services/assignment-poll-pdf.service';
-import { AssignmentPollService } from '../../services/assignment-poll.service';
 
 /**
  * Component for a single assignment poll. Used in assignment detail view
@@ -79,7 +76,6 @@ export class AssignmentPollComponent extends BasePollComponent<ViewAssignment> i
         choiceService: ChoiceService,
         repo: PollRepositoryService,
         pollDialog: AssignmentPollDialogService,
-        private pollService: AssignmentPollService,
         private formBuilder: FormBuilder,
         private pdfService: AssignmentPollPdfService,
         private operator: OperatorService,
@@ -108,14 +104,5 @@ export class AssignmentPollComponent extends BasePollComponent<ViewAssignment> i
 
     public openVotingWarning(): void {
         this.dialog.open(VotingPrivacyWarningComponent, infoDialogSettings);
-    }
-
-    protected onAfterUpdatePoll(poll: ViewPoll): void {
-        if (poll.state !== PollState.Finished && poll.state !== PollState.Published) {
-            return;
-        }
-        this.candidatesLabels = this.pollService.getChartLabels(poll);
-        const chartData = this.pollService.generateChartData(poll);
-        this.chartDataSubject.next(chartData);
     }
 }

--- a/client/src/app/site/assignments/services/assignment-pdf.service.ts
+++ b/client/src/app/site/assignments/services/assignment-pdf.service.ts
@@ -239,7 +239,7 @@ export class AssignmentPdfService {
             .map((singleResult: VotingResult) => {
                 const votingKey = this.translate.instant(this.pollKeyVerbose.transform(singleResult.vote));
                 const resultValue = this.parsePollNumber.transform(singleResult.amount);
-                const resultInPercent = this.pollPercentBase.transform(singleResult.amount, poll, 'assignment');
+                const resultInPercent = this.pollPercentBase.transform(singleResult.amount, poll);
                 return `${votingKey}${!!votingKey ? ': ' : ''}${resultValue} ${
                     singleResult.showPercent && resultInPercent ? resultInPercent : ''
                 }`;

--- a/client/src/app/site/polls/components/base-poll-dialog.component.ts
+++ b/client/src/app/site/polls/components/base-poll-dialog.component.ts
@@ -247,9 +247,9 @@ export abstract class BasePollDialogComponent extends BaseComponent implements O
             votesvalid: data.votesvalid,
             votesinvalid: data.votesinvalid,
             votescast: data.votescast,
-            amount_global_yes: data.amount_global_yes,
-            amount_global_no: data.amount_global_no,
-            amount_global_abstain: data.amount_global_abstain
+            amount_global_yes: data.global_option?.yes,
+            amount_global_no: data.global_option?.no,
+            amount_global_abstain: data.global_option?.abstain
         };
         for (const option of data.options) {
             const votes: any = {};

--- a/client/src/app/site/polls/components/base-poll.component.ts
+++ b/client/src/app/site/polls/components/base-poll.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
-import { BehaviorSubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { Id } from 'app/core/definitions/key-types';
 import { PollRepositoryService } from 'app/core/repositories/polls/poll-repository.service';
@@ -9,7 +9,6 @@ import { BasePollDialogService } from 'app/core/ui-services/base-poll-dialog.ser
 import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { PromptService } from 'app/core/ui-services/prompt.service';
-import { ChartData } from 'app/shared/components/charts/charts.component';
 import { PollState, PollType } from 'app/shared/models/poll/poll-constants';
 import { ViewPoll } from 'app/shared/models/poll/view-poll';
 import { BaseViewModel } from 'app/site/base/base-view-model';
@@ -21,8 +20,6 @@ import { BaseModelContextComponent } from 'app/site/base/components/base-model-c
 export abstract class BasePollComponent<C extends BaseViewModel = any> extends BaseModelContextComponent {
     private stateChangePendingSubject = new Subject<boolean>();
     public readonly stateChangePendingObservable = this.stateChangePendingSubject.asObservable();
-
-    public chartDataSubject: BehaviorSubject<ChartData> = new BehaviorSubject([]);
 
     public get poll(): ViewPoll<C> {
         return this._poll;

--- a/client/src/app/slides/poll/poll-slide-data.ts
+++ b/client/src/app/slides/poll/poll-slide-data.ts
@@ -1,3 +1,4 @@
+import { TitleInformationWithAgendaItem } from '../agenda_item_number';
 import { Fqid } from 'app/core/definitions/key-types';
 import {
     EntitledUsersEntry,
@@ -6,30 +7,31 @@ import {
     PollState,
     PollType
 } from 'app/shared/models/poll/poll-constants';
-import { PollData } from 'app/site/polls/services/poll.service';
 
-export interface GlobalOption {
+export interface SlideOption {
     yes?: number;
     no?: number;
     abstain?: number;
-}
-
-interface Option extends GlobalOption {
     text?: string;
-    content_object?: any;
+    content_object?: TitleInformation;
 }
 
-export interface PollSlideData extends PollData {
+interface TitleInformation extends TitleInformationWithAgendaItem {
+    collection: string;
+    [key: string]: any; // Each content object can have a variety of fields.
+}
+
+export interface PollSlideData {
     content_object_id: Fqid;
-    title_information: any;
+    title_information: TitleInformation;
     title: string;
     description: string;
     type: PollType;
     state: PollState;
     global_yes: boolean;
-    glboal_no: boolean;
+    global_no: boolean;
     global_abstain: boolean;
-    options: Option[];
+    options: SlideOption[];
 
     // These keys are only available, if poll/state == "published"
     entitled_users_at_stop: EntitledUsersEntry[];
@@ -39,5 +41,5 @@ export interface PollSlideData extends PollData {
     votesvalid: number;
     votesinvalid: number;
     votescast: number;
-    global_option: GlobalOption;
+    global_option: SlideOption;
 }

--- a/client/src/app/slides/poll/poll-slide.component.html
+++ b/client/src/app/slides/poll/poll-slide.component.html
@@ -1,15 +1,12 @@
 <ng-container *ngIf="data?.data">
     <div class="slidetitle">
-        <ng-container *ngIf="data.data.title_information">
-            <h1 class="title">{{ data.data.title_information }}</h1>
-            <h2 class="poll-title">{{ data.data.title }}</h2>
-        </ng-container>
-        <ng-container *ngIf="!data.data.title_information">
-            <h1 class="title">{{ data.data.title }}</h1>
+        <ng-container>
+            <h1 class="title">{{ title }}</h1>
+            <h2 class="poll-title" *ngIf="subtitle">{{ subtitle }}</h2>
         </ng-container>
     </div>
-    <div *ngIf="data.data.state === PollState.Published">
-        <os-motion-poll-detail-content *ngIf="pollContentObjectType==PollContentObjectType.Motion" [poll]="data.data" iconSize="gigantic"></os-motion-poll-detail-content>
-        <os-assignment-poll-detail-content *ngIf="pollContentObjectType==PollContentObjectType.Assignment" [poll]="data.data"></os-assignment-poll-detail-content>
+    <div *ngIf="polldata">
+        <os-motion-poll-detail-content *ngIf="pollContentObjectType==PollContentObjectType.Motion" [poll]="polldata" iconSize="gigantic"></os-motion-poll-detail-content>
+        <os-assignment-poll-detail-content *ngIf="pollContentObjectType==PollContentObjectType.Assignment" [poll]="polldata"></os-assignment-poll-detail-content>
     </div>
 </ng-container>

--- a/client/src/app/slides/slides.ts
+++ b/client/src/app/slides/slides.ts
@@ -77,8 +77,8 @@ export const Slides: SlideManifest[] = [
         path: 'poll',
         loadChildren: () => import('./poll/poll-slide.module').then(m => m.PollSlideModule),
         verboseName: 'Vote',
-        scaleable: false,
-        scrollable: false
+        scaleable: true,
+        scrollable: true
     },
     {
         path: 'projector_countdown',


### PR DESCRIPTION
Unified the usage of `PollData`: The poll services and
display-components only work with PollData, not ViewPoll. ViewPoll as
well as the data for the projector interfaces with PollData, so PollData
is the only single interface to operate on.

Also cleaned up the assignment/motion-poll service; Since there is just
one poll model in OS4, the data is much more streamedlined, so much code
could be moved into the poll service.

The slide for analog polls works; Maybe something else broke, but this
PR is more of a cleanup-type. Building upon this PR, the bugs/missing
logic can be fixed/implemented in a more clean fashion.