### PR TITLE
Fixes: Some client issues...

### DIFF
--- a/client/src/app/management/components/dashboard/dashboard.component.html
+++ b/client/src/app/management/components/dashboard/dashboard.component.html
@@ -14,67 +14,89 @@
 </mat-card>
 
 <ng-container *ngIf="!noMeetingsToShow">
-    <!-- active meetings -->
-    <div id="active-meetings" class="meeting-list-container">
-        <div class="meeting-icon-wrapper foreground-accent">
-            <mat-icon color="accent">access_alarm</mat-icon>
-            <span>{{ 'active' | translate }}</span>
+    <div class="padding-right-8">
+        <!-- active meetings -->
+        <div id="active-meetings" class="meeting-list-container">
+            <div class="meeting-icon-wrapper foreground-accent">
+                <mat-icon color="accent">access_alarm</mat-icon>
+                <span>{{ 'active' | translate }}</span>
+            </div>
+            <div class="meeting-list background-card">
+                <mat-card class="no-meetings-card" *ngIf="!currentMeetings.length">
+                    {{ 'No meetings available' | translate }}
+                </mat-card>
+                <ng-container *ngFor="let meeting of currentMeetings; let last = last">
+                    <ng-container
+                        [ngTemplateOutlet]="meetingTemplate"
+                        [ngTemplateOutletContext]="{
+                            meeting: meeting,
+                            context: {
+                                wrapperCssClass: 'background-accent',
+                                cssClass: 'foreground-accent-contrast'
+                            }
+                        }"
+                    ></ng-container>
+                    <mat-divider *ngIf="!last"></mat-divider>
+                </ng-container>
+            </div>
         </div>
-        <div class="meeting-list background-card">
-            <mat-card class="no-meetings-card" *ngIf="!currentMeetings.length">
-                {{ 'No meetings available' | translate }}
-            </mat-card>
-            <ng-container *ngFor="let meeting of currentMeetings; let last = last">
-                <ng-container
-                    [ngTemplateOutlet]="meetingTemplate"
-                    [ngTemplateOutletContext]="{
-                        meeting: meeting,
-                        cssClass: 'background-accent foreground-accent-contrast'
-                    }"
-                ></ng-container>
-                <mat-divider *ngIf="!last"></mat-divider>
-            </ng-container>
-        </div>
-    </div>
 
-    <!-- future meetings -->
-    <div id="future-meetings" class="meeting-list-container">
-        <div class="meeting-icon-wrapper foreground-primary">
-            <mat-icon color="primary">update</mat-icon>
-            <span>{{ 'future' | translate }}</span>
+        <!-- future meetings -->
+        <div id="future-meetings" class="meeting-list-container">
+            <div class="meeting-icon-wrapper foreground-primary">
+                <mat-icon color="primary">update</mat-icon>
+                <span>{{ 'future' | translate }}</span>
+            </div>
+            <ng-container
+                [ngTemplateOutlet]="meetingListTemplate"
+                [ngTemplateOutletContext]="{
+                    meetingList: futureMeetings,
+                    context: {
+                        cssClass: 'anchor-button',
+                        wrapperCssClass: 'subtitle',
+                        subtitleCssClass: 'light-gray-by-theme'
+                    }
+                }"
+            ></ng-container>
         </div>
-        <ng-container
-            [ngTemplateOutlet]="meetingListTemplate"
-            [ngTemplateOutletContext]="{ meetingList: futureMeetings }"
-        ></ng-container>
-    </div>
 
