### PR TITLE
Exclude non natural users from call restrictions

### DIFF
--- a/client/src/app/core/core-services/operator.service.ts
+++ b/client/src/app/core/core-services/operator.service.ts
@@ -31,7 +31,8 @@ const OPERATOR_FIELDS: (keyof User)[] = [
     `committee_ids`,
     `can_change_own_password`,
     `is_present_in_meeting_ids`,
-    `default_structure_level`
+    `default_structure_level`,
+    `is_physical_person`
 ];
 
 function getUserCML(user: ViewUser): { [id: number]: string } | null {


### PR DESCRIPTION
Allows non natural users from using restricted jitsi channels as they
please. They would not be kicked nor prevented from entering the call

fixes #632