### PR TITLE
Adjusts tree-lists to the new nested modelling from the backend

### DIFF
--- a/client/src/app/core/repositories/base-repository.ts
+++ b/client/src/app/core/repositories/base-repository.ts
@@ -102,17 +102,6 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
     public abstract getVerboseName: (plural?: boolean) => string;
     public abstract getTitle: (viewModel: V) => string;
 
-    /**
-     * Maps the given relations (`relationDefinitions`) to their affected collections. This means,
-     * if a model of the collection updates, the relation needs to be updated.
-     *
-     * Attention: Some inherited repos might put other relations than RelationDefinition in here, so
-     * *always* check the type of the relation.
-     */
-    /*protected relationsByCollection: { [collection: string]: RelationDefinition<BaseViewModel>[] } = {};
-
-    protected reverseRelationsByCollection: { [collection: string]: ReverseRelationDefinition<BaseViewModel>[] } = {};*/
-
     protected relationsByKey: { [key: string]: Relation } = {};
 
     /**
@@ -186,7 +175,12 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
     }
 
     public updateViewModelListSubject(viewModels: V[]): void {
-        this.viewModelListSubject.next(viewModels.filter(m => m.canAccess()).sort(this.viewModelSortFn));
+        this.viewModelListSubject.next(
+            viewModels
+                .filter(m => m.canAccess())
+                .tap(models => this.tapViewModels(models))
+                .sort(this.viewModelSortFn)
+        );
     }
 
     public getListTitle: (viewModel: V) => string = (viewModel: V) => this.getTitle(viewModel);
@@ -402,6 +396,8 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         });
         this.modifiedIdsSubject.next(modelIds);
     }
+
+    protected tapViewModels(_viewModels: V[]): void {}
 
     protected raiseError = (error: string | Error) => {
         this.repositoryServiceCollector.errorService.showError(error);

--- a/client/src/app/shared/components/sorting-tree/sorting-tree.component.ts
+++ b/client/src/app/shared/components/sorting-tree/sorting-tree.component.ts
@@ -27,10 +27,10 @@ enum Direction {
  * Interface which extends the `OSFlatNode`.
  * Containing further information like start- and next-position.
  */
-interface ExFlatNode<T extends Identifiable & Displayable> extends FlatNode<T> {
+type ExFlatNode<T extends Identifiable & Displayable> = FlatNode<T> & {
     startPosition: number;
     nextPosition: number;
-}
+};
 
 /**
  * Interface to hold the start position and the current position.

--- a/client/src/app/shared/models/agenda/agenda-item.ts
+++ b/client/src/app/shared/models/agenda/agenda-item.ts
@@ -35,7 +35,14 @@ export class AgendaItem extends BaseModel<AgendaItem> {
     public is_internal: boolean;
     public duration: number; // in seconds
     public weight: number;
+    /**
+     * Client-calculated field: The level indicates the indentation of an agenda-item.
+     */
     public level: number;
+    /**
+     * Client-calculated field: The tree_weight indicates the position of an agenda-item in a list of agenda-items.
+     */
+    public tree_weight: number;
 
     public content_object_id: Fqid; // */agenda_item_id;
     public parent_id?: Id; // agenda_item/child_ids;

--- a/client/src/app/shared/overload-js-functions.ts
+++ b/client/src/app/shared/overload-js-functions.ts
@@ -22,6 +22,12 @@ declare global {
          * @param symmetric If all elements from both arrays, that are included only in one of them, should be returned.
          */
         difference(other: T[], symmetric?: boolean): T[];
+        /**
+         * A function to "tap" a whole array and take it to manipulate it or anything else.
+         *
+         * @param callbackFn A function that receives the whole array and has to return nothing.
+         */
+        tap(callbackFn: (self: T[]) => void): T[];
         mapToObject(f: (item: T) => { [key: string]: any }): { [key: string]: any };
     }
 
@@ -114,6 +120,14 @@ function overloadArrayFunctions(): void {
                 }
                 return aggr;
             }, {});
+        },
+        enumerable: false
+    });
+
+    Object.defineProperty(Array.prototype, 'tap', {
+        value: function <T>(callbackFn: (self: T[]) => void): T[] {
+            callbackFn(this);
+            return this;
         },
         enumerable: false
     });

--- a/client/src/app/site/agenda/services/agenda-pdf.service.ts
+++ b/client/src/app/site/agenda/services/agenda-pdf.service.ts
@@ -42,7 +42,7 @@ export class AgendaPdfService {
      * @returns definitions ready to be opened or exported via {@link PdfDocumentService}
      */
     public agendaListToDocDef(items: ViewAgendaItem[]): object {
-        const tree: OSTreeNode<ViewAgendaItem>[] = this.treeService.makeTree(items, 'weight', 'parent_id');
+        const tree: OSTreeNode<ViewAgendaItem>[] = this.treeService.makeSortedTree(items, 'weight', 'parent_id');
         const title = {
             text: this.translate.instant('Agenda'),
             style: 'title'

--- a/client/src/app/site/motions/services/motion-multiselect.service.ts
+++ b/client/src/app/site/motions/services/motion-multiselect.service.ts
@@ -334,7 +334,7 @@ export class MotionMultiselectService {
         const INSERT_AFTER = this.translate.instant('Insert after');
         const options = [TO_PARENT, INSERT_AFTER];
         const allMotions = this.repo.getViewModelList();
-        const tree = this.treeService.makeTree(allMotions, 'sort_weight', 'sort_parent_id');
+        const tree = this.treeService.makeSortedTree(allMotions, 'sort_weight', 'sort_parent_id');
         const itemsToMove = this.treeService.getBranchesFromTree(tree, motions);
         const partialTree = this.treeService.getTreeWithoutSelection(tree, motions);
         const availableMotions = this.treeService.getFlatItemsFromTree(partialTree);


### PR DESCRIPTION
Remakes the flat-nodes as proxies to have full access to the underlying item without access the 'item' previously.

Fixes #347 

@FinnStutzenstein Please review. I have thought about how I can implement the flat tree-like data from the backend and I came up with this solution. I rewrote the existing `FlatNode` to a proxy to have full access to the properties of an underlying model without accessing the `item`-property previously. That avoid creating a third datastructure, which fulfills such functionalities.