-    <!-- previous meetings -->
-    <div id="previous-meetings" class="meeting-list-container">
-        <div class="meeting-icon-wrapper">
-            <mat-icon aria-hidden="true">history</mat-icon>
-            <span>{{ 'ended' | translate }}</span>
+        <!-- previous meetings -->
+        <div id="previous-meetings" class="meeting-list-container">
+            <div class="meeting-icon-wrapper">
+                <mat-icon aria-hidden="true">history</mat-icon>
+                <span>{{ 'ended' | translate }}</span>
+            </div>
+            <ng-container
+                [ngTemplateOutlet]="meetingListTemplate"
+                [ngTemplateOutletContext]="{
+                    meetingList: previousMeetings,
+                    context: {
+                        cssClass: 'light-gray-by-theme',
+                        wrapperCssClass: 'subtitle',
+                        subtitleCssClass: 'subtitle'
+                    }
+                }"
+            ></ng-container>
         </div>
-        <ng-container
-            [ngTemplateOutlet]="meetingListTemplate"
-            [ngTemplateOutletContext]="{ meetingList: previousMeetings, cssClass: 'light-gray-by-theme' }"
-        ></ng-container>
-    </div>
 
-    <!-- meetings with no date -->
-    <div id="no-date-meetings" class="meeting-list-container">
-        <div class="meeting-icon-wrapper">
-            <mat-icon aria-hidden="true">watch_later</mat-icon>
-            <span>{{ 'dateless' | translate }}</span>
+        <!-- meetings with no date -->
+        <div id="no-date-meetings" class="meeting-list-container">
+            <div class="meeting-icon-wrapper">
+                <mat-icon aria-hidden="true">watch_later</mat-icon>
+                <span>{{ 'dateless' | translate }}</span>
+            </div>
+            <ng-container
+                [ngTemplateOutlet]="meetingListTemplate"
+                [ngTemplateOutletContext]="{
+                    meetingList: noDateMeetings,
+                    context: { cssClass: 'light-gray-by-theme', wrapperCssClass: 'subtitle' }
+                }"
+            ></ng-container>
         </div>
-        <ng-container
-            [ngTemplateOutlet]="meetingListTemplate"
-            [ngTemplateOutletContext]="{ meetingList: noDateMeetings, cssClass: 'light-gray-by-theme' }"
-        ></ng-container>
     </div>
 </ng-container>
 
-<ng-template let-meetingList="meetingList" let-cssClass="cssClass" #meetingListTemplate>
+<ng-template let-meetingList="meetingList" let-context="context" #meetingListTemplate>
     <div
         class="meeting-list"
         [ngClass]="{ 'no-meetings': !meetingList.length }"
@@ -94,7 +116,7 @@
                 >
                     <ng-container
                         [ngTemplateOutlet]="meetingTemplate"
-                        [ngTemplateOutletContext]="{ meeting: meeting, cssClass: cssClass }"
+                        [ngTemplateOutletContext]="{ meeting: meeting, context: context }"
                     ></ng-container>
                 </div>
             </ng-container>
@@ -102,26 +124,36 @@
     </div>
 </ng-template>
 
-<ng-template let-meeting="meeting" let-cssClass="cssClass" #meetingTemplate>
-    <div matRipple class="meeting-box" [ngClass]="cssClass" [routerLink]="meeting.id">
-        <div class="one-line">
-            <div class="meeting-box--mid one-line" [matTooltip]="meeting.name">
-                {{ meeting.name }}
+<ng-template let-meeting="meeting" let-context="context" #meetingTemplate>
+    <div class="meeting-box" [ngClass]="context?.wrapperCssClass">
+        <a [routerLink]="meeting.id" [ngClass]="context?.cssClass" class="full-width flex-vertical-center" matRipple>
+            <div class="one-line">
+                <div class="meeting-box--mid one-line" [matTooltip]="meeting.name">
+                    {{ meeting.name }}
+                </div>
+                <div>
+                    <span [ngClass]="context?.subtitleCssClass" *ngIf="meeting.location">{{ meeting.location }}</span>
+                    <span
+                        [ngClass]="context?.subtitleCssClass"
+                        *ngIf="meeting.location && (meeting.start_time || meeting.end_time)"
+                    >
+                        &nbsp;&middot;&nbsp;
+                    </span>
+                    <span *ngIf="meeting.start_time || meeting.end_time">
+                        <os-meeting-time [meeting]="meeting" [cssClass]="context?.subtitleCssClass"></os-meeting-time>
+                    </span>
+                </div>
             </div>
