### PR TITLE
Updates relations to recognize if a countdown or a message were deleted

### DIFF
--- a/client/src/app/core/repositories/base-repository.ts
+++ b/client/src/app/core/repositories/base-repository.ts
@@ -1,5 +1,5 @@
 import { TranslateService } from '@ngx-translate/core';
-import { Collection } from 'app/shared/models/base/collection';
+import { HasCollection } from 'app/shared/models/base/collection';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { auditTime } from 'rxjs/operators';
 
@@ -38,7 +38,7 @@ const RELATION_AS_OBSERVABLE_SUFFIX = `_as_observable`;
  *
  */
 export abstract class BaseRepository<V extends BaseViewModel, M extends BaseModel>
-    implements OnAfterAppsLoaded, Collection, HasViewModelListObservable<V>
+    implements OnAfterAppsLoaded, HasCollection, HasViewModelListObservable<V>
 {
     /**
      * Stores all the viewModel in an object

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -327,13 +327,15 @@ export const RELATIONS: Relation[] = [
         OViewModel: ViewMeeting,
         MViewModel: ViewProjectorMessage,
         OField: `projector_messages`,
-        MField: `meeting`
+        MField: `meeting`,
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,
         MViewModel: ViewProjectorCountdown,
         OField: `projector_countdowns`,
-        MField: `meeting`
+        MField: `meeting`,
+        isFullList: true
     }),
     ...makeM2O({
         OViewModel: ViewMeeting,

--- a/client/src/app/shared/components/projector/projector.component.ts
+++ b/client/src/app/shared/components/projector/projector.component.ts
@@ -178,7 +178,7 @@ export class ProjectorComponent extends BaseComponent implements OnDestroy {
                 (data[0]?.current_projections || []).map(
                     projection =>
                         ({
-                            collection: collectionFromFqid(projection.content_object_id),
+                            collection: projection.content?.collection,
                             data: projection.content,
                             stable: !!projection.stable,
                             type: projection.type || ``,

--- a/client/src/app/shared/models/base/base-model.ts
+++ b/client/src/app/shared/models/base/base-model.ts
@@ -1,7 +1,7 @@
 import { fqidFromCollectionAndId } from 'app/core/core-services/key-transforms';
 import { Fqid, Id } from 'app/core/definitions/key-types';
 
-import { Collection } from './collection';
+import { HasCollection } from './collection';
 import { Deserializer } from './deserializer';
 import { Identifiable } from './identifiable';
 
@@ -14,7 +14,7 @@ export interface ModelConstructor<T extends BaseModel<T>> {
  * Abstract parent class to set rules and functions for all models.
  * When inherit from this class, give the subclass as the type. E.g. `class Motion extends BaseModel<Motion>`
  */
-export abstract class BaseModel<T = any> extends Deserializer implements Identifiable, Collection {
+export abstract class BaseModel<T = any> extends Deserializer implements Identifiable, HasCollection {
     /**
      * @returns The full-qualified id of an object.
      */

--- a/client/src/app/shared/models/base/collection.ts
+++ b/client/src/app/shared/models/base/collection.ts
@@ -1,6 +1,8 @@
+import { Collection } from 'app/core/definitions/key-types';
+
 /**
  * Every implementing object should have a collection string.
  */
-export interface Collection {
-    readonly collection: string;
+export interface HasCollection {
+    readonly collection: Collection;
 }

--- a/client/src/app/shared/models/projector/projection.ts
+++ b/client/src/app/shared/models/projector/projection.ts
@@ -1,7 +1,10 @@
 import { Fqid, Id } from 'app/core/definitions/key-types';
 
 import { BaseModel } from '../base/base-model';
+import { HasCollection } from '../base/collection';
 import { HasMeetingId } from '../base/has-meeting-id';
+
+type ProjectionContent = HasCollection & { [key: string]: any };
 
 export class Projection extends BaseModel<Projection> {
     public static COLLECTION = `projection`;
@@ -15,7 +18,7 @@ export class Projection extends BaseModel<Projection> {
     public weight: number;
 
     // Calculated field
-    public content: any;
+    public content: ProjectionContent;
 
     public content_object_id: Fqid; // */projection_ids
     public current_projector_id: Id; // projector/current_projection_ids;

--- a/client/src/app/site/base/base-view-model.ts
+++ b/client/src/app/site/base/base-view-model.ts
@@ -1,6 +1,6 @@
 import { Fqid, Id } from 'app/core/definitions/key-types';
 import { BaseModel } from 'app/shared/models/base/base-model';
-import { Collection } from 'app/shared/models/base/collection';
+import { HasCollection } from 'app/shared/models/base/collection';
 
 import { Identifiable } from '../../shared/models/base/identifiable';
 import { Displayable } from './displayable';
@@ -49,7 +49,7 @@ export abstract class BaseViewModel<M extends BaseModel = any> {
         return ``;
     }
 }
-export interface BaseViewModel<M extends BaseModel = any> extends Displayable, Identifiable, Collection {
+export interface BaseViewModel<M extends BaseModel = any> extends Displayable, Identifiable, HasCollection {
     getTitle: () => string;
     getListTitle: () => string;
 

--- a/client/src/app/site/projector/components/projector-list-entry/projector-list-entry.component.ts
+++ b/client/src/app/site/projector/components/projector-list-entry/projector-list-entry.component.ts
@@ -99,7 +99,7 @@ export class ProjectorListEntryComponent extends BaseComponent implements OnInit
         if (this.operator.hasPerms(Permission.projectorCanManage)) {
             return `/${this.activeMeetingId}/projectors/detail/${this.projector.id}`;
         } else {
-            return `/projector/${this.projector.id}`;
+            return `/${this.activeMeetingId}/projector/${this.projector.id}`;
         }
     }
 


### PR DESCRIPTION
- Also, renames interface Collection -> interface HasCollection
- Also, a user sees a projection and its content, now
- Also, a "delegates" will be redirected to `/{{ active-meeting-id }}/projector/{{ projector-id }}` when clicking on a projector in a projector-list

Fixes #628
Fixes #577