### PR TITLE
Adjusts the height of the meeting-lists at the dashboard for FF

### DIFF
--- a/client/src/app/management/components/dashboard/dashboard.component.html
+++ b/client/src/app/management/components/dashboard/dashboard.component.html
@@ -75,7 +75,11 @@
 </ng-container>
 
 <ng-template let-meetingList="meetingList" let-cssClass="cssClass" #meetingListTemplate>
-    <div class="meeting-list" [ngStyle]="{ height: getHeightByMeetings(meetingList) }">
+    <div
+        class="meeting-list"
+        [ngClass]="{ 'no-meetings': !meetingList.length }"
+        [ngStyle]="{ height: getHeightByMeetings(meetingList) }"
+    >
         <mat-card class="no-meetings-card" *ngIf="!meetingList.length">
             {{ 'No meetings available' | translate }}
         </mat-card>

--- a/client/src/app/management/components/dashboard/dashboard.component.scss
+++ b/client/src/app/management/components/dashboard/dashboard.component.scss
@@ -81,6 +81,10 @@ os-dashboard {
         background: white;
         overflow: hidden;
 
+        &.no-meetings {
+            height: fit-content;
+        }
+
         cdk-virtual-scroll-viewport {
             height: 100%;
         }

--- a/client/src/app/management/components/dashboard/dashboard.component.ts
+++ b/client/src/app/management/components/dashboard/dashboard.component.ts
@@ -75,7 +75,7 @@ export class DashboardComponent extends BaseModelContextComponent implements OnI
     public getHeightByMeetings(meetings: ViewMeeting[]): string {
         let height = 0;
         if (meetings.length === 0) {
-            return 'fit-content';
+            return '';
         } else if (meetings.length > 3) {
             height = 240;
         } else {


### PR DESCRIPTION
This should also fix the same for Safari. A css-class is used for the property "height" (if there are no meetings to show), instead of applying a value directly to an element's style.

Fixes #570 