### PR TITLE
Improves the "cleanup" command for the client

### DIFF
--- a/client/cli/cleanup.ts
+++ b/client/cli/cleanup.ts
@@ -1,0 +1,54 @@
+import { spawn } from 'child_process';
+
+const clearLastLine = () => {
+    process.stdout.moveCursor(0, -1);
+    process.stdout.clearLine(1);
+};
+
+const spawnChildProcess = (
+    command: string,
+    { onData = data => process.stdout.write(data.toString()) }: { onData?: (data: Buffer) => void } = {}
+) => {
+    return new Promise<number>(resolve => {
+        console.log(`${command}: Starting process...`);
+        const startTime = new Date().getTime();
+        const child = spawn(command, { shell: true });
+
+        // write to the console
+        child.stdout.on(`data`, data => onData(data));
+
+        // print errors
+        child.stderr.on(`data`, data => process.stdout.write(data.toString()));
+
+        child.on(`close`, code => {
+            const endTime = new Date().getTime();
+            console.log(`\n\r`);
+            console.log(`${command}: Finished with code ${code}.`);
+            console.log(`${command}: Execution took ${Math.round((endTime - startTime) / 1000)} s.\n\r`);
+            resolve(code);
+        });
+    });
+};
+
+const doLinting = async () => {
+    return await spawnChildProcess(`npm run lint-write`);
+};
+
+const doPrettifying = async () => {
+    return await spawnChildProcess(`npm run prettify-write`, {
+        onData: data => {
+            process.stdout.write(data.toString());
+            setTimeout(() => clearLastLine(), 2);
+        }
+    });
+};
+
+(async () => {
+    const lintFinishCode = await doLinting();
+    const prettifyFinishCode = await doPrettifying();
+    if (lintFinishCode + prettifyFinishCode === 0) {
+        console.log(`Cleanup finishes successfully.`);
+    } else {
+        console.log(`Cleanup finishes with an error.`);
+    }
+})();

--- a/client/package.json
+++ b/client/package.json
@@ -30,8 +30,7 @@
         "po2json-tempfix": "./node_modules/.bin/po2json -f mf src/assets/i18n/de.po /dev/stdout | sed -f sed_replacements > src/assets/i18n/de.json && ./node_modules/.bin/po2json -f mf src/assets/i18n/cs.po /dev/stdout | sed -f sed_replacements > src/assets/i18n/cs.json && ./node_modules/.bin/po2json -f mf src/assets/i18n/ru.po /dev/stdout | sed -f sed_replacements > src/assets/i18n/ru.json",
         "prettify-check": "prettier --config ./.prettierrc --list-different \"src/{app,environments}/**/*{.ts,.js,.json,.css,.scss}\" cli/*{.ts,.json}",
         "prettify-write": "prettier --config ./.prettierrc --write \"src/{app,environments}/**/*{.ts,.js,.json,.css,.scss}\" cli/*{.ts,.json}",
-        "cleanup": "npm run prettify-write; npm run lint-write",
-        "cleanup-win": "npm run prettify-write & npm run lint-write",
+        "cleanup": "ts-node -s -r tsconfig-paths/register cli/cleanup.ts",
         "generate-defaults": "ts-node -s -r tsconfig-paths/register cli/generate-settings-defaults.ts && prettier --config ./.prettierrc --write src/app/core/repositories/management/meeting-settings-defaults.ts",
         "generate-permissions": "ts-node -s -r tsconfig-paths/register cli/generate-permissions.ts && prettier --config ./.prettierrc --write src/app/core/core-services/permission-children.ts"
     },


### PR DESCRIPTION
At the moment, the command "npm run cleanup" is not practical. The command executes "npm run prettify-write" first and then "npm run lint-write". However, after executing "npm run lint-write" some changes are not "beautiful" enough to go through the "prettify-check". Therefore, it is necessary to execute the command "npm run lint-write" before executing "npm run prettify-write".
The commands are executed in the previously mentioned order, because "npm run prettify-write" floods a console. To avoid this, I wrote the script "cleanup.ts".
This should also have the benefit, that we do not need the command "cleanup-win".

@tsiegleauq What do you think?