### PR TITLE
Fixes: The navigation after "committee.create"/"committee.update"

### DIFF
--- a/client/src/app/management/components/committee-list/committee-list.component.ts
+++ b/client/src/app/management/components/committee-list/committee-list.component.ts
@@ -19,6 +19,8 @@ import { Follow } from '../../../core/core-services/model-request-builder.servic
 import { MeetingRepositoryService } from '../../../core/repositories/management/meeting-repository.service';
 import { CommitteeExportService } from '../../services/committee-export.service';
 
+export const NAVIGATION_FROM_LIST = `list`;
+
 const getCommitteesModelRequest = (fellowship?: Follow) => {
     const FOLLOW: Follow[] = [
         {
@@ -95,7 +97,10 @@ export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee>
     }
 
     public editSingle(committee: ViewCommittee): void {
-        this.router.navigate([committee.id, `edit-committee`], { relativeTo: this.route });
+        this.router.navigate([committee.id, `edit-committee`], {
+            relativeTo: this.route,
+            queryParams: { from: NAVIGATION_FROM_LIST }
+        });
     }
 
     public createNewCommittee(): void {


### PR DESCRIPTION
- After creating a committee, the operator stays at the detail-view of committees
- After updating a committee, the routing depends of where an operator came from

Fixes #662