### PR TITLE
Some UI and UX improvements

### DIFF
--- a/client/src/app/management/components/committee-detail/committee-detail.component.html
+++ b/client/src/app/management/components/committee-detail/committee-detail.component.html
@@ -81,13 +81,10 @@
 
         <os-committee-meta-info icon="engineering" title="Committee manager" *ngIf="canManageCommittee">
             <ng-container *ngIf="committee.getManagers() as managers">
-                <ul class="content-list" *ngIf="managers.length > 0">
-                    <li *ngFor="let manager of managers">
-                        <a [routerLink]="['/', 'members', manager.id]">
-                            {{ manager }}
-                        </a>
-                    </li>
-                </ul>
+                <span *ngFor="let manager of managers; let last = last">
+                    <a [routerLink]="['/', 'members', manager.id]">{{ manager }}</a>
+                    <span *ngIf="!last">,&nbsp;</span>
+                </span>
                 <i class="red-warning-text" *ngIf="managers.length === 0">
                     {{ 'This committee has no managers!' | translate }}
                 </i>

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.html
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.html
@@ -47,11 +47,11 @@
 
     <!-- users -->
     <div class="user-footer">
-        <a mat-icon-button matTooltip="{{ 'Participants' | translate }}">
+        <button mat-icon-button matTooltip="{{ 'Participants' | translate }}" (click)="changeToMeetingUsers()">
             <mat-icon [matBadgeHidden]="!showUserAmount" [matBadge]="userAmount" [matBadgeColor]="'accent'">
                 group
             </mat-icon>
-        </a>
+        </button>
     </div>
 </mat-card>
 

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
@@ -9,6 +9,7 @@ import { ViewMeeting } from 'app/management/models/view-meeting';
 import { CommitteeRepositoryService } from '../../../core/repositories/management/committee-repository.service';
 import { ViewCommittee } from '../../models/view-committee';
 import { OML } from '../../../core/core-services/organization-permission';
+import { MeetingService } from '../../services/meeting.service';
 
 @Component({
     selector: 'os-meeting-preview',
@@ -51,7 +52,8 @@ export class MeetingPreviewComponent {
         private translate: TranslateService,
         private meetingRepo: MeetingRepositoryService,
         private committeeRepo: CommitteeRepositoryService,
-        private promptService: PromptService
+        private promptService: PromptService,
+        private meetingService: MeetingService
     ) {}
 
     public async onArchive(): Promise<void> {
@@ -100,5 +102,9 @@ export class MeetingPreviewComponent {
         } else {
             await this.committeeRepo.update({ default_meeting_id: this.meeting.id }, this.committee);
         }
+    }
+
+    public changeToMeetingUsers(): void {
+        this.meetingService.navigateToMeetingUsers(this.meeting);
     }
 }

--- a/client/src/app/management/components/member-list/member-list.component.ts
+++ b/client/src/app/management/components/member-list/member-list.component.ts
@@ -19,6 +19,8 @@ import { BaseListViewComponent } from 'app/site/base/components/base-list-view.c
 import { BaseUserHeadersAndVerboseNames } from 'app/site/users/base/base-user.constants';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { OMLMapping } from '../../../core/core-services/organization-permission';
+import { ORGANIZATION_ID } from '../../../core/core-services/organization.service';
+import { ViewOrganization } from '../../models/view-organization';
 
 @Component({
     selector: 'os-members',
@@ -60,6 +62,7 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
     public ngOnInit(): void {
         super.ngOnInit();
         this.loadUsers();
+        this.loadMeetings();
     }
 
     public createNewMember(): void {
@@ -116,6 +119,29 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
 
     public getOmlByUser(user: ViewUser): string {
         return getOmlVerboseName(user.organization_management_level as keyof OMLMapping);
+    }
+
+    private async loadMeetings(): Promise<void> {
+        await this.requestModels(
+            {
+                viewModelCtor: ViewOrganization,
+                ids: [ORGANIZATION_ID],
+                follow: [
+                    {
+                        idField: 'committee_ids',
+                        fieldset: '',
+                        follow: [
+                            {
+                                idField: 'meeting_ids',
+                                fieldset: '',
+                                follow: [{ idField: 'user_ids', fieldset: 'shortName' }]
+                            }
+                        ]
+                    }
+                ]
+            },
+            'load_meetings'
+        );
     }
 
     private async loadUsers(start_index: number = 0, entries: number = 10000): Promise<void> {

--- a/client/src/app/management/services/meeting.service.ts
+++ b/client/src/app/management/services/meeting.service.ts
@@ -1,0 +1,18 @@
+import { Router } from '@angular/router';
+import { MemberFilterService } from './member-filter.service';
+import { ViewMeeting } from 'app/management/models/view-meeting';
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class MeetingService {
+    public constructor(private router: Router, private memberFilterService: MemberFilterService) {}
+
+    public async navigateToMeetingUsers(meeting: ViewMeeting): Promise<void> {
+        await this.router.navigate(['members']);
+        this.memberFilterService.clearAllFilters();
+        this.memberFilterService.toggleFilterOption('id', {
+            condition: meeting.user_ids,
+            label: meeting.name
+        });
+    }
+}

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
@@ -95,6 +95,10 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormControlCo
     @Input()
     public tooltipFn: (value: Selectable, source: MatOption) => string | null = () => null;
 
+    @Input()
+    public sortFn: (valueA: Selectable, valueB: Selectable) => number = (a, b) =>
+        a.getTitle().localeCompare(b.getTitle());
+
     /**
      * Emits the currently searched string.
      */
@@ -133,10 +137,11 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormControlCo
      * All items
      */
     protected set selectableItems(items: Selectable[]) {
+        const sortedItems = [...items].sort(this.sortFn);
         if (!this.multiple && this.includeNone) {
-            this._selectableItems = [this.noneItem].concat(items);
+            this._selectableItems = [this.noneItem].concat(sortedItems);
         } else {
-            this._selectableItems = items;
+            this._selectableItems = sortedItems;
         }
     }
 


### PR DESCRIPTION
Fixes #556 

- The memberlist is filterable by meetings
- A user is navigated to the memberlist when clicking on the meeting-preview-group-button
- The managers of a committee are displayed separated by a comma not by a linebreak
- A search-(repo | value)-selector is sortable (default sorting is by the name of an item)