### PR TITLE
Users can forward to meetings within the same committee

### DIFF
--- a/client/src/app/core/repositories/management/committee-repository.service.ts
+++ b/client/src/app/core/repositories/management/committee-repository.service.ts
@@ -128,11 +128,11 @@ export class CommitteeRepositoryService
     ): CommitteeAction.PartialPayload {
         return {
             description: committee.description,
-            organization_tag_ids: committee.organization_tag_ids,
+            organization_tag_ids: committee.organization_tag_ids ?? [],
             user_ids: committee.user_ids,
             manager_ids: committee.manager_ids,
-            forward_to_committee_ids: committee.forward_to_committee_ids,
-            receive_forwardings_from_committee_ids: committee.receive_forwardings_from_committee_ids
+            forward_to_committee_ids: committee.forward_to_committee_ids ?? [],
+            receive_forwardings_from_committee_ids: committee.receive_forwardings_from_committee_ids ?? []
         };
     }
 }

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -68,8 +68,9 @@
                     formControlName="forward_to_committee_ids"
                     [multiple]="true"
                     [repo]="committeeRepo"
-                    [pipeFn]="getPipeFilterFn()"
                     [showChips]="false"
+                    [lazyLoading]="false"
+                    (selectionChanged)="onSelectionChanged($event)"
                 ></os-search-repo-selector>
             </mat-form-field>
 
@@ -79,8 +80,10 @@
                     formControlName="receive_forwardings_from_committee_ids"
                     [multiple]="true"
                     [repo]="committeeRepo"
-                    [pipeFn]="getPipeFilterFn()"
                     [showChips]="false"
+                    [lazyLoading]="false"
+                    [disableOptionWhenFn]="getDisableOptionWhenFn()"
+                    [tooltipFn]="getTooltipFn()"
                 ></os-search-repo-selector>
             </mat-form-field>
         </ng-container>

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
@@ -34,7 +34,7 @@ export class MeetingPreviewComponent {
     }
 
     public get userAmount(): number {
-        return this.meeting?.user_ids.length;
+        return this.meeting?.user_ids?.length || 0;
     }
 
     public get showUserAmount(): boolean {

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.html
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.html
@@ -47,11 +47,14 @@
             {{ noOptionsFoundLabel | translate }}
         </mat-option>
         <mat-option
-            *cdkVirtualFor="let selectedItem of getFilteredItemsBySearchValue()"
-            [value]="selectedItem.id"
-            (onSelectionChange)="onSelectionChange($event)"
+            #currentOption
+            *cdkVirtualFor="let selectableItem of getFilteredItemsBySearchValue()"
+            [value]="selectableItem.id"
+            [disabled]="disableOptionWhenFn(selectableItem)"
+            [matTooltip]="tooltipFn(selectableItem, currentOption)"
+            (onSelectionChange)="onSelectionChange(selectableItem, $event)"
         >
-            {{ selectedItem.getTitle() | translate }}
+            {{ selectableItem.getTitle() | translate }}
         </mat-option>
     </cdk-virtual-scroll-viewport>
 </mat-select>

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
@@ -10,7 +10,7 @@ import {
     TemplateRef
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { MatOptionSelectionChange } from '@angular/material/core';
+import { MatOption, MatOptionSelectionChange } from '@angular/material/core';
 import { MatSelect } from '@angular/material/select';
 
 import { Id } from 'app/core/definitions/key-types';
@@ -18,6 +18,11 @@ import { BaseFormControlComponent } from 'app/shared/components/base-form-contro
 import { ParentErrorStateMatcher } from 'app/shared/parent-error-state-matcher';
 import { Selectable } from '../../selectable';
 import { NotFoundDescriptionDirective } from '../../../directives/not-found-description.directive';
+
+export interface OsOptionSelectionChanged {
+    value: Selectable;
+    source: MatOption;
+}
 
 @Component({
     template: ''
@@ -77,10 +82,29 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormControlCo
     public transformPropagateFn?: (value: Selectable) => Selectable;
 
     /**
+     * Function to determine depending on a specific selectable item whether the item should be disabled.
+     *
+     * @returns `true` if the item should be disabled.
+     */
+    @Input()
+    public disableOptionWhenFn: (value: Selectable) => boolean = () => false;
+
+    /**
+     * Function to determine whether a tooltip should be displayed on the given option
+     *
+     * @returns either the string that will be displayed as tooltip or `null` if no tooltip should be displayed
+     */
+    @Input()
+    public tooltipFn: (value: Selectable, source: MatOption) => string | null = () => null;
+
+    /**
      * Emits the currently searched string.
      */
     @Output()
     public clickNotFound = new EventEmitter<string>();
+
+    @Output()
+    public selectionChanged = new EventEmitter<OsOptionSelectionChanged>();
 
     public searchValueForm: FormControl;
 
@@ -176,10 +200,10 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormControlCo
         }
     }
 
-    public onSelectionChange(change: MatOptionSelectionChange): void {
+    public onSelectionChange(value: Selectable, change: MatOptionSelectionChange): void {
         if (change.isUserInput && this.multiple) {
-            const value = change.source.value;
-            this.addOrRemoveId(value);
+            this.addOrRemoveId(value.id);
+            this.selectionChanged.emit({ value, source: change.source });
         }
     }
 

--- a/client/src/app/shared/components/search-selector/search-repo-selector/search-repo-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/search-repo-selector/search-repo-selector.component.ts
@@ -73,7 +73,7 @@ export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponen
     }
 
     public onContainerClick(event: MouseEvent): void {
-        if (!this.selectableItems) {
+        if (!this.selectableItems?.length) {
             this.doModelRequest().then(() => this.initItems());
         }
         super.onContainerClick(event);

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -5,7 +5,7 @@
             <div *ngIf="committee.meetings?.length">
                 <h4>{{ committee.name }}</h4>
                 <div *ngFor="let meeting of committee.meetings">
-                    <mat-radio-button [value]="meeting.id">
+                    <mat-radio-button [value]="meeting.id" [disabled]="isActiveMeeting(meeting)">
                         <os-icon-container
                             [swap]="true"
                             [icon]="isDefaultMeetingFor(meeting, committee) ? 'star' : 'star_outline'"

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -63,6 +63,10 @@ export class MotionForwardDialogComponent implements OnInit {
         return meeting.id === committee.default_meeting_id;
     }
 
+    public isActiveMeeting(meeting: PresenterMeeting): boolean {
+        return meeting.id === this.activeMeeting.meetingId;
+    }
+
     private getFirstDefaultMeetingId(): Id | null {
         const committees = this.meetingsSubject.value;
         return committees.find(committee => committee.default_meeting_id)?.default_meeting_id || null;


### PR DESCRIPTION
Now, users can select the same committee to forward/receive motions from that is currently being edited.

Fixes #487 