### PR TITLE
automatically removes committee-managers if removed from committee-users

### DIFF
--- a/client/src/app/management/components/committee-edit/committee-edit.component.html
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.html
@@ -48,6 +48,7 @@
                 [multiple]="true"
                 placeholder="{{ 'Committee members' | translate }}"
                 [inputListValues]="organizationMembers"
+                (selectionChanged)="onUserSelectionChanged($event)"
             ></os-search-value-selector>
         </mat-form-field>
 
@@ -70,7 +71,7 @@
                     [repo]="committeeRepo"
                     [showChips]="false"
                     [lazyLoading]="false"
-                    (selectionChanged)="onSelectionChanged($event)"
+                    (selectionChanged)="onForwardingSelectionChanged($event)"
                 ></os-search-repo-selector>
             </mat-form-field>
 

--- a/client/src/app/management/components/committee-edit/committee-edit.component.ts
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.ts
@@ -144,18 +144,39 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
     }
 
     /**
+     * Function to automatically unselect a user from the manager-array. If the user remains as committee-manager,
+     * then the backend would remain them as manager and remain them as user, too. If a user would only be added as
+     * committee-manager, then they would be automatically added as committee-user to always have committee-managers
+     * as a subset of committee-users.
+     *
+     * @param value the user who is selected or unselected
+     * @param selected whether the incoming value has been selected or not
+     */
+    public onUserSelectionChanged({ value: user, selected }: OsOptionSelectionChanged<ViewUser>): void {
+        if (selected) {
+            return;
+        }
+        const committeeManagerIds = this.managerIdCtrl.value as Id[];
+        const managerIndex = committeeManagerIds.findIndex(managerId => managerId === user.id);
+        if (managerIndex > -1) {
+            committeeManagerIds.splice(managerIndex, 1);
+            this.managerIdCtrl.setValue(committeeManagerIds);
+        }
+    }
+
+    /**
      * Function to (un-) select the same committee in the `receive_forwardings_from_committee_ids`-control. This
      * enables then the forwarding to the same committee.
      *
      * @param value is the committee that is selected or unselected
-     * @param source is the MatOption that emitted the SelectionChanged-event
+     * @param selected whether the incoming value has been selected or not
      */
-    public onSelectionChanged({ value, source }: OsOptionSelectionChanged): void {
-        if (value.id === this.committeeId) {
+    public onForwardingSelectionChanged({ value: committee, selected }: OsOptionSelectionChanged): void {
+        if (committee.id === this.committeeId) {
             const formControlName = 'receive_forwardings_from_committee_ids';
             const previousValue: Set<Id> = new Set(this.committeeForm.get(formControlName).value || []);
-            const fn = source.selected ? 'add' : 'delete';
-            previousValue[fn](value.id);
+            const fn = selected ? 'add' : 'delete';
+            previousValue[fn](committee.id);
             this.committeeForm.patchValue({ [formControlName]: Array.from(previousValue) });
         }
     }


### PR DESCRIPTION
If a user is added as a manager of a committee, then they would automatically be added as a user of the committee by the backend. Therefore, the client removes a manager automatically if they are removed as user. Otherwise, it will remain as it.

Fixes #564 