### PR TITLE
Fixes: Further improvements (#730)

### DIFF
--- a/client/src/app/management/components/committee-list/committee-list.component.ts
+++ b/client/src/app/management/components/committee-list/committee-list.component.ts
@@ -123,19 +123,20 @@ export class CommitteeListComponent extends BaseListViewComponent<ViewCommittee>
     }
 
     public async doDelete(committee?: ViewCommittee): Promise<void> {
+        const toDelete = committee ? [committee] : this.selectedRows;
         const toTranslate = committee
             ? `Are you sure you want to delete this committee?`
             : `Are you sure you want to delete all selected committees?`;
         const title = this.translate.instant(toTranslate);
         const content = committee?.name ?? ``;
 
+        const haveMeetings = toDelete.some(committee => !!committee.meeting_ids?.length);
         const YES_WITH_MEETINGS = _(`Yes, inclusive meetings`);
         const YES = _(`Yes`);
-        const actions = [YES_WITH_MEETINGS, YES];
+        const actions = haveMeetings ? [YES_WITH_MEETINGS] : [YES];
 
         const answer = await this.choiceService.open({ title, content, actions });
         if (answer) {
-            const toDelete = committee ? [committee] : this.selectedRows;
             if (answer.action === YES_WITH_MEETINGS) {
                 const meetingIdsToDelete = toDelete
                     .flatMap(committeeToDelete => committeeToDelete.meeting_ids)

--- a/client/src/app/management/components/dashboard/dashboard.component.html
+++ b/client/src/app/management/components/dashboard/dashboard.component.html
@@ -145,6 +145,9 @@
                 </div>
             </div>
         </a>
+        <mat-icon *ngIf="meeting.isArchived" matTooltip="{{ 'This meeting is archived' | translate }}">
+            archive
+        </mat-icon>
         <a
             mat-icon-button
             [routerLink]="['/', 'committees', meeting.committee_id]"
@@ -152,8 +155,5 @@
         >
             <mat-icon>auto_awesome_mosaic</mat-icon>
         </a>
-        <mat-icon *ngIf="meeting.isArchived" matTooltip="{{ 'This meeting is archived' | translate }}">
-            archive
-        </mat-icon>
     </div>
 </ng-template>

--- a/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
+++ b/client/src/app/site/motions/modules/motion-list/components/motion-list/motion-list.component.ts
@@ -303,7 +303,7 @@ export class MotionListComponent extends BaseListViewComponent<ViewMotion> imple
             viewModelCtor: ViewMeeting,
             ids: [this.activeMeetingIdService.meetingId],
             follow: [
-                { idField: `agenda_item_ids`, follow: [`content_object_id`] },
+                { idField: `agenda_item_ids` },
                 {
                     idField: `motion_ids`,
                     follow: [
@@ -324,8 +324,7 @@ export class MotionListComponent extends BaseListViewComponent<ViewMotion> imple
                         SUBMITTER_FOLLOW,
                         SPEAKER_BUTTON_FOLLOW
                     ],
-                    fieldset: `list`,
-                    additionalFields: [`text`, `reason`]
+                    fieldset: `list`
                 },
                 {
                     idField: `motion_category_ids`,


### PR DESCRIPTION
- In a committee-list: Button "Yes, inclusive meetings" appears only, if at least one committee has meetings (at a deleting action)
- In a motion-list: The text and reason of motions will not be requested anymore
- At a dashboard: The icon "archive" is aligned to the left of the icon "committee"

Fixes #730.