### PR TITLE
Determines, whether a user can be edited or not, now

### DIFF
--- a/client/src/app/core/core-services/member.service.ts
+++ b/client/src/app/core/core-services/member.service.ts
@@ -4,7 +4,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { Meeting } from 'app/shared/models/event-management/meeting';
 import { mediumDialogSettings } from 'app/shared/utils/dialog-settings';
 import { ViewUser } from 'app/site/users/models/view-user';
-import { Observable } from 'rxjs';
 
 import { MemberDeleteDialogComponent } from '../../management/components/member-delete-dialog/member-delete-dialog.component';
 import { Id } from '../definitions/key-types';
@@ -56,10 +55,6 @@ export class MemberService {
         private translate: TranslateService,
         private prompt: PromptService
     ) {}
-
-    public getMemberListObservable(): Observable<ViewUser[]> {
-        return this.userRepo.getViewModelListObservable();
-    }
 
     public async delete(users: ViewUser[], meeting: Meeting = this.activeMeeting.meeting): Promise<boolean> {
         try {

--- a/client/src/app/core/core-services/operator.service.ts
+++ b/client/src/app/core/core-services/operator.service.ts
@@ -464,18 +464,19 @@ export class OperatorService {
     public hasCommitteePermissions(committeeId: Id | undefined, ...permissionsToCheck: CML[]): boolean {
         // If a user can manage an entire organization, they can also manage every committee.
         // Regardless, if they have no CML.
-        if (this.isSuperAdmin || this.isOrgaManager) {
+        if (this.isOrgaManager) {
             return true;
-        }
-        if (!this.CML) {
-            return false;
         }
         return this.hasCommitteePermissionsNonAdminCheck(committeeId, ...permissionsToCheck);
     }
 
     public hasCommitteePermissionsNonAdminCheck(committeeId: Id | undefined, ...permissionsToCheck: CML[]): boolean {
+        // A superadmin can still do everything
+        if (this.isSuperAdmin) {
+            return true;
+        }
         // A user can have a CML for any committee but they could be not present in some of them.
-        if (!this.currentCommitteeIds.includes(committeeId)) {
+        if (!this.CML || !this.currentCommitteeIds.includes(committeeId)) {
             return false;
         }
         const currentCommitteePermission = cmlNameMapping[(this.CML || {})[committeeId]] || 0;

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -123,7 +123,9 @@ export class UserRepositoryService
             `default_number`,
             `default_structure_level`,
             `default_vote_weight`,
-            { templateField: `comment_$` }
+            { templateField: `comment_$` },
+            { templateField: `structure_level_$` },
+            { templateField: `number_$` }
         ]);
         const committeeEditFields = shortNameFields.concat([
             `committee_ids`,

--- a/client/src/app/core/ui-services/user.service.ts
+++ b/client/src/app/core/ui-services/user.service.ts
@@ -4,12 +4,23 @@ import { ActiveMeetingIdService } from 'app/core/core-services/active-meeting-id
 import { OperatorService } from '../core-services/operator.service';
 import { OML } from '../core-services/organization-permission';
 import { Permission } from '../core-services/permission';
+import { Presenter, PresenterService } from '../core-services/presenter.service';
+import { Id } from '../definitions/key-types';
+
+/**
+ * Form control names that are editable for all users even if they have no permissions to manage users.
+ */
+export const PERSONAL_FORM_CONTROLS = [`username`, `email`, `about_me`];
 
 @Injectable({
     providedIn: `root`
 })
 export class UserService {
-    public constructor(private operator: OperatorService, private activeMeetingId: ActiveMeetingIdService) {}
+    public constructor(
+        private operator: OperatorService,
+        private activeMeetingId: ActiveMeetingIdService,
+        private presenter: PresenterService
+    ) {}
 
     /**
      * Should determine if the user (Operator) has the
@@ -56,6 +67,15 @@ export class UserService {
                 );
             default:
                 return false;
+        }
+    }
+
+    public async isUserInScope(...userIds: Id[]): Promise<boolean> {
+        try {
+            await this.presenter.call(Presenter.GET_USER_RELATED_MODELS, { user_ids: userIds });
+            return true;
+        } catch (e) {
+            return false;
         }
     }
 }

--- a/client/src/app/management/components/account-dialog/account-dialog.component.html
+++ b/client/src/app/management/components/account-dialog/account-dialog.component.html
@@ -44,19 +44,20 @@
 <ng-template #showProfileView>
     <div class="flex-container">
         <h2 class="left-align">{{ 'My profile' | translate }}</h2>
-        <button mat-icon-button (click)="editSelf = !editSelf">
-            <mat-icon>{{ editSelf ? 'close' : 'edit' }}</mat-icon>
+        <button mat-icon-button (click)="isEditing = !isEditing">
+            <mat-icon>{{ isEditing ? 'close' : 'edit' }}</mat-icon>
         </button>
     </div>
     <os-user-detail-view
         [user]="self"
-        [isEditing]="editSelf"
-        [isAllowedFn]="getIsAllowedFn()"
+        [isEditing]="isEditing"
+        [isAllowedFn]="isAllowedFn"
+        [shouldEnableFormControlFn]="shouldEnableFormControlFn"
         [useMatcard]="false"
         (validEvent)="isUserFormValid = $event"
         (changeEvent)="userPersonalForm = $event"
     ></os-user-detail-view>
-    <div *ngIf="editSelf" class="margin-top-16">
+    <div *ngIf="isEditing" class="margin-top-16">
         <button mat-button [disabled]="!isUserFormValid" (click)="saveUserChanges()">
             {{ 'Save' | translate }}
         </button>

--- a/client/src/app/management/components/account-dialog/account-dialog.component.ts
+++ b/client/src/app/management/components/account-dialog/account-dialog.component.ts
@@ -14,7 +14,7 @@ import { ViewGroup } from 'app/site/users/models/view-group';
 import { ViewUser } from 'app/site/users/models/view-user';
 
 import { MeetingRepositoryService } from '../../../core/repositories/management/meeting-repository.service';
-import { UserService } from '../../../core/ui-services/user.service';
+import { PERSONAL_FORM_CONTROLS, UserService } from '../../../core/ui-services/user.service';
 
 interface MenuItem {
     name: string;
@@ -55,13 +55,40 @@ export class AccountDialogComponent extends BaseModelContextComponent implements
 
     public activeMenuItem = this.menuItems[0].name;
 
-    public editSelf = false;
+    public get isAllowedFn(): (permission: string) => boolean {
+        return permission => this.userService.isAllowed(permission, true);
+    }
+
+    public get shouldEnableFormControlFn(): (controlName: string) => boolean {
+        return controlName => {
+            const canManageUsers = this.userService.isAllowed(`manage`, true);
+            if (canManageUsers && this._isUserInScope) {
+                return true;
+            } else {
+                return PERSONAL_FORM_CONTROLS.includes(controlName);
+            }
+        };
+    }
+
+    public set isEditing(is: boolean) {
+        this._isEditing = is;
+        if (is) {
+            this.updateIsUserInScope();
+        }
+    }
+
+    public get isEditing(): boolean {
+        return this._isEditing;
+    }
+
     public isUserFormValid = false;
     public isUserPasswordValid = false;
     public userPersonalForm: any;
     public userPasswordForm: PasswordForm;
 
     private _self: ViewUser;
+    private _isUserInScope: boolean;
+    private _isEditing = false;
 
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
@@ -78,7 +105,8 @@ export class AccountDialogComponent extends BaseModelContextComponent implements
     public ngOnInit(): void {
         super.ngOnInit();
         this.subscriptions.push(
-            this.userRepo.getViewModelObservable(this.operator.operatorId).subscribe(user => (this._self = user))
+            this.userRepo.getViewModelObservable(this.operator.operatorId).subscribe(user => (this._self = user)),
+            this.operator.operatorUpdatedEvent.subscribe(() => this.updateIsUserInScope())
         );
     }
 
@@ -98,17 +126,13 @@ export class AccountDialogComponent extends BaseModelContextComponent implements
     }
 
     public async saveUserChanges(): Promise<void> {
-        if (this.operator.hasPerms(Permission.userCanManage)) {
+        if (this.operator.hasPerms(Permission.userCanManage) && this._isUserInScope) {
             await this.userRepo.update(this.userPersonalForm, this.self);
         } else {
             await this.userRepo.updateSelf(this.userPersonalForm, this.self);
         }
         this.isUserFormValid = false;
-        this.editSelf = false;
-    }
-
-    public getIsAllowedFn(): (permission: string) => boolean {
-        return permission => this.userService.isAllowed(permission, true);
+        this.isEditing = false;
     }
 
     protected getModelRequest(): SimplifiedModelRequest | null {
@@ -118,5 +142,9 @@ export class AccountDialogComponent extends BaseModelContextComponent implements
             fieldset: `orgaEdit`,
             follow: [{ idField: `group_$_ids`, fieldset: `title`, follow: [{ idField: `meeting_id` }] }]
         };
+    }
+
+    private async updateIsUserInScope(): Promise<void> {
+        this._isUserInScope = await this.userService.isUserInScope(this.operator.operatorId);
     }
 }

--- a/client/src/app/management/components/committee-edit/committee-edit.component.ts
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.ts
@@ -22,6 +22,7 @@ import { ViewUser } from 'app/site/users/models/view-user';
 import { Observable, OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { UserRepositoryService } from '../../../core/repositories/users/user-repository.service';
 import { OsOptionSelectionChanged } from '../../../shared/components/search-selector/base-search-value-selector/base-search-value-selector.component';
 
 const ADD_COMMITTEE_LABEL = _(`New committee`);
@@ -55,6 +56,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
 
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
+        userRepo: UserRepositoryService,
         protected translate: TranslateService,
         private formBuilder: FormBuilder,
         private memberService: MemberService,
@@ -74,7 +76,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
         } else {
             super.setTitle(EDIT_COMMITTEE_LABEL);
         }
-        this.organizationMembers = this.memberService.getMemberListObservable();
+        this.organizationMembers = userRepo.getViewModelListObservable();
         this.meetingsObservable = this.meetingRepo.getViewModelListObservable();
     }
 

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.html
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.html
@@ -6,7 +6,7 @@
             {{ title }}
         </mat-card-title>
 
-        <span class="align-right">
+        <span class="align-right align-center">
             <mat-label class="archived-label" *ngIf="meeting.isArchived">{{ 'Archived' | translate }}</mat-label>
             <ng-container *osCmlPerms="CML.can_manage; committeeId: committee.id; nonAdminCheck: true">
                 <button

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.scss
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.scss
@@ -20,7 +20,6 @@
 
         .align-right {
             min-width: 80px;
-            margin-left: auto;
         }
     }
 

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
@@ -187,6 +187,9 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormFieldCont
     }
 
     public addOrRemoveId(id: Id): void {
+        if (!Array.isArray(this.selectedIds)) {
+            this.selectedIds = [];
+        }
         const index = this.selectedIds.indexOf(id);
         const value = this._selectableItemsIdMap[id];
         let selected = false;

--- a/client/src/app/shared/components/user-detail-view/user-detail-view.component.ts
+++ b/client/src/app/shared/components/user-detail-view/user-detail-view.component.ts
@@ -77,14 +77,6 @@ export class UserDetailViewComponent extends BaseComponent {
     }
 
     @Input()
-    public set additionalAllowedPersonalForms(formNames: string[]) {
-        if (formNames) {
-            this._additionalAllowedPersonalForms = formNames;
-            this.prepareForm();
-        }
-    }
-
-    @Input()
     public set additionalValidators(validators: ValidatorFn | ValidatorFn[]) {
         if (!Array.isArray(validators)) {
             validators = [validators];
@@ -101,6 +93,9 @@ export class UserDetailViewComponent extends BaseComponent {
 
     @Input()
     public generatePasswordFn: () => string;
+
+    @Input()
+    public shouldEnableFormControlFn: (controlName: string) => boolean = () => true;
 
     @Output()
     public changeEvent = new EventEmitter();
@@ -133,7 +128,6 @@ export class UserDetailViewComponent extends BaseComponent {
     private _user: ViewUser;
     private _additionalValidators: ValidatorFn[] = [];
     private _additionalFormControls: any = {};
-    private _additionalAllowedPersonalForms: string[] = [];
     private _formValueChangeSubscription: Subscription | null = null;
 
     public constructor(
@@ -231,13 +225,11 @@ export class UserDetailViewComponent extends BaseComponent {
         });
 
         // Disable not permitted controls
-        if (!this.isAllowed(`manage`)) {
-            formControlNames.forEach(formControlName => {
-                if (![`username`, `email`, ...this._additionalAllowedPersonalForms].includes(formControlName)) {
-                    this.personalInfoForm.get(formControlName).disable();
-                }
-            });
-        }
+        formControlNames.forEach(formControlName => {
+            if (!this.shouldEnableFormControlFn(formControlName)) {
+                this.personalInfoForm.get(formControlName).disable();
+            }
+        });
     }
 
     /**

--- a/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.scss
+++ b/client/src/app/site/agenda/components/agenda-item-list/agenda-item-list.component.scss
@@ -13,6 +13,3 @@
         width: $icon-size;
     }
 }
-.align-right {
-    margin-left: auto;
-}

--- a/client/src/app/site/users/components/user-detail/user-detail.component.html
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.html
@@ -3,10 +3,10 @@
     mainButtonIcon="edit"
     [nav]="false"
     [goBack]="!isAllowed('seeOtherUsers')"
-    [editMode]="editUser"
+    [editMode]="isEditingSubject.value"
     [isSaveButtonEnabled]="isFormValid"
     [saveAction]="getSaveAction()"
-    (mainEvent)="setEditMode(!editUser)"
+    (mainEvent)="setEditMode(!isEditingSubject.value)"
 >
     <!-- Title -->
     <div class="title-slot">
@@ -57,12 +57,12 @@
 <os-user-detail-view
     [user]="user"
     [isNewUser]="newUser"
-    [isEditing]="editUser"
+    [isEditing]="isEditingSubject | async"
     [additionalFormControls]="additionalFormControls"
-    [additionalAllowedPersonalForms]="['about_me']"
     [isAllowedFn]="isAllowedFn"
     [generatePasswordFn]="randomPasswordFn"
     [patchFormValueFn]="patchFormValueFn"
+    [shouldEnableFormControlFn]="shouldEnableFormControlFn"
     (changeEvent)="personalInfoFormValue = $event"
     (validEvent)="isFormValid = $event"
     (errorEvent)="formErrors = $event"
@@ -177,7 +177,7 @@
         </span>
     </ng-template>
 
-    <ng-template #showView let-user="user">
+    <ng-template #showView>
         <div *ngIf="isAllowed('seePersonal') && user.isLastEmailSend">
             <div>
                 <h4>{{ 'Last email sent' | translate }}</h4>
@@ -248,7 +248,7 @@
         </div>
     </ng-template>
 
-    <ng-template #moreIcons let-user="user">
+    <ng-template #moreIcons>
         <mat-icon *ngIf="user.isPresentInMeeting() && isAllowed('seeName')" matTooltip="{{ 'Is present' | translate }}">
             check_box
         </mat-icon>

--- a/client/src/app/site/users/components/user-list/user-list.component.html
+++ b/client/src/app/site/users/components/user-list/user-list.component.html
@@ -12,7 +12,8 @@
     <!-- Multiselect info -->
     <div class="central-info-slot">
         <button mat-icon-button (click)="toggleMultiSelect()"><mat-icon>arrow_back</mat-icon></button>
-        <span>{{ selectedRows.length }}&nbsp;</span><span>{{ 'selected' | translate }}</span>
+        <span>{{ selectedRows.length }}&nbsp;</span>
+        <span>{{ 'selected' | translate }}</span>
     </div>
 </os-head-bar>
 
@@ -31,7 +32,8 @@
 >
     <!-- extra content in the filter bar -->
     <div class="filter-bar-info-slot" *ngIf="showVoteWeight">
-        &nbsp;<span>({{ 'Vote weight' | translate }} {{ totalVoteWeight }})</span>
+        &nbsp;
+        <span>({{ 'Vote weight' | translate }} {{ totalVoteWeight }})</span>
     </div>
 
     <!-- Name column -->
@@ -66,7 +68,8 @@
             <div *ngIf="user.groups() && user.groups().length">
                 <os-icon-container icon="people" noWrap="true">
                     <span *ngFor="let group of user.groups(); let last = last">
-                        {{ group.getTitle() | translate }}<span *ngIf="!last">,</span>
+                        {{ group.getTitle() | translate }}
+                        <span *ngIf="!last">,</span>
                     </span>
                 </os-icon-container>
             </div>
@@ -108,7 +111,7 @@
             </mat-icon>
 
             <!-- Has comment indicator -->
-            <mat-icon inline *ngIf="!!user.comment()" matTooltip="{{ user.comment() }}"> comment </mat-icon>
+            <mat-icon inline *ngIf="!!user.comment()" matTooltip="{{ user.comment() }}">comment</mat-icon>
 
             <!--<os-icon-container *ngIf="user.isSamlUser" icon="device_hub"
                 ><span>{{ 'Is SAML user' | translate }}</span></os-icon-container
@@ -278,7 +281,11 @@
             ></os-search-value-selector>
         </mat-form-field>
         <mat-form-field>
-            <mat-select placeholder="{{ 'Gender' | translate }}" [(ngModel)]="infoDialog.gender">
+            <mat-select
+                placeholder="{{ 'Gender' | translate }}"
+                [disabled]="!isUserInScope"
+                [(ngModel)]="infoDialog.gender"
+            >
                 <mat-option>-</mat-option>
                 <mat-option *ngFor="let gender of genderList" [value]="gender">{{ gender | translate }}</mat-option>
             </mat-select>

--- a/client/src/app/site/users/components/user-list/user-list.component.ts
+++ b/client/src/app/site/users/components/user-list/user-list.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
 import { PblColumnDefinition } from '@pebula/ngrid';
-import { ActiveMeetingIdService } from 'app/core/core-services/active-meeting-id.service';
 import { SimplifiedModelRequest } from 'app/core/core-services/model-request-builder.service';
 import { OperatorService } from 'app/core/core-services/operator.service';
 import { Permission } from 'app/core/core-services/permission';
@@ -13,7 +12,6 @@ import { UserRepositoryService, UserStateField } from 'app/core/repositories/use
 import { ChoiceService } from 'app/core/ui-services/choice.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { CsvExportService } from 'app/core/ui-services/csv-export.service';
-import { MeetingSettingsService } from 'app/core/ui-services/meeting-settings.service';
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { ViewMeeting } from 'app/management/models/view-meeting';
 import { genders } from 'app/shared/models/users/user';
@@ -22,6 +20,7 @@ import { BaseListViewComponent } from 'app/site/base/components/base-list-view.c
 import { PollService } from 'app/site/polls/services/poll.service';
 import { BehaviorSubject, Observable } from 'rxjs';
 
+import { UserService } from '../../../../core/ui-services/user.service';
 import { ViewGroup } from '../../models/view-group';
 import { ViewUser } from '../../models/view-user';
 import { UserFilterListService } from '../../services/user-filter-list.service';
@@ -141,6 +140,10 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
         return votes ?? 0;
     }
 
+    public get isUserInScope(): boolean {
+        return this._isUserInScope;
+    }
+
     /**
      * Define the columns to show
      */
@@ -168,7 +171,8 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
      */
     public filterProps = [`full_name`, `groups`, `structure_level`, `number`, `delegationName`];
 
-    private allowSelfSetPresent: boolean;
+    private _allowSelfSetPresent: boolean;
+    private _isUserInScope = true;
 
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
@@ -183,7 +187,7 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
         private promptService: PromptService,
         public filterService: UserFilterListService,
         public sortService: UserSortListService,
-        private meetingSettingsService: MeetingSettingsService,
+        private userService: UserService,
         private userPdf: UserPdfExportService,
         private dialog: MatDialog,
         private pollService: PollService
@@ -192,15 +196,15 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
 
         // enable multiSelect for this listView
         this.canMultiSelect = true;
-        this.meetingSettingsService
+        this.meetingSettingService
             .get(`users_enable_presence_view`)
             .subscribe(state => (this._presenceViewConfigured = state));
-        this.meetingSettingsService
+        this.meetingSettingService
             .get(`users_enable_vote_weight`)
             .subscribe(enabled => (this.voteWeightEnabled = enabled));
-        this.meetingSettingsService
+        this.meetingSettingService
             .get(`users_allow_self_set_present`)
-            .subscribe(allowed => (this.allowSelfSetPresent = allowed));
+            .subscribe(allowed => (this._allowSelfSetPresent = allowed));
     }
 
     /**
@@ -260,7 +264,7 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
     public isPresentToggleDisabled(user: ViewUser): boolean {
         if (this.isMultiSelect) {
             return true;
-        } else if (this.allowSelfSetPresent && this.operator.operatorId === user.id) {
+        } else if (this._allowSelfSetPresent && this.operator.operatorId === user.id) {
             return false;
         } else {
             return !this.operator.hasPerms(Permission.userCanManage);
@@ -274,10 +278,11 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
      *
      * @param user is an instance of ViewUser. This is the given user, who will be modified.
      */
-    public openEditInfo(user: ViewUser, ev: MouseEvent): void {
+    public async openEditInfo(user: ViewUser, ev: MouseEvent): Promise<void> {
         if (this.isMultiSelect || !this.operator.hasPerms(Permission.userCanManage)) {
             return;
         }
+        this._isUserInScope = await this.userService.isUserInScope(user.id);
         ev.stopPropagation();
         this.infoDialog = {
             name: user.username,
@@ -422,7 +427,7 @@ export class UserListComponent extends BaseListViewComponent<ViewUser> implement
     public setPresent(viewUser: ViewUser): void {
         const isAllowed =
             this.operator.hasPerms(Permission.userCanManage) ||
-            (this.allowSelfSetPresent && this.operator.operatorId === viewUser.id);
+            (this._allowSelfSetPresent && this.operator.operatorId === viewUser.id);
         if (isAllowed) {
             this.repo.setPresent(!this.isUserPresent(viewUser), viewUser);
         }

--- a/client/src/assets/styles/default-classes.scss
+++ b/client/src/assets/styles/default-classes.scss
@@ -37,3 +37,16 @@
         line-height: $size;
     }
 }
+
+.align-right {
+    margin-left: auto;
+}
+
+.align-left {
+    margin-right: auto;
+}
+
+.align-center {
+    margin-top: auto;
+    margin-bottom: auto;
+}


### PR DESCRIPTION
- Fixes incorrect editing of users who are out of scope
- Fixes the loading of meetings in the dashboard
- Fixes the 'non-admin-check' in the OperatorService

Fixes #633

There are different ways to test:
- As superadmin, I should be able to edit every user regardless of their scope
- As only meeting-admin, I should be able to edit every user, who is only in the same meeting (not in a committee or elsewhere)
- As only meeting-admin, I should always be able to edit meeting-related information of every user in the same meeting
- I can always edit my own username, my own email (and `about_me` within a meeting) 