### PR TITLE
Disable indirect redirect

### DIFF
--- a/client/src/app/core/core-services/auth-guard.service.ts
+++ b/client/src/app/core/core-services/auth-guard.service.ts
@@ -104,8 +104,6 @@ export class AuthGuard implements CanActivate, CanActivateChild {
         }
         // Fall-through: If the url is the start page, but no other fallback was found,
         // navigate to the error page.
-
-        this.authService.redirectUrl = location.pathname;
         this.router.navigate(['/error'], {
             queryParams: {
                 error: 'Authentication Error',

--- a/client/src/app/core/core-services/auth.service.ts
+++ b/client/src/app/core/core-services/auth.service.ts
@@ -26,11 +26,6 @@ export interface LoginResponse {
     providedIn: 'root'
 })
 export class AuthService {
-    /**
-     * If the user tries to access a certain URL without being authenticated, the URL will be stored here
-     */
-    public redirectUrl: string;
-
     // This is a wrapper around authTokenService.accessTokenObservable
     // We need to control the point, when specific token changes should be propagated.
     // undefined is used to indicate, that there is no valid token yet
@@ -94,14 +89,7 @@ export class AuthService {
 
     public redirectUser(meetingId?: number): void {
         const baseRoute = meetingId ? `${meetingId}/` : '/';
-        let redirect = this.redirectUrl ? this.redirectUrl : baseRoute;
-
-        const excludedUrls = ['login'];
-        if (excludedUrls.some(url => redirect.includes(url))) {
-            redirect = baseRoute;
-        }
-
-        this.router.navigate([`${redirect}`]);
+        this.router.navigate([baseRoute]);
     }
 
     public async logout(): Promise<void> {

--- a/client/src/app/core/core-services/openslides.service.ts
+++ b/client/src/app/core/core-services/openslides.service.ts
@@ -35,9 +35,6 @@ export class OpenSlidesService {
         }
 
         if (!this.authService.isAuthenticated()) {
-            if (!location.pathname.includes('error')) {
-                this.authService.redirectUrl = location.pathname;
-            }
             this.osRouter.navigateToLogin();
         }
 


### PR DESCRIPTION
If a user lost their session, the re-logging in will forward them to the
organization root view and not to their last remembered meeting

fixes #571