### PR TITLE
Shows the "created at" timestamps of motions

### DIFF
--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -195,7 +195,7 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
     }
 
     public getFieldsets(): Fieldsets<Motion> {
-        const titleFields: TypedFieldset<Motion> = ['title', 'number'];
+        const titleFields: TypedFieldset<Motion> = ['title', 'number', 'created'];
         const listFields: TypedFieldset<Motion> = titleFields.concat([
             'sequential_number',
             'sort_weight',

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-meta-data/motion-meta-data.component.html
@@ -36,7 +36,8 @@
     </button>
     <p *ngIf="showSupporters" class="supporters">
         <span *ngFor="let supporter of motion.supporters; let last = last">
-            {{ supporter.full_name }}<span *ngIf="!last">, </span>
+            {{ supporter.full_name }}
+            <span *ngIf="!last">,</span>
         </span>
     </p>
 </div>
@@ -55,16 +56,19 @@
     >
         <span class="trigger-menu" *ngIf="motion.state">
             <button *ngFor="let state of motion.state.next_states" mat-menu-item (click)="setState(state.id)">
-                {{ state.name | translate }} <span *ngIf="state.show_state_extension_field">&nbsp;...</span>
+                {{ state.name | translate }}
+                <span *ngIf="state.show_state_extension_field">&nbsp;...</span>
             </button>
             <div>
                 <mat-divider *ngIf="motion.state.next_states.length > 0"></mat-divider>
                 <button *ngFor="let state of motion.state.previous_states" mat-menu-item (click)="setState(state.id)">
-                    <mat-icon>arrow_back</mat-icon> {{ state.name | translate }}
+                    <mat-icon>arrow_back</mat-icon>
+                    {{ state.name | translate }}
                     <span *ngIf="state.show_state_extension_field">&nbsp;...</span>
                 </button>
                 <button mat-menu-item (click)="resetState()">
-                    <mat-icon>replay</mat-icon> {{ 'Reset state' | translate }}
+                    <mat-icon>replay</mat-icon>
+                    {{ 'Reset state' | translate }}
                 </button>
             </div>
         </span>
@@ -96,7 +100,8 @@
             </button>
             <mat-divider></mat-divider>
             <button mat-menu-item (click)="resetRecommendation()">
-                <mat-icon>replay</mat-icon> {{ 'Reset recommendation' | translate }}
+                <mat-icon>replay</mat-icon>
+                {{ 'Reset recommendation' | translate }}
             </button>
         </span>
     </os-extension-field>
@@ -111,7 +116,7 @@
     <h4>{{ 'Referring motions' | translate }}</h4>
     <span *ngFor="let motion of recommendationReferencingMotions; let last = last">
         <a routerLink="motion.getDetailStateURL()" class="nowrap">{{ motion.numberOrTitle }}</a>
-        <span *ngIf="!last"> · </span>
+        <span *ngIf="!last">·</span>
     </span>
 </div>
 
@@ -217,6 +222,12 @@
     </mat-basic-chip>
 </div>
 
+<!-- Created timestamp -->
+<div *ngIf="motion?.created">
+    <h4>{{ 'Creation date' | translate }}</h4>
+    <div>{{ motion.created | localizedDate }}</div>
+</div>
+
 <!-- Origins - display only -->
 <div *ngIf="motion?.all_origins?.length">
     <h4>{{ 'Origin' | translate }}</h4>
@@ -261,9 +272,12 @@
 <os-motion-manage-polls [motion]="motion"></os-motion-manage-polls>
 
 <ng-template let-motion="motion" #meetingLink>
-    <a *ngIf="motion.meeting?.canAccess()" [routerLink]="motion.getDetailStateURL()">
-        {{ motion.meeting?.name }}
-    </a>
+    <span *ngIf="motion.meeting?.canAccess()">
+        <a [routerLink]="motion.getDetailStateURL()">
+            {{ motion.meeting?.name }}
+        </a>
+        <span>({{ motion.created | localizedDate }})</span>
+    </span>
     <div *ngIf="!motion.meeting?.canAccess()">
         {{ motion.meeting?.name }}
     </div>

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.html
@@ -14,7 +14,8 @@
     <!-- Multiselect info -->
     <div class="central-info-slot">
         <button mat-icon-button (click)="toggleMultiSelect()"><mat-icon>arrow_back</mat-icon></button>
-        <span>{{ selectedRows.length }}&nbsp;</span><span>{{ 'selected' | translate }}</span>
+        <span>{{ selectedRows.length }}&nbsp;</span>
+        <span>{{ 'selected' | translate }}</span>
     </div>
 
     <div class="extra-controls-slot">
@@ -96,9 +97,15 @@
                     </span>
 
                     <span *ngIf="showSequential">
-                        <span *ngIf="motion.submitters.length"> &middot; </span>
+                        <span *ngIf="motion.submitters.length">&middot;&nbsp;</span>
                         <span>{{ 'Sequential number' | translate }}</span>
                         {{ motion.sequential_number }}
+                    </span>
+
+                    <span>
+                        <span *ngIf="motion.submitters.length || showSequential">&middot;&nbsp;</span>
+                        <span>{{ 'Created' | translate }}</span>
+                        {{ motion.created | localizedDate }}
                     </span>
                 </div>
 


### PR DESCRIPTION
Fixes #518

Only one, who can access a meeting, sees the created-timestamp. I assume, that one, who can forward a motion to a meeting, can also access that meeting.