### PR TITLE
Updates some small things

### DIFF
--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -90,10 +90,12 @@ export class AutoupdateService {
      * Which component opens which stream?
      */
     public async simpleRequest(simpleRequest: SimplifiedModelRequest, description: string): Promise<ModelSubscription> {
-        const { request, collectionsToUpdate }: { request: ModelRequest; collectionsToUpdate: Collection[] } =
-            await this.modelRequestBuilder.build(simpleRequest);
-        console.log('autoupdate: new request:', description, simpleRequest, request);
-        return await this.request(request, description, collectionsToUpdate);
+        if (simpleRequest.ids.length > 0 && simpleRequest.ids.every(id => typeof id === 'number')) {
+            const { request, collectionsToUpdate }: { request: ModelRequest; collectionsToUpdate: Collection[] } =
+                await this.modelRequestBuilder.build(simpleRequest);
+            console.log('autoupdate: new request:', description, simpleRequest, request);
+            return await this.request(request, description, collectionsToUpdate);
+        }
     }
 
     private async request(

--- a/client/src/app/core/core-services/member.service.ts
+++ b/client/src/app/core/core-services/member.service.ts
@@ -7,6 +7,8 @@ import { HttpService } from './http.service';
 import { Id } from '../definitions/key-types';
 import { SimplifiedModelRequest } from './model-request-builder.service';
 import { UserRepositoryService } from '../repositories/users/user-repository.service';
+import { OperatorService } from './operator.service';
+import { OML } from './organization-permission';
 
 export interface GetUsersRequest {
     users: Id[];
@@ -16,7 +18,11 @@ export interface GetUsersRequest {
     providedIn: 'root'
 })
 export class MemberService {
-    public constructor(private userRepo: UserRepositoryService, private http: HttpService) {}
+    public constructor(
+        private userRepo: UserRepositoryService,
+        private http: HttpService,
+        private operator: OperatorService
+    ) {}
 
     public getMemberListObservable(): Observable<ViewUser[]> {
         return this.userRepo.getViewModelListObservable();
@@ -31,6 +37,9 @@ export class MemberService {
      * @returns A list of ids from users
      */
     public async fetchAllOrgaUsers(start_index: number = 0, entries: number = 10000): Promise<Id[]> {
+        if (!this.operator.hasOrganizationPermissions(OML.can_manage_users)) {
+            return [];
+        }
         const payload = [
             {
                 presenter: 'get_users',

--- a/client/src/app/management/components/committee-detail/committee-detail.component.html
+++ b/client/src/app/management/components/committee-detail/committee-detail.component.html
@@ -75,7 +75,7 @@
         </os-committee-meta-info>
 
         <!-- Member amount -->
-        <os-committee-meta-info icon="group" title="Members">
+        <os-committee-meta-info *ngIf="canManageUsers" icon="group" title="Members">
             {{ getMemberAmount(committee) }}
         </os-committee-meta-info>
 
@@ -97,6 +97,9 @@
 
     <!-- Meetings -->
     <div class="meeting-list">
+        <mat-card class="os-card" *ngIf="!getMeetingsSorted(committee).length">
+            {{ 'There are no meetings yet' | translate }}
+        </mat-card>
         <os-meeting-preview
             *ngFor="let meeting of getMeetingsSorted(committee)"
             class="meeting-preview-card"

--- a/client/src/app/management/components/committee-detail/committee-detail.component.ts
+++ b/client/src/app/management/components/committee-detail/committee-detail.component.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs';
 import { MemberService } from 'app/core/core-services/member.service';
 import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
 import { OperatorService } from 'app/core/core-services/operator.service';
-import { CML } from 'app/core/core-services/organization-permission';
+import { CML, OML } from 'app/core/core-services/organization-permission';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { PromptService } from 'app/core/ui-services/prompt.service';
@@ -35,6 +35,10 @@ export class CommitteeDetailComponent extends BaseModelContextComponent implemen
         return this.operator.hasCommitteePermissions(this.committeeId, CML.can_manage);
     }
 
+    public get canManageUsers(): boolean {
+        return this.operator.hasOrganizationPermissions(OML.can_manage_users);
+    }
+
     public constructor(
         protected componentServiceCollector: ComponentServiceCollector,
         private route: ActivatedRoute,
@@ -56,7 +60,7 @@ export class CommitteeDetailComponent extends BaseModelContextComponent implemen
     }
 
     public async ngOnInit(): Promise<void> {
-        await super.ngOnInit();
+        super.ngOnInit();
     }
 
     public onCreateMeeting(): void {

--- a/client/src/app/management/components/committee-list/committee-list.component.html
+++ b/client/src/app/management/components/committee-list/committee-list.component.html
@@ -9,7 +9,8 @@
     </div>
 
     <!-- Menu -->
-    <div class="menu-slot">
+    <!-- Only organization managers can do something -->
+    <div class="menu-slot" *osOmlPerms="OML.can_manage_organization">
         <button type="button" mat-icon-button [matMenuTriggerFor]="committeeMenu">
             <mat-icon>more_vert</mat-icon>
         </button>
@@ -18,7 +19,8 @@
     <!-- Multiselect info -->
     <div class="central-info-slot">
         <button mat-icon-button (click)="toggleMultiSelect()"><mat-icon>arrow_back</mat-icon></button>
-        <span>{{ selectedRows.length }}&nbsp;</span><span>{{ 'selected' | translate }}</span>
+        <span>{{ selectedRows.length }}&nbsp;</span>
+        <span>{{ 'selected' | translate }}</span>
     </div>
 </os-head-bar>
 

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.html
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.html
@@ -23,8 +23,8 @@
             <!-- location -->
             <span>
                 {{ location }}
+                <span *ngIf="location && (meeting.start_time || meeting.end_time)">,&nbsp;</span>
             </span>
-
             <!-- date -->
             <span>
                 <!-- TODO: CLEANUP: copied from dashboard -->

--- a/client/src/app/management/components/member-edit/member-edit.component.ts
+++ b/client/src/app/management/components/member-edit/member-edit.component.ts
@@ -10,6 +10,7 @@ import { ComponentServiceCollector } from 'app/core/ui-services/component-servic
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
 import { ViewUser } from 'app/site/users/models/view-user';
+import { ViewCommittee } from '../../models/view-committee';
 
 @Component({
     selector: 'os-member-edit',
@@ -121,15 +122,15 @@ export class MemberEditComponent extends BaseModelContextComponent implements On
     }
 
     public getUserCommitteeManagementLevels(): string {
-        const committeesToManage = [];
+        const committeesToManage: ViewCommittee[] = [];
         for (const id of this.user.committee_$_management_level) {
             if (this.user.committee_management_level(id) === CML.can_manage) {
                 committeesToManage.push(this.committeeRepo.getViewModel(id));
             }
         }
-        return this.user.committee_$_management_level
-            .filter(id => this.user.committee_management_level(id) === CML.can_manage)
-            .map(id => this.committeeRepo.getViewModel(id).getTitle())
+        return committeesToManage
+            .filter(committee => !!committee)
+            .map(committee => committee.getTitle())
             .join(', ');
     }
 

--- a/client/src/app/management/components/member-list/member-list.component.html
+++ b/client/src/app/management/components/member-list/member-list.component.html
@@ -12,7 +12,8 @@
     <!-- Multiselect info -->
     <div class="central-info-slot">
         <button mat-icon-button (click)="toggleMultiSelect()"><mat-icon>arrow_back</mat-icon></button>
-        <span>{{ selectedRows.length }}&nbsp;</span><span>{{ 'selected' | translate }}</span>
+        <span>{{ selectedRows.length }}&nbsp;</span>
+        <span>{{ 'selected' | translate }}</span>
     </div>
 </os-head-bar>
 
@@ -48,8 +49,14 @@
                 [noWrap]="true"
             >
                 <span *ngFor="let committee of user.committees; last as last">
-                    {{ committee.name | translate }}<span *ngIf="!last">,&nbsp;</span>
+                    {{ committee.name | translate }}
+                    <span *ngIf="!last">,&nbsp;</span>
                 </span>
+            </os-icon-container>
+        </div>
+        <div *osOmlPerms="OML.can_manage_users; and: getOmlByUser(user)" class="flex-center">
+            <os-icon-container icon="engineering">
+                {{ getOmlByUser(user) | translate }}
             </os-icon-container>
         </div>
     </div>

--- a/client/src/app/management/components/member-list/member-list.component.ts
+++ b/client/src/app/management/components/member-list/member-list.component.ts
@@ -5,7 +5,7 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { PblColumnDefinition } from '@pebula/ngrid';
 
 import { MemberService } from 'app/core/core-services/member.service';
-import { OML } from 'app/core/core-services/organization-permission';
+import { OML, getOmlVerboseName } from 'app/core/core-services/organization-permission';
 import { Id } from 'app/core/definitions/key-types';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
@@ -18,6 +18,7 @@ import { MemberSortService } from 'app/management/services/member-sort.service';
 import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component';
 import { BaseUserHeadersAndVerboseNames } from 'app/site/users/base/base-user.constants';
 import { ViewUser } from 'app/site/users/models/view-user';
+import { OMLMapping } from '../../../core/core-services/organization-permission';
 
 @Component({
     selector: 'os-members',
@@ -111,6 +112,10 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
             })),
             `${this.translate.instant('Members')}.csv`
         );
+    }
+
+    public getOmlByUser(user: ViewUser): string {
+        return getOmlVerboseName(user.organization_management_level as keyof OMLMapping);
     }
 
     private async loadUsers(start_index: number = 0, entries: number = 10000): Promise<void> {


### PR DESCRIPTION
- Removes the "more menu" on the committee-list if a user's oml is lower than OML.can_manage_organization
- Adds a comma between location and date in the meeting-preview
- Removes the amount of members in a committee in the committee-detail-view if a user's oml is lower than OML.can_manage_users
- Adds the organization management level to every member in the member-list
- Prevents throwing an error for a committee-manager if the committee is "null" (in the member-detail-view)