### PR TITLE
Removes displaying the history mode for OpenSlides

### DIFF
--- a/client/src/app/core/core-services/app-load.service.ts
+++ b/client/src/app/core/core-services/app-load.service.ts
@@ -8,7 +8,7 @@ import { AssignmentsAppConfig } from 'app/site/assignments/assignments.config';
 import { isSearchable } from 'app/site/base/searchable';
 import { CinemaAppConfig } from 'app/site/cinema/cinema.config';
 import { CommonAppConfig } from 'app/site/common/common.config';
-import { HistoryAppConfig } from 'app/site/history/history.config';
+// import { HistoryAppConfig } from 'app/site/history/history.config';
 import { MediafileAppConfig } from 'app/site/mediafiles/mediafile.config';
 import { SettingsAppConfig } from 'app/site/meeting-settings/meeting-settings.config';
 import { MotionsAppConfig } from 'app/site/motions/motions.config';
@@ -37,7 +37,7 @@ const appConfigs: AppConfig[] = [
     MediafileAppConfig,
     TagAppConfig,
     UsersAppConfig,
-    HistoryAppConfig,
+    // HistoryAppConfig,
     ProjectorAppConfig,
     TopicsAppConfig,
     CinemaAppConfig,

--- a/client/src/app/core/core-services/history.service.ts
+++ b/client/src/app/core/core-services/history.service.ts
@@ -49,7 +49,8 @@ export class HistoryService {
      * Returns, if OpenSlides is in the history mode.
      */
     public get isInHistoryMode(): boolean {
-        return !!this.position;
+        return false; // Currently not supported
+        // return !!this.position;
     }
 
     /**
@@ -71,15 +72,17 @@ export class HistoryService {
      * Enters the history mode
      */
     public enterHistoryMode(position: Position): void {
-        this.position = position;
-        this.banner.addBanner(this.bannerDefinition);
+        throw new Error('The history mode is currently not supported');
+        // this.position = position;
+        // this.banner.addBanner(this.bannerDefinition);
     }
 
     /**
      * Leaves the history mode
      */
     public leaveHistoryMode(): void {
-        this.position = null;
-        this.banner.removeBanner(this.bannerDefinition);
+        throw new Error('The history mode is currently not supported');
+        // this.position = null;
+        // this.banner.removeBanner(this.bannerDefinition);
     }
 }

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.html
@@ -13,7 +13,8 @@
         <h2 *ngIf="motion && !newMotion">
             <span>{{ 'Motion' | translate }}</span>
             <!-- Whitespace between "Motion" and number -->
-            <span>&nbsp;</span> <span *ngIf="!editMotion">{{ motion.number }}</span>
+            <span>&nbsp;</span>
+            <span *ngIf="!editMotion">{{ motion.number }}</span>
             <!-- <span *ngIf="editMotion">{{ contentForm.get('number').value }}</span> -->
         </h2>
         <h2 *ngIf="newMotion && !amendmentEdit">{{ 'New motion' | translate }}</h2>
@@ -89,7 +90,7 @@
                     <span>{{ 'Remove from agenda' | translate }}</span>
                 </button>
             </div>
-            <button
+            <!-- <button
                 mat-menu-item
                 *osPerms="permission.meetingCanSeeHistory"
                 [routerLink]="['/', activeMeetingId, 'history']"
@@ -99,7 +100,7 @@
                 <span>
                     {{ 'History' | translate }}
                 </span>
-            </button>
+            </button> -->
             <mat-divider *ngIf="perms.isAllowed('update', motion) || perms.isAllowed('manage')"></mat-divider>
             <!-- Forward to meeting -->
             <button mat-menu-item (click)="forwardMotionToMeetings()" *ngIf="perms.isAllowed('manage')">

--- a/client/src/app/site/site-routing.module.ts
+++ b/client/src/app/site/site-routing.module.ts
@@ -68,11 +68,11 @@ const routes: Route[] = [
                 loadChildren: () => import('./tags/tag.module').then(m => m.TagModule),
                 data: { basePerm: Permission.tagCanManage }
             },
-            {
-                path: 'history',
-                loadChildren: () => import('./history/history.module').then(m => m.HistoryModule),
-                data: { basePerm: Permission.meetingCanSeeHistory }
-            },
+            // {
+            //     path: 'history',
+            //     loadChildren: () => import('./history/history.module').then(m => m.HistoryModule),
+            //     data: { basePerm: Permission.meetingCanSeeHistory }
+            // },
             {
                 path: 'projectors',
                 loadChildren: () => import('./projector/projector.module').then(m => m.ProjectorModule),


### PR DESCRIPTION
I also prevent programmatically to enter the history mode. I only commented the related lines for the history mode, because we have then already the necessary places when the history mode will be supported.

Fixes #520 