### PR TITLE
Allow meeting title to use multiple lines

### DIFF
--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.scss
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.scss
@@ -5,7 +5,7 @@
     position: relative;
 
     .mat-card-header {
-        height: 40px;
+        min-height: 40px;
         display: flex !important;
 
         .mat-card-header-text {
@@ -18,6 +18,7 @@
         }
 
         .align-right {
+            min-width: 80px;
             margin-left: auto;
         }
     }


### PR DESCRIPTION
Meeting title in committee detail page can have multiple lines
![image](https://user-images.githubusercontent.com/10233032/131835512-4cccf66b-3469-4351-925a-f3ca7f67e437.png)