-            <div>
-                <span *ngIf="meeting.location">{{ meeting.location }}</span>
-                <span *ngIf="meeting.location && (meeting.start_time || meeting.end_time)">&nbsp;&middot;&nbsp;</span>
-                <span *ngIf="meeting.start_time || meeting.end_time">
-                    <ng-container *ngTemplateOutlet="meetingTime; context: { meeting: meeting }"></ng-container>
-                </span>
-            </div>
-        </div>
+        </a>
+        <a
+            mat-icon-button
+            [routerLink]="['/', 'committees', meeting.committee_id]"
+            matTooltip="{{ 'Go to its committee' | translate }}"
+        >
+            <mat-icon>auto_awesome_mosaic</mat-icon>
+        </a>
         <mat-icon *ngIf="meeting.isArchived" matTooltip="{{ 'This meeting is archived' | translate }}">
             archive
         </mat-icon>
     </div>
-</ng-template>
-
-<ng-template let-meeting="meeting" #meetingTime>
-    <os-meeting-time [meeting]="meeting"></os-meeting-time>
 </ng-template>

--- a/client/src/app/management/components/dashboard/dashboard.component.scss
+++ b/client/src/app/management/components/dashboard/dashboard.component.scss
@@ -27,11 +27,11 @@ os-dashboard {
 
     .meeting-list-container {
         @include desktop {
-            width: 1000px;
+            max-width: 1000px;
             margin: 20px auto;
         }
         display: flex;
-        margin: 0 8px 8px 0;
+        margin: 0 0px 8px 0;
     }
 
     .meeting-icon-wrapper,
@@ -109,6 +109,10 @@ os-dashboard {
         justify-content: space-between;
         box-sizing: border-box;
         height: 60px;
+
+        > a {
+            text-decoration: none;
+        }
 
         &--mid {
             font-size: 18px;

--- a/client/src/app/management/components/dashboard/dashboard.component.ts
+++ b/client/src/app/management/components/dashboard/dashboard.component.ts
@@ -110,7 +110,7 @@ export class DashboardComponent extends BaseModelContextComponent implements OnI
             viewModelCtor: ViewOrganization,
             ids: [ORGANIZATION_ID],
             follow: [
-                { idField: `active_meeting_ids`, fieldset: `dashboard`, follow: [`user_ids`] },
+                { idField: `active_meeting_ids`, fieldset: `dashboard`, follow: [`user_ids`, `committee_id`] },
                 {
                     idField: `committee_ids`,
                     follow: [{ idField: `meeting_ids`, fieldset: `dashboard`, follow: [`user_ids`] }]

--- a/client/src/app/management/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/management/components/meeting-edit/meeting-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
@@ -39,7 +39,8 @@ const USER_GROUPS_FOLLOW_FN = (meetingId: Id) => ({
 @Component({
     selector: `os-meeting-edit`,
     templateUrl: `./meeting-edit.component.html`,
-    styleUrls: [`./meeting-edit.component.scss`]
+    styleUrls: [`./meeting-edit.component.scss`],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MeetingEditComponent extends BaseModelContextComponent implements OnInit {
     public readonly CML = CML;
@@ -269,7 +270,7 @@ export class MeetingEditComponent extends BaseModelContextComponent implements O
 
     private onAfterCreateForm(): void {
         this.enableFormControls();
-        if (!this.isMeetingAdmin) {
+        if (!this.isMeetingAdmin && !this.isCreateView) {
             Object.keys(this.meetingForm.controls).forEach(controlName => {
                 if (!ORGA_ADMIN_ALLOWED_CONTROLNAMES.includes(controlName)) {
                     this.meetingForm.get(controlName).disable();

--- a/client/src/app/shared/components/list-of-speakers-content/list-of-speakers-content.component.html
+++ b/client/src/app/shared/components/list-of-speakers-content/list-of-speakers-content.component.html
@@ -114,7 +114,7 @@
                         <!-- Extra stuff: Spoken Count, Gender, 1st Contribution -->
                         <span *ngIf="canManage && !speaker.point_of_order">
                             <!-- Speaker count -->
-                            <span *ngIf="hasSpokenCount(speaker)" class="red-warning-text speaker-warning">
+                            <span *ngIf="hasSpokenCount(speaker)" class="foreground-warn speaker-warning">
                                 {{ hasSpokenCount(speaker) + 1 }}.
                                 <span>{{ 'contribution' | translate }}</span>
                             </span>
@@ -122,7 +122,7 @@
                             <!-- First contribution -->
                             <span
                                 *ngIf="(showFistContributionHint | async) && isFirstContribution(speaker)"
-                                class="red-warning-text speaker-warning"
+                                class="foreground-warn speaker-warning"
                             >
                                 {{ 'First speech' | translate }}
                             </span>
@@ -344,7 +344,7 @@
         >
             warning
         </mat-icon>
-        <i [class.red-warning-text]="!!showcolor" *ngIf="(showSpeakerNoteForEveryoneObservable | async) || canManage">
+        <i [class.foreground-warn]="!!showcolor" *ngIf="(showSpeakerNoteForEveryoneObservable | async) || canManage">
             {{ speaker.note }}
         </i>
     </ng-container>

--- a/client/src/app/shared/components/meeting-time/meeting-time.component.html
+++ b/client/src/app/shared/components/meeting-time/meeting-time.component.html
@@ -1,14 +1,17 @@
-<ng-container *ngIf="meeting">
-    <ng-container *ngIf="meeting.start_time === meeting.end_time">
-        <span>{{ meeting.start_time | localizedDate: 'll' }}</span>
+<span [ngClass]="cssClass">
+    <ng-container *ngIf="meeting">
+        <ng-container
+            *ngTemplateOutlet="timeTemplate; context: { startTime: meeting.start_time, endTime: meeting.end_time }"
+        ></ng-container>
     </ng-container>
-    <ng-container *ngIf="meeting.start_time !== meeting.end_time">
-        <span *ngIf="meeting.start_time">{{ meeting.start_time | localizedDate: 'll' }}</span>
-        <span *ngIf="meeting.start_time && meeting.end_time">&nbsp;-&nbsp;</span>
-        <span *ngIf="meeting.end_time">{{ meeting.end_time | localizedDate: 'll' }}</span>
+    <ng-container *ngIf="!meeting">
+        <ng-container
+            *ngTemplateOutlet="timeTemplate; context: { startTime: startTime, endTime: endTime }"
+        ></ng-container>
     </ng-container>
-</ng-container>
-<ng-container *ngIf="!meeting">
+</span>
+
+<ng-template #timeTemplate let-startTime="startTime" let-endTime="endTime">
     <ng-container *ngIf="startTime === endTime">
         <span>{{ startTime | localizedDate: 'll' }}</span>
     </ng-container>
@@ -17,4 +20,4 @@
         <span *ngIf="startTime && endTime">&nbsp;-&nbsp;</span>
         <span *ngIf="endTime">{{ endTime | localizedDate: 'll' }}</span>
     </ng-container>
-</ng-container>
+</ng-template>

--- a/client/src/app/shared/components/meeting-time/meeting-time.component.ts
+++ b/client/src/app/shared/components/meeting-time/meeting-time.component.ts
@@ -8,11 +8,14 @@ import { ViewMeeting } from '../../../management/models/view-meeting';
 })
 export class MeetingTimeComponent {
     @Input()
-    public meeting: ViewMeeting;
+    public meeting?: ViewMeeting;
 
     @Input()
     public startTime?: string | number;
 
     @Input()
     public endTime?: string | number;
+
+    @Input()
+    public cssClass: string | string[];
 }

--- a/client/src/app/site/login/components/login-mask/login-mask.component.html
+++ b/client/src/app/site/login/components/login-mask/login-mask.component.html
@@ -31,12 +31,11 @@
                 formControlName="password"
                 [type]="!hide ? 'password' : 'text'"
             />
-            <mat-icon color="primary" matSuffix (click)="hide = !hide">{{
-                hide ? 'visibility_off' : 'visibility_on'
-            }}</mat-icon>
-
-            <mat-error>{{ loginErrorMsg | translate }}</mat-error>
+            <mat-icon color="primary" matSuffix (click)="hide = !hide">
+                {{ hide ? 'visibility_off' : 'visibility_on' }}
+            </mat-icon>
         </mat-form-field>
+        <mat-error>{{ loginErrorMsg | translate }}</mat-error>
 
         <!-- forgot password button -->
         <br />

--- a/client/src/app/site/login/components/login-mask/login-mask.component.ts
+++ b/client/src/app/site/login/components/login-mask/login-mask.component.ts
@@ -180,10 +180,8 @@ export class LoginMaskComponent extends BaseComponent implements OnInit, OnDestr
             await this.authService.login(username, password, this.currentMeetingId);
         } catch (e) {
             this.spinnerService.hide();
-            this.loginForm.get(`password`).setErrors({ notFound: true });
             this.loginErrorMsg = e;
         }
-        // throw new Error('TODO'); // Ingore SAML for now...
     }
 
     public async guestLogin(): Promise<void> {

--- a/client/src/app/site/login/components/reset-password/reset-password.component.html
+++ b/client/src/app/site/login/components/reset-password/reset-password.component.html
@@ -22,8 +22,11 @@
             class="submit-button"
             [disabled]="resetPasswordForm.invalid"
         >
-            {{ 'Reset password' | translate }}</button
-        >&nbsp;
-        <button type="button" mat-button routerLink="..">{{ 'Back' | translate }}</button>
+            {{ 'Reset password' | translate }}
+        </button>
+        &nbsp;
+        <button type="button" mat-button [routerLink]="['/', activeMeetingId, 'login']">
+            {{ 'Back' | translate }}
+        </button>
     </form>
 </div>

--- a/client/src/app/site/login/components/reset-password/reset-password.component.ts
+++ b/client/src/app/site/login/components/reset-password/reset-password.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpService } from 'app/core/core-services/http.service';
 import { ComponentServiceCollector } from 'app/core/ui-services/component-service-collector';
 import { BaseComponent } from 'app/site/base/components/base.component';
 
@@ -29,7 +28,6 @@ export class ResetPasswordComponent extends BaseComponent implements OnInit {
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
         protected translate: TranslateService,
-        private http: HttpService,
         formBuilder: FormBuilder,
         private router: Router,
         private userRepo: UserRepositoryService

--- a/client/src/app/site/users/components/user-detail/user-detail.component.html
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.html
@@ -67,7 +67,7 @@
     (validEvent)="isFormValid = $event"
     (errorEvent)="formErrors = $event"
     (submitEvent)="saveUser()"
-    *ngIf="user"
+    *ngIf="user || newUser"
 >
     <ng-template #editView let-form="form">
         <div [formGroup]="form">
@@ -256,6 +256,6 @@
     </ng-template>
 </os-user-detail-view>
 
-<os-not-found *ngIf="!user">
-    {{ 'The user you requested is not accesible' | translate }}
+<os-not-found *ngIf="!user && !newUser">
+    {{ 'The user you requested is not accessible' | translate }}
 </os-not-found>


### PR DESCRIPTION
- In a list of speakers, every "red warning" text is replaced by the warn colors of a theme
- The button "login" at the login-mask is always active as long as a username and a password is typed in
- At the dashboard: Space to the right (viewport <= 1100px)
- At the dashboard: Every meeting in the dashboard has a "jump" button to its dedicated committee
- A user can be created, again
- Navigate back from '/forget-password' works
- Slightly adjusted the meetings' boxes at the dashboard

Fixes #684