### PR TITLE
Navigating back to detail-view

### DIFF
--- a/client/src/app/management/components/committee-edit/committee-edit.component.ts
+++ b/client/src/app/management/components/committee-edit/committee-edit.component.ts
@@ -143,7 +143,7 @@ export class CommitteeEditComponent extends BaseModelContextComponent implements
     }
 
     public onCancel(): void {
-        this.navigateBack();
+        this.navigateBack(this.committeeId);
     }
 
     /**


### PR DESCRIPTION
Fixes #681 

If a manager navigates from a committee's detail-view to its edit-view, they will be redirected to its detail-view, if the cancel button is clicked.