### PR TITLE
Implements archiving and unarchiving of meetings

### DIFF
--- a/client/src/app/core/actions/meeting-action.ts
+++ b/client/src/app/core/actions/meeting-action.ts
@@ -14,6 +14,8 @@ export namespace MeetingAction {
     export const UNSET_LOGO = 'meeting.unset_logo';
     export const IMPORT = 'meeting.import';
     export const CLONE = 'meeting.clone';
+    export const ARCHIVE = 'meeting.archive';
+    export const UNARCHIVE = 'meeting.unarchive';
 
     interface MetaPayload {
         description?: string;
@@ -193,4 +195,6 @@ export namespace MeetingAction {
     export interface ClonePayload {
         meeting_id: Id;
     }
+    export interface ArchivePayload extends Identifiable {}
+    export interface UnarchivePayload extends Identifiable {}
 }

--- a/client/src/app/core/core-services/archive-status.service.ts
+++ b/client/src/app/core/core-services/archive-status.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+/**
+ * A service to hold information about the `archive`-status of a meeting.
+ * Necessary, because there is a circular dependency if the `ActionService` injects the `ActiveMeetingService`.
+ */
+@Injectable({
+    providedIn: 'root'
+})
+export class ArchiveStatusService {
+    public get isArchived(): boolean {
+        return this.isArchivedEvent.value;
+    }
+
+    public readonly isArchivedEvent = new BehaviorSubject<boolean>(false);
+}

--- a/client/src/app/core/core-services/organization.service.ts
+++ b/client/src/app/core/core-services/organization.service.ts
@@ -30,6 +30,10 @@ export class OrganizationService {
         return this.organizationSubject.value;
     }
 
+    public get currentActiveMeetings(): number {
+        return this.organization.active_meeting_ids?.length || 0;
+    }
+
     private organizationSubject = new BehaviorSubject<ViewOrganization | null>(null);
 
     private modelSubscription: ModelSubscription | null = null;

--- a/client/src/app/core/errors/process-error.ts
+++ b/client/src/app/core/errors/process-error.ts
@@ -1,0 +1,62 @@
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
+import { HttpErrorResponse } from '@angular/common/http';
+
+interface ErrorMessageResponse {
+    message: string;
+    success: boolean;
+}
+
+function isErrorMessageResponse(obj: any): obj is ErrorMessageResponse {
+    return (
+        obj &&
+        typeof obj === 'object' &&
+        typeof obj.message === 'string' &&
+        (obj as ErrorMessageResponse).success === false
+    );
+}
+
+export class ProcessError extends Error {
+    public constructor(description: unknown) {
+        // Unfortunately, this must be handled before the `super`-call to have the dedicated message.
+        const handleErrorDescription = () => {
+            let error = _('Error') + ': ';
+            // If the error is a string already, return it.
+            if (typeof description === 'string') {
+                return error + _(description);
+            }
+
+            // If the error is no HttpErrorResponse, it's not clear what is wrong.
+            if (!(description instanceof HttpErrorResponse)) {
+                console.error('Unknown error thrown by the http client: ', description);
+                error += _('An unknown error occurred.');
+                return error;
+            }
+
+            if (!description.error) {
+                error += _("The server didn't respond.");
+            } else if (typeof description.error === 'object') {
+                if (isErrorMessageResponse(description.error)) {
+                    error += description.error.message;
+                } else {
+                    const errorList = Object.keys(description.error).map(key => {
+                        const capitalizedKey = key.charAt(0).toUpperCase() + key.slice(1);
+                        const message = description.error[key];
+                        return `${_(capitalizedKey)}: ${message}`;
+                    });
+                    error = errorList.join(', ');
+                }
+            } else if (typeof description.error === 'string') {
+                error += _(description.error);
+            } else if (description.status === 500) {
+                error += _('A server error occured. Please contact your system administrator.');
+            } else if (description.status > 500) {
+                error += _('The server could not be reached.') + ` (${description.status})`;
+            } else {
+                error += description.message;
+            }
+
+            return error;
+        };
+        super(handleErrorDescription());
+    }
+}

--- a/client/src/app/core/repositories/management/organization-repository.service.ts
+++ b/client/src/app/core/repositories/management/organization-repository.service.ts
@@ -21,14 +21,15 @@ export class OrganizationRepositoryService extends BaseRepository<ViewOrganizati
         this.translate.instant(plural ? 'Organizations' : 'Organization');
 
     public getFieldsets(): Fieldsets<Organization> {
-        const coreFieldset: (keyof Organization)[] = ['name', 'description'];
+        const coreFieldset: (keyof Organization)[] = ['name', 'description', 'active_meeting_ids'];
         const settingsFieldset: (keyof (OrganizationSetting & Organization))[] = coreFieldset.concat(
             'legal_notice',
             'privacy_policy',
             'login_text',
             'theme',
             'enable_electronic_voting',
-            'reset_password_verbose_errors'
+            'reset_password_verbose_errors',
+            'limit_of_meetings'
         );
         const detailFieldset: (keyof Organization)[] = coreFieldset.concat('committee_ids', 'organization_tag_ids');
         return {

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -134,6 +134,13 @@ export const RELATIONS: Relation[] = [
         MField: 'organization',
         isFullList: true
     }),
+    ...makeM2O({
+        OViewModel: ViewOrganization,
+        MViewModel: ViewMeeting,
+        OField: 'active_meetings',
+        MField: 'is_active_in_organization'
+    }),
+    // ########## Organization tags
     ...makeGenericM2M<ViewOrganizationTag, HasOrganizationTags>({
         viewModel: ViewOrganizationTag,
         possibleViewModels: [ViewCommittee, ViewMeeting],

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -129,10 +129,9 @@ export class UserRepositoryService
             'comment',
             'default_password'
         ]);
-        const orgaListFields = listFields.concat(['committee_ids']);
+        const orgaListFields = listFields.concat(['committee_ids', 'organization_management_level']);
         const orgaEditFields = orgaListFields.concat([
             'default_password',
-            'organization_management_level',
             { templateField: 'committee_$_management_level' }
         ]);
 

--- a/client/src/app/core/ui-services/banner.service.ts
+++ b/client/src/app/core/ui-services/banner.service.ts
@@ -48,7 +48,7 @@ export class BannerService {
      * @param toAdd the banner to add
      */
     public addBanner(toAdd: BannerDefinition): void {
-        if (!this.activeBanners.value.find(banner => banner === toAdd)) {
+        if (!this.activeBanners.value.find(banner => JSON.stringify(banner) === JSON.stringify(toAdd))) {
             const newBanners = this.activeBanners.value.concat([toAdd]);
             this.activeBanners.next(newBanners);
         }
@@ -80,7 +80,9 @@ export class BannerService {
      */
     public removeBanner(toRemove: BannerDefinition): void {
         if (toRemove) {
-            const newBanners = this.activeBanners.value.filter(banner => banner !== toRemove);
+            const newBanners = this.activeBanners.value.filter(
+                banner => JSON.stringify(banner) !== JSON.stringify(toRemove)
+            );
             this.activeBanners.next(newBanners);
         }
     }

--- a/client/src/app/management/components/committee-detail/committee-detail.component.ts
+++ b/client/src/app/management/components/committee-detail/committee-detail.component.ts
@@ -15,6 +15,7 @@ import { ViewCommittee } from 'app/management/models/view-committee';
 import { ViewMeeting } from 'app/management/models/view-meeting';
 import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
 import { ViewUser } from 'app/site/users/models/view-user';
+import { MeetingRepositoryService } from '../../../core/repositories/management/meeting-repository.service';
 
 const ForwardLabel = _('Forward motions to');
 const ReceiveLabel = _('Receive motions from');
@@ -46,7 +47,8 @@ export class CommitteeDetailComponent extends BaseModelContextComponent implemen
         private operator: OperatorService,
         private committeeRepo: CommitteeRepositoryService,
         private promptService: PromptService,
-        private memberService: MemberService
+        private memberService: MemberService,
+        private meetingRepo: MeetingRepositoryService
     ) {
         super(componentServiceCollector);
         this.subscriptions.push(

--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -16,7 +16,7 @@
     <form class="committee-form" [formGroup]="committeeForm" (ngSubmit)="onSubmit()" *ngIf="committeeForm">
         <mat-form-field>
             <mat-label>{{ 'Title' | translate }}</mat-label>
-            <input matInput formControlName="name" required />
+            <input matInput formControlName="name" required osAutofocus />
             <mat-error>{{ 'The title is required' | translate }}</mat-error>
         </mat-form-field>
 

--- a/client/src/app/management/components/dashboard/dashboard.component.html
+++ b/client/src/app/management/components/dashboard/dashboard.component.html
@@ -101,8 +101,13 @@
         <div class="meeting-box--left" *ngIf="!isPhone">
             <ng-container *ngTemplateOutlet="meetingTime; context: { meeting: meeting }"></ng-container>
         </div>
-        <div class="meeting-box--mid">
-            {{ meeting.name }}
+        <div class="meeting-box--mid one-line">
+            <mat-icon *ngIf="meeting.isArchived" matTooltip="{{ 'This meeting is archived' | translate }}">
+                archive
+            </mat-icon>
+            <span class="one-line" [matTooltip]="meeting.name">
+                {{ meeting.name }}
+            </span>
 
             <div *ngIf="isPhone" class="meeting-box--information-phone">
                 <span>

--- a/client/src/app/management/components/dashboard/dashboard.component.scss
+++ b/client/src/app/management/components/dashboard/dashboard.component.scss
@@ -102,6 +102,9 @@
     &--mid {
         font-size: 18px;
         flex: 3;
+
+        display: flex;
+        align-items: center;
     }
 
     &--information-phone {

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.html
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.html
@@ -1,20 +1,25 @@
 <mat-card class="meeting-prev">
-    <mat-card-header class="background-accent">
+    <mat-card-header
+        [ngClass]="{ 'background-accent': meeting.isActive, 'background-dark-brighter': meeting.isArchived }"
+    >
         <mat-card-title class="break-word">
             {{ title }}
         </mat-card-title>
 
-        <span *osCmlPerms="CML.can_manage; committeeId: committee.id" class="align-right">
-            <button
-                mat-icon-button
-                (click)="toggleDefaultMeeting()"
-                matTooltip="{{ (isDefaultMeeting ? 'Is default meeting' : 'Set as default meeting') | translate }}"
-            >
-                <mat-icon>{{ isDefaultMeeting ? 'star' : 'star_outline' }}</mat-icon>
-            </button>
-            <button type="button" mat-icon-button [matMenuTriggerFor]="meetingMenu">
-                <mat-icon>more_vert</mat-icon>
-            </button>
+        <span class="align-right">
+            <mat-label class="archived-label" *ngIf="meeting.isArchived">{{ 'Archived' | translate }}</mat-label>
+            <ng-container *osCmlPerms="CML.can_manage; committeeId: committee.id">
+                <button
+                    mat-icon-button
+                    (click)="toggleDefaultMeeting()"
+                    matTooltip="{{ (isDefaultMeeting ? 'Is default meeting' : 'Set as default meeting') | translate }}"
+                >
+                    <mat-icon>{{ isDefaultMeeting ? 'star' : 'star_outline' }}</mat-icon>
+                </button>
+                <button type="button" mat-icon-button [matMenuTriggerFor]="meetingMenu">
+                    <mat-icon>more_vert</mat-icon>
+                </button>
+            </ng-container>
         </span>
     </mat-card-header>
     <mat-card-content class="prev-content">
@@ -53,14 +58,17 @@
         <mat-icon>edit</mat-icon>
         <span>{{ 'Edit' | translate }}</span>
     </a>
-    <button mat-menu-item (click)="onDuplicate()">
+    <button mat-menu-item *ngIf="meeting.isActive" disabled (click)="onDuplicate()">
         <mat-icon>file_copy</mat-icon>
         <span>{{ 'Duplicate' | translate }}</span>
     </button>
-    <!-- TODO Archive is not yet implemented -->
-    <button mat-menu-item disabled (click)="onArchive()">
+    <button mat-menu-item *ngIf="meeting.isActive" (click)="onArchive()">
         <mat-icon>archive</mat-icon>
         <span>{{ 'Archive' | translate }}</span>
+    </button>
+    <button mat-menu-item *osOmlPerms="OML.superadmin; and: meeting.isArchived" (click)="onUnarchive()">
+        <mat-icon>unarchive</mat-icon>
+        <span>{{ 'Unarchive' | translate }}</span>
     </button>
     <mat-divider></mat-divider>
     <button mat-menu-item class="red-warning-text" (click)="onDeleteMeeting()">

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.scss
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.scss
@@ -9,6 +9,7 @@
         display: flex !important;
 
         .mat-card-header-text {
+            flex: 1;
             margin-top: auto !important;
             margin-bottom: auto !important;
 
@@ -45,4 +46,10 @@
 
 .prev-content {
     padding: 0 20px;
+}
+
+.archived-label {
+    padding: 6px;
+    border: 1px solid;
+    border-radius: 4px;
 }

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
@@ -8,6 +8,7 @@ import { PromptService } from 'app/core/ui-services/prompt.service';
 import { ViewMeeting } from 'app/management/models/view-meeting';
 import { CommitteeRepositoryService } from '../../../core/repositories/management/committee-repository.service';
 import { ViewCommittee } from '../../models/view-committee';
+import { OML } from '../../../core/core-services/organization-permission';
 
 @Component({
     selector: 'os-meeting-preview',
@@ -17,6 +18,7 @@ import { ViewCommittee } from '../../models/view-committee';
 })
 export class MeetingPreviewComponent {
     public readonly CML = CML;
+    public readonly OML = OML;
 
     @Input() public meeting: ViewMeeting = null;
     @Input() public committee: ViewCommittee | null = null;
@@ -58,10 +60,17 @@ export class MeetingPreviewComponent {
 
         const confirmed = await this.promptService.open(title, content);
         if (confirmed) {
-            /**
-             * seems archive was not yet implemented
-             */
-            // await this.meetingRepo.archive(this.meeting);
+            await this.meetingRepo.archive(this.meeting);
+        }
+    }
+
+    public async onUnarchive(): Promise<void> {
+        const title = `${this.translate.instant('Unarchive meeting')} "${this.title}"`;
+        const content = this.translate.instant('Are you sure you want to unarchive this meeting?');
+
+        const confirmed = await this.promptService.open(title, content);
+        if (confirmed) {
+            await this.meetingRepo.unarchive(this.meeting);
         }
     }
 

--- a/client/src/app/management/components/orga-settings/orga-settings.component.html
+++ b/client/src/app/management/components/orga-settings/orga-settings.component.html
@@ -42,7 +42,7 @@
         <mat-label>{{ 'Privacy Policy' | translate }}</mat-label>
         <editor formControlName="privacy_policy" [init]="tinyMceSettings"></editor>
 
-        <ng-container *osOmlPerms="OML.superadmin">
+        <div class="superadmin-place" *osOmlPerms="OML.superadmin">
             <!-- electronic voting -->
             <section>
                 <mat-checkbox formControlName="enable_electronic_voting">
@@ -55,6 +55,20 @@
                     {{ 'Allow verbose error messages for reset password process' | translate }}
                 </mat-checkbox>
             </section>
-        </ng-container>
+            <section>
+                <mat-form-field>
+                    <mat-label>{{ 'Limit of active meetings' | translate }}</mat-label>
+                    <input
+                        matInput
+                        type="number"
+                        formControlName="limit_of_meetings"
+                        min="0"
+                        [osOnlyNumber]="true"
+                        required
+                    />
+                    <mat-hint>{{ '"0" means an unlimited number of active meetings' | translate }}</mat-hint>
+                </mat-form-field>
+            </section>
+        </div>
     </form>
 </mat-card>

--- a/client/src/app/management/components/orga-settings/orga-settings.component.scss
+++ b/client/src/app/management/components/orga-settings/orga-settings.component.scss
@@ -4,3 +4,12 @@
     max-width: 100%;
     margin: auto;
 }
+
+.superadmin-place {
+    section {
+        mat-form-field {
+            display: block;
+            margin: 6px 0;
+        }
+    }
+}

--- a/client/src/app/management/components/orga-settings/orga-settings.component.ts
+++ b/client/src/app/management/components/orga-settings/orga-settings.component.ts
@@ -74,7 +74,8 @@ export class OrgaSettingsComponent extends BaseModelContextComponent implements 
                 rawSettingsForm = {
                     ...rawSettingsForm,
                     reset_password_verbose_errors: [this.currentOrgaSettings.reset_password_verbose_errors],
-                    enable_electronic_voting: [this.currentOrgaSettings.enable_electronic_voting]
+                    enable_electronic_voting: [this.currentOrgaSettings.enable_electronic_voting],
+                    limit_of_meetings: [this.currentOrgaSettings.limit_of_meetings ?? 0]
                 };
             }
             this.orgaSettingsForm = this.formBuilder.group(rawSettingsForm);
@@ -98,10 +99,11 @@ export class OrgaSettingsComponent extends BaseModelContextComponent implements 
     }
 
     private updateForm(viewOrga: ViewOrganization): void {
-        if (this.orgaSettingsForm) {
-            const patchMeeting: any = viewOrga.organization;
-            this.orgaSettingsForm.patchValue(patchMeeting);
+        if (!this.orgaSettingsForm) {
+            this.createForm();
         }
+        const patchMeeting: any = viewOrga.organization;
+        this.orgaSettingsForm.patchValue(patchMeeting);
     }
 
     public onSubmit(): void {

--- a/client/src/app/management/models/view-meeting.ts
+++ b/client/src/app/management/models/view-meeting.ts
@@ -32,6 +32,7 @@ import { ViewPersonalNote } from 'app/site/users/models/view-personal-note';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { ViewCommittee } from './view-committee';
 import { HasOrganizationTags } from './view-organization-tag';
+import { ViewOrganization } from './view-organization';
 
 export interface HasMeeting {
     meeting: ViewMeeting;
@@ -53,6 +54,15 @@ export class ViewMeeting extends BaseViewModel<Meeting> {
     public get userAmount(): number {
         return this.user_ids?.length || 0;
     }
+
+    public get isArchived(): boolean {
+        return !this.is_active_in_organization_id;
+    }
+
+    public get isActive(): boolean {
+        return !!this.is_active_in_organization_id;
+    }
+
     public static COLLECTION = Meeting.COLLECTION;
 
     public static ACCESSIBILITY_FIELD: keyof Meeting = 'description';
@@ -112,5 +122,6 @@ interface IMeetingRelations {
     projections: ViewProjection[];
     default_group: ViewGroup;
     admin_group: ViewGroup;
+    is_active_in_organization: ViewOrganization;
 }
 export interface ViewMeeting extends Meeting, IMeetingRelations, HasProjectorTitle, HasOrganizationTags {}

--- a/client/src/app/management/models/view-organization.ts
+++ b/client/src/app/management/models/view-organization.ts
@@ -3,6 +3,7 @@ import { BaseViewModel } from 'app/site/base/base-view-model';
 import { ViewCommittee } from './view-committee';
 import { ViewOrganizationTag } from './view-organization-tag';
 import { ViewResource } from './view-resource';
+import { ViewMeeting } from './view-meeting';
 
 export class ViewOrganization extends BaseViewModel<Organization> {
     public static COLLECTION = Organization.COLLECTION;
@@ -15,6 +16,7 @@ export class ViewOrganization extends BaseViewModel<Organization> {
 interface IOrganizationRelations {
     committees: ViewCommittee[];
     resources: ViewResource[];
-    organization_tags: ViewOrganizationTag;
+    organization_tags: ViewOrganizationTag[];
+    active_meetings: ViewMeeting[];
 }
 export interface ViewOrganization extends Organization, IOrganizationRelations {}

--- a/client/src/app/shared/components/account-button/account-button.component.html
+++ b/client/src/app/shared/components/account-button/account-button.component.html
@@ -15,6 +15,7 @@
         <div (mouseenter)="closeLanguageMenu()">
             <div class="username-wrapper">
                 <div class="username">{{ username }}</div>
+                <div *ngIf="user" class="subtitle">{{ getOmlVerboseName() | translate }}</div>
                 <div *ngIf="user" class="subtitle structure-level">{{ user.structure_level() }}</div>
             </div>
 

--- a/client/src/app/shared/components/account-button/account-button.component.ts
+++ b/client/src/app/shared/components/account-button/account-button.component.ts
@@ -14,6 +14,7 @@ import { largeDialogSettings } from 'app/shared/utils/dialog-settings';
 import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { Router } from '@angular/router';
+import { getOmlVerboseName } from '../../../core/core-services/organization-permission';
 
 @Component({
     selector: 'os-account-button',
@@ -126,6 +127,10 @@ export class AccountButtonComponent extends BaseModelContextComponent implements
         this._languageTrigger?.closeMenu();
     }
 
+    public getOmlVerboseName(): string {
+        return getOmlVerboseName(this.user?.organization_management_level);
+    }
+
     private onOperatorUpdate(): void {
         this.isLoggedIn = !this.operator.isAnonymous;
         this.username = this.isLoggedIn ? this.operator.shortName : this.translate.instant('Guest');
@@ -145,7 +150,7 @@ export class AccountButtonComponent extends BaseModelContextComponent implements
         this.requestModels({
             viewModelCtor: ViewUser,
             ids: [this._userId],
-            fieldset: ['is_present_in_meeting_ids', 'can_change_own_password']
+            fieldset: ['is_present_in_meeting_ids', 'can_change_own_password', 'organization_management_level']
         });
 
         if (this._userSubscription) {

--- a/client/src/app/shared/components/banner/banner.component.html
+++ b/client/src/app/shared/components/banner/banner.component.html
@@ -14,9 +14,13 @@
         <a (click)="timeTravel.resumeTime()">{{ 'Exit' | translate }}</a>
     </ng-container>
     <ng-container *ngSwitchDefault>
-        <a class="banner-link" [routerLink]="banner.link" [style.cursor]="banner.link ? 'pointer' : 'default'">
+        <a
+            class="banner-link flex-center"
+            [routerLink]="banner.link"
+            [style.cursor]="banner.link ? 'pointer' : 'default'"
+        >
             <mat-icon>{{ banner.icon }}</mat-icon>
-            <span>{{ banner.text }}</span>
+            <span>{{ banner.text | translate }}</span>
             <div *ngIf="banner.subText">
                 {{ banner.subText | translate }}
             </div>

--- a/client/src/app/shared/components/sidenav/sidenav.component.scss
+++ b/client/src/app/shared/components/sidenav/sidenav.component.scss
@@ -3,8 +3,6 @@
     height: 100%;
 
     .background-dark {
-        background: #4f4f4f;
-
         .copyright-link {
             color: white;
         }

--- a/client/src/app/shared/directives/only-number.directive.ts
+++ b/client/src/app/shared/directives/only-number.directive.ts
@@ -55,7 +55,6 @@ export class OnlyNumberDirective implements OnInit {
      * ^: starts with
      * $: ends
      */
-    // private regExp = new RegExp('^([1-9][0-9]*|0)?$');
     private regExp: RegExp;
 
     private allowedKeys = ['Backspace', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Tab'];

--- a/client/src/app/shared/models/event-management/meeting.ts
+++ b/client/src/app/shared/models/event-management/meeting.ts
@@ -218,6 +218,7 @@ export class Meeting extends BaseModel<Meeting> {
     public admin_group_id: Id; // group/admin_group_for_meeting_id;
 
     public organization_tag_ids: Id[]; // (organization_tag/meeting_ids)[];
+    public is_active_in_organization_id: Id; // (organization/active_meeting_ids)[];
 
     public constructor(input?: any) {
         super(Meeting.COLLECTION, input);

--- a/client/src/app/shared/models/event-management/organization.ts
+++ b/client/src/app/shared/models/event-management/organization.ts
@@ -10,6 +10,7 @@ export interface OrganizationSetting {
     theme: string;
     reset_password_verbose_errors: boolean;
     enable_electronic_voting: boolean;
+    limit_of_meetings: number;
 }
 
 export class Organization extends BaseModel<Organization> {
@@ -19,18 +20,10 @@ export class Organization extends BaseModel<Organization> {
     public name: string;
     public description: string;
 
-    // Configs
-    public legal_notice: string;
-    public privacy_policy: string;
-    public login_text: string;
-    public theme: string;
-    public custom_translations: JSON[];
-    public reset_password_verbose_errors: boolean;
-    public enable_electronic_voting: boolean;
-
     public committee_ids: Id[]; // (committee/organization_id)[];
     public resource_ids: Id[]; // (resource/organization_id)[];
-    public organization_tag_ids: Id[]; // (organization_tag/organization_id)[]
+    public organization_tag_ids: Id[]; // (organization_tag/organization_id)[];
+    public active_meeting_ids: Id[]; // (meeting/is_active_in_organization_id);
 
     public constructor(input?: any) {
         super(Organization.COLLECTION, input);

--- a/client/src/app/shared/models/users/user.ts
+++ b/client/src/app/shared/models/users/user.ts
@@ -4,6 +4,7 @@ import { CML } from 'app/core/core-services/organization-permission';
 import { Id } from 'app/core/definitions/key-types';
 import { BaseDecimalModel } from '../base/base-decimal-model';
 import { HasProjectionIds } from '../base/has-projectable-ids';
+import { OMLMapping } from '../../../core/core-services/organization-permission';
 
 /**
  * Iterable pre selection of genders (sexes)
@@ -60,7 +61,7 @@ export class User extends BaseDecimalModel<User> {
     public projection_$_ids: any[];
     public current_projector_$_ids: any[];
 
-    public organization_management_level: string;
+    public organization_management_level: keyof OMLMapping;
     public committee_$_management_level: Id[];
 
     public get isVoteWeightOne(): boolean {

--- a/client/src/assets/styles/global-components-style.scss
+++ b/client/src/assets/styles/global-components-style.scss
@@ -222,8 +222,25 @@
     }
 
     /**
+    * Background styles used for the global theme
+    */
+    .background-dark {
+        background: #4f4f4f;
+        color: white;
+    }
+
+    .background-dark-brighter {
+        background: #6f6f6f;
+        color: white;
+    }
+
+    .background-dark-brightest {
+        background: #8f8f8f;
+    }
+
+    /**
      * CLEANUP:
-     * whole themes can be replaced using classes like this one
+     * whole theme-related stylesheets can be replaced using classes like this one
      */
     .background-default {
         background: mat.get-color-from-palette($background, background);
@@ -243,6 +260,10 @@
     .background-accent {
         background: mat.get-color-from-palette($accent) !important;
         color: mat.get-color-from-palette($accent, default-contrast) !important;
+    }
+
+    .background-warn {
+        background: mat.get-color-from-palette($warn) !important;
     }
 
     .background-card {


### PR DESCRIPTION
Fixes #465 

There is an issue for the AU-service: Currently, only users with the `OML.superadmin` receive the information about `meeting.is_active_in_organization_id`. Every user has to get information about this to know which meeting is archived and which is active (see: OpenSlides/openslides-autoupdate-service#319)