### PR TITLE
Shows a warning if a user is linked to a motion as submitter or an election as candidate or anything else

### DIFF
--- a/client/src/app/core/core-services/presenter.service.ts
+++ b/client/src/app/core/core-services/presenter.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+
+import { HttpService } from './http.service';
+
+const PRESENTER_URL = '/system/presenter/handle_request';
+
+export enum Presenter {
+    SERVERTIME = 'server_time',
+    GET_USERS = 'get_users',
+    GET_USER_RELATED_MODELS = 'get_user_related_models',
+    GET_FORWARDING_MEETINGS = 'get_forwarding_meetings'
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class PresenterService {
+    public constructor(private readonly http: HttpService) {}
+
+    public async call<R, D = any>(presenter: Presenter, data?: D): Promise<R> {
+        const result = await this.http.post<R[]>(PRESENTER_URL, [{ presenter, data }]);
+        if (result?.length !== 1) {
+            throw new Error('The presenter service has returned a wrong format');
+        }
+        return result[0];
+    }
+}

--- a/client/src/app/core/definitions/custom-errors.ts
+++ b/client/src/app/core/definitions/custom-errors.ts
@@ -3,7 +3,6 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 /**
  * Define custom error classes here
  */
-
 export class PreventedInDemo extends Error {
     public constructor(message: string = _('Cannot do that in demo mode!'), name: string = 'Error') {
         super(message);

--- a/client/src/app/core/repositories/management/organization-repository.service.ts
+++ b/client/src/app/core/repositories/management/organization-repository.service.ts
@@ -30,7 +30,8 @@ export class OrganizationRepositoryService extends BaseRepository<ViewOrganizati
             'theme_id',
             'enable_electronic_voting',
             'reset_password_verbose_errors',
-            'limit_of_meetings'
+            'limit_of_meetings',
+            'limit_of_users'
         );
         const detailFieldset: (keyof Organization)[] = coreFieldset.concat('committee_ids', 'organization_tag_ids');
         return {

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -20,6 +20,8 @@ import { BaseRepositoryWithActiveMeeting } from '../base-repository-with-active-
 import { ModelRequestRepository } from '../model-request-repository';
 import { RepositoryServiceCollector } from '../repository-service-collector';
 import { Displayable } from '../../../site/base/displayable';
+import { PresenterService } from '../../core-services/presenter.service';
+import { Meeting } from '../../../shared/models/event-management/meeting';
 
 export interface MassImportResult {
     importedTrackIds: number[];
@@ -222,7 +224,7 @@ export class UserRepositoryService
                 vote_delegated_$_to_id: { [this.activeMeetingId]: partialUser.vote_delegated_to_id },
                 vote_delegations_$_from_ids: { [this.activeMeetingId]: partialUser.vote_delegations_from_ids },
                 group_$_ids: {
-                    [this.activeMeetingId]: partialUser.group_ids?.length ? partialUser.group_ids : [defaultGroupId]
+                    [this.activeMeetingId]: partialUser.group_ids ? partialUser.group_ids : [defaultGroupId]
                 }
             };
         }
@@ -414,6 +416,10 @@ export class UserRepositoryService
         this.preventInDemo();
         const payload: UserAction.DeletePayload[] = users.map(user => ({ id: user.id }));
         return this.sendBulkActionToBackend(UserAction.DELETE, payload);
+    }
+
+    public remove(meeting: Meeting, ...users: ViewUser[]): Promise<void> {
+        return this.bulkRemoveGroupsFromUsers(users, meeting.group_ids);
     }
 
     /**

--- a/client/src/app/core/ui-services/base-filter-list.service.ts
+++ b/client/src/app/core/ui-services/base-filter-list.service.ts
@@ -270,7 +270,7 @@ export abstract class BaseFilterListService<V extends BaseViewModel> {
                 }
             }
 
-            this.filterDefinitions = newDefinitions;
+            this.filterDefinitions = newDefinitions ?? []; // Prevent being null or undefined
             this.storeActiveFilters();
         }
     }

--- a/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.html
+++ b/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.html
@@ -1,0 +1,78 @@
+<h2 mat-dialog-title>
+    {{
+        (isOneMember
+            ? 'Are you sure you want to delete this account?'
+            : 'Are you sure you want to delete these accounts?'
+        ) | translate
+    }}
+</h2>
+
+<div mat-dialog-content>
+    <div class="member-delete-dialog-content">
+        <cdk-virtual-scroll-viewport class="member-list-block" [itemSize]="30">
+            <ng-container *cdkVirtualFor="let member of data | keyvalue">
+                <div
+                    class="member padding-left-8 pointer"
+                    [ngClass]="{
+                        'background-primary': selectedMember === member.value
+                    }"
+                    (click)="selectedMember = member.value"
+                >
+                    <div class="flex-vertical-center">
+                        <mat-icon *ngIf="!hasRelations(member.value)"></mat-icon>
+                        <mat-icon
+                            *ngIf="hasRelations(member.value)"
+                            color="warn"
+                            matTooltip="{{ 'This member has relations to meetings or committees' | translate }}"
+                        >
+                            warning
+                        </mat-icon>
+                        <p class="padding-left-8 padding-right-8 one-line">{{ member.value.name }}</p>
+                    </div>
+                    <mat-divider></mat-divider>
+                </div>
+            </ng-container>
+        </cdk-virtual-scroll-viewport>
+        <ng-container *ngIf="selectedMember">
+            <mat-divider [vertical]="true"></mat-divider>
+            <div class="member-detail-block">
+                <ng-container *ngTemplateOutlet="memberRelations; context: { member: selectedMember }"></ng-container>
+            </div>
+        </ng-container>
+    </div>
+</div>
+
+<p mat-dialog-actions>
+    <button mat-button color="warn" [matDialogClose]="true">{{ 'Yes, delete' | translate }}</button>
+    <button mat-button [matDialogClose]="false">{{ 'Cancel' | translate }}</button>
+</p>
+
+<ng-template #memberRelations let-member="member">
+    <div class="member-name padding-left-25">{{ member.name }}</div>
+    <ng-container *ngIf="!hasRelations(member)">
+        <p class="padding-left-25">
+            {{
+                'This account is not linked as candidate, submitter or speaker in any meeting and is not manager of any committee'
+                    | translate
+            }}
+        </p>
+    </ng-container>
+    <ng-container *ngIf="hasRelations(member)">
+        <ul *ngFor="let meeting of member.meetings">
+            <p class="meeting-title">{{ meeting.name }}</p>
+            <li *ngIf="meeting.candidate_ids?.length">
+                {{ 'Is candidate' | translate }}
+            </li>
+            <li *ngIf="meeting.submitter_ids?.length">
+                {{ 'Is submitter' | translate }}
+            </li>
+            <li *ngIf="meeting.speaker_ids?.length">
+                {{ 'Is speaker' | translate }}
+            </li>
+        </ul>
+        <ul *ngFor="let committee of getManagedCommittees(member)">
+            <p class="committee-title">{{ committee.name }}</p>
+            <li>{{ 'Is manager' | translate }}</li>
+        </ul>
+    </ng-container>
+</ng-template>

--- a/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.scss
+++ b/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.scss
@@ -1,0 +1,42 @@
+.member-delete-dialog-content {
+    display: flex;
+    height: 50vh;
+    overflow-y: auto;
+
+    .member-list-block {
+        width: 100%;
+        flex: 1;
+
+        div.cdk-virtual-scroll-content-wrapper {
+            width: 100%;
+        }
+
+        .member {
+            &:hover {
+                background-color: rgba(0, 0, 0, 0.025);
+            }
+        }
+
+        p {
+            margin: 4px 0;
+            width: 100%;
+        }
+    }
+
+    .member-detail-block {
+        flex: 1;
+
+        .member-name {
+            font-size: 16px;
+        }
+    }
+
+    .committee-title,
+    .meeting-title {
+        font-weight: 500;
+        margin-left: -15px;
+        ~ li {
+            font-size: 13px;
+        }
+    }
+}

--- a/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.spec.ts
+++ b/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MemberDeleteDialogComponent } from './member-delete-dialog.component';
+
+describe('MemberDeleteDialogComponent', () => {
+    let component: MemberDeleteDialogComponent;
+    let fixture: ComponentFixture<MemberDeleteDialogComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [MemberDeleteDialogComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(MemberDeleteDialogComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.ts
+++ b/client/src/app/management/components/member-delete-dialog/member-delete-dialog.component.ts
@@ -1,0 +1,48 @@
+import { Component, Inject, OnInit, ViewEncapsulation } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import {
+    GetUserRelatedModelsPresenterResult,
+    GetUserRelatedModelsUser,
+    GetUserRelatedModelsCommittee
+} from '../../../core/core-services/member.service';
+import { CML } from '../../../core/core-services/organization-permission';
+
+@Component({
+    selector: 'os-member-delete-dialog',
+    templateUrl: './member-delete-dialog.component.html',
+    styleUrls: ['./member-delete-dialog.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class MemberDeleteDialogComponent implements OnInit {
+    public get isOneMember(): boolean {
+        return Object.keys(this.data).length === 1;
+    }
+
+    public set selectedMember(member: GetUserRelatedModelsUser) {
+        if (this._selectedMember === member) {
+            this._selectedMember = null;
+        } else {
+            this._selectedMember = member;
+        }
+    }
+
+    public get selectedMember(): GetUserRelatedModelsUser | null {
+        return this._selectedMember;
+    }
+
+    private _selectedMember: GetUserRelatedModelsUser | null = null;
+
+    public constructor(@Inject(MAT_DIALOG_DATA) public data: GetUserRelatedModelsPresenterResult) {}
+
+    public ngOnInit(): void {
+        this.selectedMember = Object.values(this.data)[0];
+    }
+
+    public hasRelations(member: GetUserRelatedModelsUser): boolean {
+        return member.meetings?.length > 0 || this.getManagedCommittees(member).length > 0;
+    }
+
+    public getManagedCommittees(member: GetUserRelatedModelsUser): GetUserRelatedModelsCommittee[] {
+        return (member.committees || []).filter(committee => committee.cml === CML.can_manage);
+    }
+}

--- a/client/src/app/management/components/member-edit/member-edit.component.html
+++ b/client/src/app/management/components/member-edit/member-edit.component.html
@@ -97,7 +97,7 @@
                         placeholder="{{ 'Committee manager' | translate }}"
                         [repo]="committeeRepo"
                         [transformPropagateFn]="transformPropagateFn"
-                        [transformSetFn]="transformSetFn()"
+                        [transformSetFn]="getTransformSetFn()"
                     ></os-search-repo-selector>
                 </mat-form-field>
             </div>
@@ -137,7 +137,8 @@
         <div *ngIf="user.committee_ids?.length">
             <h4>{{ 'Committee member' | translate }}</h4>
             <span *ngFor="let committee of user.committees; let last = last">
-                {{ committee.getTitle() | translate }}<span *ngIf="!last">,&nbsp;</span>
+                {{ committee.getTitle() | translate }}
+                <span *ngIf="!last">,&nbsp;</span>
             </span>
         </div>
 

--- a/client/src/app/management/components/member-edit/member-edit.component.ts
+++ b/client/src/app/management/components/member-edit/member-edit.component.ts
@@ -7,10 +7,10 @@ import { Id } from 'app/core/definitions/key-types';
 import { CommitteeRepositoryService } from 'app/core/repositories/management/committee-repository.service';
 import { UserRepositoryService } from 'app/core/repositories/users/user-repository.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
-import { PromptService } from 'app/core/ui-services/prompt.service';
 import { BaseModelContextComponent } from 'app/site/base/components/base-model-context.component';
 import { ViewUser } from 'app/site/users/models/view-user';
 import { ViewCommittee } from '../../models/view-committee';
+import { MemberService } from '../../../core/core-services/member.service';
 
 @Component({
     selector: 'os-member-edit',
@@ -47,8 +47,8 @@ export class MemberEditComponent extends BaseModelContextComponent implements On
         private router: Router,
         private route: ActivatedRoute,
         private repo: UserRepositoryService,
-        private promptService: PromptService,
-        private operator: OperatorService
+        private operator: OperatorService,
+        private memberService: MemberService
     ) {
         super(componentServiceCollector);
     }
@@ -62,7 +62,7 @@ export class MemberEditComponent extends BaseModelContextComponent implements On
         return (value || []).mapToObject(id => ({ [id]: CML.can_manage }));
     }
 
-    public transformSetFn(): (value?: string[]) => any {
+    public getTransformSetFn(): (value?: string[]) => any {
         return (value?: string[]) => {
             const managementIds = [];
             for (const strId of value || []) {
@@ -113,10 +113,7 @@ export class MemberEditComponent extends BaseModelContextComponent implements On
      * click on the delete user button
      */
     public async deleteUser(): Promise<void> {
-        const title = this.translate.instant('Are you sure you want to delete this member?');
-        const content = this.user.full_name;
-        if (await this.promptService.open(title, content)) {
-            await this.repo.delete(this.user);
+        if (await this.memberService.delete([this.user])) {
             this.router.navigate(['./accounts/']);
         }
     }

--- a/client/src/app/management/components/member-list/member-list.component.html
+++ b/client/src/app/management/components/member-list/member-list.component.html
@@ -61,6 +61,12 @@
             </os-icon-container>
         </div>
     </div>
+    <!-- Active or not active column -->
+    <div *pblNgridCellDef="'is_active'; row as user">
+        <div>
+            <mat-label class="inactive-label" *ngIf="!user.is_active">{{ 'Inactive' | translate }}</mat-label>
+        </div>
+    </div>
     <!-- Menu column -->
     <ng-container *osOmlPerms="OML.can_manage_users">
         <div *pblNgridCellDef="'menu'; row as user" class="cell-slot fill">

--- a/client/src/app/management/components/member-list/member-list.component.scss
+++ b/client/src/app/management/components/member-list/member-list.component.scss
@@ -1,3 +1,9 @@
 .committee-wrapper {
     width: 100%;
 }
+
+.inactive-label {
+    padding: 6px;
+    border: 1px solid;
+    border-radius: 4px;
+}

--- a/client/src/app/management/components/member-list/member-list.component.ts
+++ b/client/src/app/management/components/member-list/member-list.component.ts
@@ -12,7 +12,6 @@ import { UserRepositoryService } from 'app/core/repositories/users/user-reposito
 import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { CsvExportService } from 'app/core/ui-services/csv-export.service';
-import { PromptService } from 'app/core/ui-services/prompt.service';
 import { MemberFilterService } from 'app/management/services/member-filter.service';
 import { MemberSortService } from 'app/management/services/member-sort.service';
 import { BaseListViewComponent } from 'app/site/base/components/base-list-view.component';
@@ -38,6 +37,10 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
         {
             prop: 'info',
             width: '50%'
+        },
+        {
+            prop: 'is_active',
+            width: '100px'
         }
     ];
 
@@ -48,7 +51,6 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
         private memberService: MemberService,
         private router: Router,
         private route: ActivatedRoute,
-        private promptService: PromptService,
         private choiceService: ChoiceService,
         public readonly filterService: MemberFilterService,
         public readonly sortService: MemberSortService,
@@ -74,14 +76,7 @@ export class MemberListComponent extends BaseListViewComponent<ViewUser> impleme
     }
 
     public async deleteSelected(members: ViewUser[] = this.selectedRows): Promise<void> {
-        const title = this.translate.instant(
-            members.length === 1
-                ? 'Are you sure you want to delete this member?'
-                : 'Are you sure you want to delete all selected participants?'
-        );
-        if (await this.promptService.open(title)) {
-            this.repo.delete(...members).catch(this.raiseError);
-        }
+        await this.memberService.delete(members);
     }
 
     public async assignCommitteesToUsers(): Promise<void> {

--- a/client/src/app/management/management.module.ts
+++ b/client/src/app/management/management.module.ts
@@ -24,6 +24,7 @@ import { OrganizationTagDialogComponent } from './components/organization-tag-di
 import { OrganizationTagListComponent } from './components/organization-tag-list/organization-tag-list.component';
 import { ThemeBuilderDialogComponent } from './components/theme-builder-dialog/theme-builder-dialog.component';
 import { ThemeListComponent } from './components/theme-list/theme-list.component';
+import { MemberDeleteDialogComponent } from './components/member-delete-dialog/member-delete-dialog.component';
 
 @NgModule({
     imports: [CommonModule, SharedModule, ManagementRoutingModule],
@@ -48,7 +49,8 @@ import { ThemeListComponent } from './components/theme-list/theme-list.component
         CommitteeMetaInfoComponent,
         CommitteeImportListComponent,
         ThemeBuilderDialogComponent,
-        ThemeListComponent
+        ThemeListComponent,
+        MemberDeleteDialogComponent
     ]
 })
 export class ManagementModule {}

