### PR TITLE
Fixes offline banner in firefox

### DIFF
--- a/client/src/app/core/core-services/communication-manager.service.ts
+++ b/client/src/app/core/core-services/communication-manager.service.ts
@@ -35,8 +35,8 @@ export class CommunicationManagerService {
         private offlineBroadcastService: OfflineBroadcastService,
         private lifecycleService: LifecycleService
     ) {
-        this.offlineBroadcastService.goOfflineObservable.subscribe(() => this.stopCommunication());
-        this.offlineBroadcastService.goOnlineObservable.subscribe(() => this.startCommunication());
+        this.offlineBroadcastService.goOfflineEvent.subscribe(() => this.stopCommunication());
+        this.offlineBroadcastService.goOnlineEvent.subscribe(() => this.startCommunication());
         this.lifecycleService.openslidesBooted.subscribe(() => this.startCommunication());
         this.lifecycleService.openslidesShutdowned.subscribe(() => this.stopCommunication());
     }

--- a/client/src/app/core/core-services/http-stream.service.ts
+++ b/client/src/app/core/core-services/http-stream.service.ts
@@ -76,7 +76,7 @@ export class HttpStreamService {
 
     private onError(endpoint: EndpointConfiguration, description?: ErrorDescription): void {
         console.log(`ERROR`, description);
-        this.offlineService.goOffline({
+        this.offlineService.goOfflineEvent.emit({
             reason: lostConnectionToFn(endpoint),
             isOnlineFn: async () => this.endpointService.isEndpointHealthy(endpoint)
         });

--- a/client/src/app/core/core-services/http-stream.ts
+++ b/client/src/app/core/core-services/http-stream.ts
@@ -303,6 +303,10 @@ export class HttpStream<T> {
     }
 
     private handleStreamError(error: unknown): void {
+        console.log(`Handle stream error:`, error);
+        console.log(
+            `${this.id}:${this.description}: Retry counter ${this._reconnectAttempts} of ${this._reconnectsBeforeClose}`
+        );
         const shouldReconnect =
             typeof this._shouldReconnectOnFailure === `function`
                 ? this._shouldReconnectOnFailure()

--- a/client/src/app/core/core-services/offline-broadcast.service.ts
+++ b/client/src/app/core/core-services/offline-broadcast.service.ts
@@ -1,5 +1,5 @@
 import { EventEmitter, Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 export interface OfflineReasonConfig {
     /**
@@ -16,34 +16,12 @@ export interface OfflineReasonConfig {
     providedIn: `root`
 })
 export class OfflineBroadcastService {
-    public get isOfflineObservable(): Observable<boolean> {
-        return this._isOfflineSubject.asObservable();
-    }
-
-    public get goOfflineObservable(): Observable<OfflineReasonConfig> {
-        return this._goOffline.asObservable();
-    }
-
-    public get goOnlineObservable(): Observable<void> {
-        return this._goOnline.asObservable();
-    }
-
-    private readonly _isOfflineSubject = new BehaviorSubject<boolean>(false);
-    private readonly _goOnline = new EventEmitter<void>();
-    private readonly _goOffline = new EventEmitter<OfflineReasonConfig>();
-
-    public goOffline(config: OfflineReasonConfig): void {
-        this._isOfflineSubject.next(true);
-        this._goOffline.emit(config);
-    }
-
-    public goOnline(): void {
-        this._isOfflineSubject.next(false);
-        this._goOnline.emit();
-    }
+    public readonly isOfflineSubject = new BehaviorSubject<boolean>(false);
+    public readonly goOnlineEvent = new EventEmitter<void>();
+    public readonly goOfflineEvent = new EventEmitter<OfflineReasonConfig>();
 
     public isOffline(): boolean {
-        return this._isOfflineSubject.getValue();
+        return this.isOfflineSubject.getValue();
     }
 
     public isOnline(): boolean {

--- a/client/src/app/core/core-services/offline.service.ts
+++ b/client/src/app/core/core-services/offline.service.ts
@@ -15,7 +15,7 @@ export class OfflineService {
     private config: OfflineReasonConfig | null = null;
 
     public constructor(private offlineBroadcastService: OfflineBroadcastService) {
-        this.offlineBroadcastService.goOfflineObservable.subscribe(reason => this.goOffline(reason));
+        this.offlineBroadcastService.goOfflineEvent.subscribe(reason => this.goOffline(reason));
     }
 
     /**
@@ -37,16 +37,18 @@ export class OfflineService {
         console.log(`Try to go online in ${timeout} ms`);
 
         setTimeout(async () => {
+            // Verifies that we are (still) offline
             const isOnline = await this.config.isOnlineFn();
             console.log(`Is online again? ->`, isOnline);
 
             if (isOnline) {
                 // stop trying.
                 this.config = null;
-                this.offlineBroadcastService.goOnline();
+                this.offlineBroadcastService.isOfflineSubject.next(false);
             } else {
                 // continue trying.
                 this.deferCheckStillOffline();
+                this.offlineBroadcastService.isOfflineSubject.next(true);
             }
         }, timeout);
     }

--- a/client/src/app/core/core-services/openslides.service.ts
+++ b/client/src/app/core/core-services/openslides.service.ts
@@ -30,7 +30,7 @@ export class OpenSlidesService {
     public async bootup(): Promise<void> {
         const online = await this.authService.doWhoAmIRequest();
         if (!online) {
-            this.offlineBroadcastService.goOffline({
+            this.offlineBroadcastService.goOfflineEvent.emit({
                 reason: WHOAMI_FAILED,
                 isOnlineFn: async () => this.authService.doWhoAmIRequest()
             });

--- a/client/src/app/core/ui-services/banner.service.ts
+++ b/client/src/app/core/ui-services/banner.service.ts
@@ -29,11 +29,8 @@ export class BannerService {
 
     public activeBanners: BehaviorSubject<BannerDefinition[]> = new BehaviorSubject<BannerDefinition[]>([]);
 
-    public constructor(/*translate: TranslateService, */ offlineBroadcastService: OfflineBroadcastService) {
-        /*translate.onLangChange.subscribe(() => {
-            this.offlineBannerDefinition.text = translate.instant(this.offlineBannerDefinition.text);
-        });*/
-        offlineBroadcastService.isOfflineObservable.subscribe(offline => {
+    public constructor(offlineBroadcastService: OfflineBroadcastService) {
+        offlineBroadcastService.isOfflineSubject.subscribe(offline => {
             if (offline) {
                 this.addBanner(this.offlineBannerDefinition);
             } else {

--- a/client/src/app/core/ui-services/spinner.service.ts
+++ b/client/src/app/core/ui-services/spinner.service.ts
@@ -92,7 +92,7 @@ export class SpinnerService {
     private initStableSubscription(): void {
         this.isStableSubscription = combineLatest([
             this.operator.isReadyObservable,
-            this.offlineBroadcastService.isOfflineObservable,
+            this.offlineBroadcastService.isOfflineSubject,
             this.upgradeService.upgradeChecked.pipe(distinctUntilChanged()),
             this.router.events.pipe(filter(event => event instanceof RoutesRecognized))
         ]).subscribe(([isReady, isOffline, hasUpgradeChecked, event]) => {

--- a/client/src/app/shared/components/projector/projector.component.ts
+++ b/client/src/app/shared/components/projector/projector.component.ts
@@ -161,7 +161,7 @@ export class ProjectorComponent extends BaseComponent implements OnDestroy {
         });
 
         this.subscriptions.push(
-            this.offlineBroadcastService.isOfflineObservable.subscribe(isOffline => (this.isOffline = isOffline))
+            this.offlineBroadcastService.isOfflineSubject.subscribe(isOffline => (this.isOffline = isOffline))
         );
 
         const trigger$ = merge(


### PR DESCRIPTION
I could reproduce the (wrong) behavior in a local prod setup. Before an offline banner is shown, this will check if we are really offline and then, only then, an offline banner is shown.

Fixes #652.