--- a/client/src/app/shared/components/basic-list-view-table/basic-list-view-table.component.scss
+++ b/client/src/app/shared/components/basic-list-view-table/basic-list-view-table.component.scss
@@ -38,6 +38,7 @@ $pbl-height: var(--pbl-height);
 
         .pbl-ngrid-row {
             height: $pbl-height;
+            user-select: none;
         }
 
         .pbl-ngrid-row:last-of-type {

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -4,9 +4,9 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { ActiveMeetingService } from 'app/core/core-services/active-meeting.service';
-import { HttpService } from 'app/core/core-services/http.service';
 import { Id } from 'app/core/definitions/key-types';
 import { MatCheckboxChange } from '@angular/material/checkbox';
+import { PresenterService, Presenter } from '../../../../../../core/core-services/presenter.service';
 
 interface PresenterMeeting {
     id: Id;
@@ -20,7 +20,7 @@ interface ForwardingPresenter {
     meetings?: PresenterMeeting[];
 }
 
-type ForwardingPresenterResult = ForwardingPresenter[][];
+type ForwardingPresenterResult = ForwardingPresenter[];
 
 @Component({
     selector: 'os-motion-forward-dialog',
@@ -39,21 +39,14 @@ export class MotionForwardDialogComponent implements OnInit {
 
     public constructor(
         private dialogRef: MatDialogRef<MotionForwardDialogComponent, Id[]>,
-        private http: HttpService,
+        private presenter: PresenterService,
         private activeMeeting: ActiveMeetingService
     ) {}
 
     public async ngOnInit(): Promise<void> {
-        const payload = [
-            {
-                presenter: 'get_forwarding_meetings',
-                data: {
-                    meeting_id: this.activeMeeting.meetingId
-                }
-            }
-        ];
-        const result = await this.http.post<ForwardingPresenterResult>('/system/presenter/handle_request', payload);
-        this.committeesSubject.next(result[0]);
+        const payload = { meeting_id: this.activeMeeting.meetingId };
+        const result = await this.presenter.call<ForwardingPresenterResult>(Presenter.GET_FORWARDING_MEETINGS, payload);
+        this.committeesSubject.next(result);
         this.selectedMeetings = new Set(this.getDefaultMeetingsIds());
         this.initStateMap();
     }

--- a/client/src/app/site/users/components/user-detail/user-detail.component.ts
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.ts
@@ -20,6 +20,7 @@ import { UserPdfExportService } from '../../services/user-pdf-export.service';
 import { ViewGroup } from '../../models/view-group';
 import { ViewUser } from '../../models/view-user';
 import { UserService } from '../../../../core/ui-services/user.service';
+import { MemberService } from '../../../../core/core-services/member.service';
 
 /**
  * Users detail component for both new and existing users
@@ -114,7 +115,8 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
         private pollService: PollService,
         private meetingSettingsService: MeetingSettingsService,
         private activeMeetingIdService: ActiveMeetingIdService,
-        private userService: UserService
+        private userService: UserService,
+        private memberService: MemberService
     ) {
         super(componentServiceCollector);
         this.getUserByUrl();
@@ -259,10 +261,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
      * click on the delete user button
      */
     public async deleteUserButton(): Promise<void> {
-        const title = this.translate.instant('Are you sure you want to delete this participant?');
-        const content = this.user.full_name;
-        if (await this.promptService.open(title, content)) {
-            await this.repo.delete(this.user);
+        if (await this.memberService.delete([this.user])) {
             this.goToAllUsers();
         }
     }


### PR DESCRIPTION
- Implements the "get_user_related_models"-presenter
- Also implements a "PresenterService" for presenters

When a user should be deleted, then a dialog is appearing which shows to which meetings and committees the user is linked to. If the user is linked to something as submitter or candidate (...), their account is only deactivated. If a requesting user (within a meeting) has not the necessary permissions to perform this action, the user will be removed from the meeting instead of being deleted.

Fixes #495