### PR TITLE
Some improvements to archived meetings and other

### DIFF
--- a/client/src/app/core/core-services/active-meeting-id.service.ts
+++ b/client/src/app/core/core-services/active-meeting-id.service.ts
@@ -5,7 +5,7 @@ import { distinctUntilChanged, filter } from 'rxjs/operators';
 
 import { DataStoreService } from './data-store.service';
 
-export class NoActiveMeeting extends Error {}
+export class NoActiveMeetingError extends Error {}
 
 @Injectable({
     providedIn: `root`

--- a/client/src/app/core/core-services/autoupdate.service.ts
+++ b/client/src/app/core/core-services/autoupdate.service.ts
@@ -116,7 +116,7 @@ export class AutoupdateService {
             { bodyFn: () => [request] }
         );
         const { data, stream } = await httpStream.toPromise();
-        await this.handleAutoupdate(data, stream.id);
+        await this.handleAutoupdate({ autoupdateData: data, id: stream.id, description });
     }
 
     /**
@@ -142,7 +142,12 @@ export class AutoupdateService {
         const buildStreamFn = (streamId: number) =>
             this.httpStreamService.create(
                 AUTOUPDATE_DEFAULT_ENDPOINT,
-                { onMessage: (data, stream) => this.handleAutoupdate(data, stream.id), description, id: streamId },
+                {
+                    onMessage: (data, stream) =>
+                        this.handleAutoupdate({ autoupdateData: data, id: stream.id, description }),
+                    description,
+                    id: streamId
+                },
                 { bodyFn: () => [request] }
             );
         const { closeFn, id } = this.communicationManager.registerStreamBuildFn(buildStreamFn);
@@ -155,9 +160,17 @@ export class AutoupdateService {
         };
     }
 
-    private async handleAutoupdate(autoupdateData: AutoupdateModelData, id: number): Promise<void> {
+    private async handleAutoupdate({
+        autoupdateData,
+        id,
+        description
+    }: {
+        autoupdateData: AutoupdateModelData;
+        id: number;
+        description?: string;
+    }): Promise<void> {
         const modelData = autoupdateFormatToModelData(autoupdateData);
-        console.log(`autoupdate: from stream`, id, modelData, `raw data:`, autoupdateData);
+        console.log(`autoupdate: from stream ${description}`, id, modelData, `raw data:`, autoupdateData);
         const fullListUpdateCollections = {};
         for (const key of Object.keys(autoupdateData)) {
             const data = key.split(`/`);

--- a/client/src/app/core/repositories/assignments/assignment-candidate-repository.service.ts
+++ b/client/src/app/core/repositories/assignments/assignment-candidate-repository.service.ts
@@ -37,6 +37,9 @@ export class AssignmentCandidateRepositoryService extends BaseRepositoryWithActi
     public getVerboseName = (plural: boolean = false) => this.translate.instant(plural ? `Candidates` : `Candidate`);
 
     public create(assignment: ViewAssignment, userId: Id): Promise<Identifiable> {
+        if (typeof userId !== `number`) {
+            return;
+        }
         const payload: AssignmentCandidateAction.CreatePayload = {
             assignment_id: assignment.id,
             user_id: userId

--- a/client/src/app/core/repositories/management/meeting-repository.service.ts
+++ b/client/src/app/core/repositories/management/meeting-repository.service.ts
@@ -54,7 +54,8 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
             `name`,
             `start_time`,
             `end_time`,
-            `is_active_in_organization_id`
+            `is_active_in_organization_id`,
+            `is_archived_organization_id`
         ]);
         const listFields: (keyof Meeting)[] = nameFields.concat(`user_ids`, `organization_tag_ids`);
         const editFields: (keyof Meeting)[] = listFields.concat([
@@ -76,7 +77,8 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
             `user_ids`,
             `location`,
             `description`,
-            `default_meeting_for_committee_id`
+            `default_meeting_for_committee_id`,
+            `group_ids`
         );
 
         return {

--- a/client/src/app/core/repositories/motions/motion-repository.service.ts
+++ b/client/src/app/core/repositories/motions/motion-repository.service.ts
@@ -122,14 +122,14 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
             submitter_ids: partialMotion.submitter_ids,
             workflow_id: partialMotion.workflow_id,
             category_id: partialMotion.category_id,
-            attachment_ids: partialMotion.attachment_ids,
+            attachment_ids: partialMotion.attachment_ids === null ? [] : partialMotion.attachment_ids,
             reason: partialMotion.reason,
             number: partialMotion.number,
             block_id: partialMotion.block_id,
             state_extension: partialMotion.state_extension,
             sort_parent_id: partialMotion.sort_parent_id,
-            tag_ids: partialMotion.tag_ids,
-            supporter_ids: partialMotion.supporter_ids,
+            tag_ids: partialMotion.tag_ids === null ? [] : partialMotion.tag_ids,
+            supporter_ids: partialMotion.supporter_ids === null ? [] : partialMotion.supporter_ids,
             ...createAgendaItem(partialMotion)
         };
     }
@@ -149,9 +149,9 @@ export class MotionRepositoryService extends BaseIsAgendaItemAndListOfSpeakersCo
             recommendation_extension: update.recommendation_extension,
             category_id: update.category_id,
             block_id: update.block_id,
-            supporter_ids: update.supporter_ids,
-            tag_ids: update.tag_ids,
-            attachment_ids: update.attachment_ids,
+            supporter_ids: update.supporter_ids === null ? [] : update.supporter_ids,
+            tag_ids: update.tag_ids === null ? [] : update.tag_ids,
+            attachment_ids: update.attachment_ids === null ? [] : update.attachment_ids,
             workflow_id: update.workflow_id,
             amendment_paragraph_$: update.amendment_paragraph_$
         };

--- a/client/src/app/core/repositories/relations.ts
+++ b/client/src/app/core/repositories/relations.ts
@@ -146,6 +146,12 @@ export const RELATIONS: Relation[] = [
     }),
     ...makeM2O({
         OViewModel: ViewOrganization,
+        MViewModel: ViewMeeting,
+        OField: `archived_meetings`,
+        MField: `is_archived_in_organization`
+    }),
+    ...makeM2O({
+        OViewModel: ViewOrganization,
         MViewModel: ViewTheme,
         OField: `themes`,
         MField: `organization`,

--- a/client/src/app/core/repositories/users/user-repository.service.ts
+++ b/client/src/app/core/repositories/users/user-repository.service.ts
@@ -264,7 +264,7 @@ export class UserRepositoryService
     /**
      * getter for the name
      */
-    public getName(user: NameInformation): string {
+    private getName(user: NameInformation): string {
         const firstName = user.first_name?.trim() || ``;
         const lastName = user.last_name?.trim() || ``;
         const userName = user.username?.trim() || ``;

--- a/client/src/app/core/ui-services/amendment.service.ts
+++ b/client/src/app/core/ui-services/amendment.service.ts
@@ -56,18 +56,18 @@ export class AmendmentService {
             lead_motion_id: partialMotion.lead_motion_id,
             title: partialMotion.title,
             origin_id: partialMotion.origin_id,
-            submitter_ids: partialMotion.submitter_ids,
+            submitter_ids: partialMotion.submitter_ids === null ? [] : partialMotion.submitter_ids,
             workflow_id: partialMotion.workflow_id,
             category_id: partialMotion.category_id,
-            attachment_ids: partialMotion.attachment_ids,
+            attachment_ids: partialMotion.attachment_ids === null ? [] : partialMotion.attachment_ids,
             reason: partialMotion.reason,
             number: partialMotion.number,
             block_id: partialMotion.block_id,
             state_extension: partialMotion.state_extension,
             amendment_paragraph_$: partialMotion.amendment_paragraph_$,
             sort_parent_id: partialMotion.sort_parent_id,
-            tag_ids: partialMotion.tag_ids,
-            supporter_ids: partialMotion.supporter_ids,
+            tag_ids: partialMotion.tag_ids === null ? [] : partialMotion.tag_ids,
+            supporter_ids: partialMotion.supporter_ids === null ? [] : partialMotion.supporter_ids,
             ...createAgendaItem(partialMotion)
         };
         return this.actions.sendRequest(AmendmentAction.CREATE_PARAGRAPHBASED_AMENDMENT, payload);

--- a/client/src/app/core/ui-services/voting.service.ts
+++ b/client/src/app/core/ui-services/voting.service.ts
@@ -23,10 +23,9 @@ const VotingErrorVerbose = {
     [VotingError.POLL_WRONG_STATE]: _(`You can not vote right now because the voting has not yet started.`),
     [VotingError.POLL_WRONG_TYPE]: _(`You can not vote because this is an analog voting.`),
     [VotingError.USER_HAS_NO_PERMISSION]: _(`You do not have the permission to vote.`),
-    [VotingError.POLL_WRONG_STATE]: _(`You have to be logged in to be able to vote.`),
-    [VotingError.USER_IS_ANONYMOUS]: _(`You have to be present to vote.`),
-    [VotingError.USER_NOT_PRESENT]: _(`Your voting right was delegated to another person.`),
-    [VotingError.USER_HAS_DELEGATED_RIGHT]: _(`You have already voted.`),
+    [VotingError.USER_IS_ANONYMOUS]: _(`You have to be logged in to be able to vote.`),
+    [VotingError.USER_NOT_PRESENT]: _(`You have to be present to vote.`),
+    [VotingError.USER_HAS_DELEGATED_RIGHT]: _(`Your voting right was delegated to another person.`),
     [VotingError.USER_HAS_VOTED]: _(`You have already voted.`)
 };
 

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.html
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.html
@@ -42,11 +42,17 @@
         </div>
     </mat-card-content>
     <mat-card-actions class="prev-content">
-        <ng-container
-            *osCmlPerms="CML.can_manage; committeeId: committee.id; nonAdminCheck: true; or: meeting.canAccess()"
+        <a *ngIf="canEnter" mat-stroked-button color="accent" [routerLink]="meeting.getUrl()">
+            {{ 'Open meeting' | translate }}
+        </a>
+        <span
+            *ngIf="!canEnter"
+            matTooltip="{{ 'You cannot enter this meeting because you are not assigned to any group' | translate }}"
         >
-            <a mat-stroked-button color="accent" [routerLink]="meeting.getUrl()">{{ 'Open meeting' | translate }}</a>
-        </ng-container>
+            <button mat-stroked-button color="accent" [disabled]="true">
+                {{ 'Open meeting' | translate }}
+            </button>
+        </span>
     </mat-card-actions>
 
     <!-- users -->
@@ -74,7 +80,7 @@
             <mat-icon>edit</mat-icon>
             <span>{{ 'Edit' | translate }}</span>
         </a>
-        <button mat-menu-item *ngIf="meeting.isActive" (click)="onDuplicate()">
+        <button mat-menu-item (click)="onDuplicate()">
             <mat-icon>file_copy</mat-icon>
             <span>{{ 'Duplicate' | translate }}</span>
         </button>

--- a/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
+++ b/client/src/app/management/components/meeting-preview/meeting-preview.component.ts
@@ -5,6 +5,7 @@ import { MeetingRepositoryService } from 'app/core/repositories/management/meeti
 import { PromptService } from 'app/core/ui-services/prompt.service';
 import { ViewMeeting } from 'app/management/models/view-meeting';
 
+import { OperatorService } from '../../../core/core-services/operator.service';
 import { OML } from '../../../core/core-services/organization-permission';
 import { CommitteeRepositoryService } from '../../../core/repositories/management/committee-repository.service';
 import { ViewCommittee } from '../../models/view-committee';
@@ -47,17 +48,22 @@ export class MeetingPreviewComponent {
         return this.meeting.id === this.committee.default_meeting_id;
     }
 
+    public get canEnter(): boolean {
+        return this.operator.isInMeetingIds(this.meeting.id);
+    }
+
     public constructor(
         protected translate: TranslateService,
         private meetingRepo: MeetingRepositoryService,
         private committeeRepo: CommitteeRepositoryService,
         private promptService: PromptService,
-        private meetingService: MeetingService
+        private meetingService: MeetingService,
+        private operator: OperatorService
     ) {}
 
     public async onArchive(): Promise<void> {
         const title = this.translate.instant(`Are you sure you want to archive this meeting?`);
-        const content = this.title;
+        const content = this.translate.instant(`Attention: This action can NOT be undone!`);
 
         const confirmed = await this.promptService.open(title, content);
         if (confirmed) {

--- a/client/src/app/management/models/view-meeting.ts
+++ b/client/src/app/management/models/view-meeting.ts
@@ -128,5 +128,6 @@ interface IMeetingRelations {
     default_group: ViewGroup;
     admin_group: ViewGroup;
     is_active_in_organization: ViewOrganization;
+    is_archived_in_organization: ViewOrganization;
 }
 export interface ViewMeeting extends Meeting, IMeetingRelations, HasProjectorTitle, HasOrganizationTags {}

--- a/client/src/app/management/models/view-organization.ts
+++ b/client/src/app/management/models/view-organization.ts
@@ -22,6 +22,8 @@ interface IOrganizationRelations {
     organization_tags: ViewOrganizationTag[];
     active_meetings: ViewMeeting[];
     active_meetings_as_observable: Observable<ViewMeeting[]>;
+    archived_meetings: ViewMeeting[];
+    archived_meetings_as_observable: Observable<ViewMeeting[]>;
     theme: ViewTheme;
     themes: ViewTheme[];
 }

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
@@ -137,16 +137,14 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormFieldCont
      * All items
      */
     protected set selectableItems(items: Selectable[]) {
-        const sortedItems = [...items].sort(this.sortFn);
-        this._selectableItemsIdMap = {};
-        const allItems = !this.multiple && this.includeNone ? [this.noneItem].concat(sortedItems) : sortedItems;
+        const allItems = !this.multiple && this.includeNone ? [this.noneItem].concat(items) : items;
         for (const item of allItems) {
             this._selectableItemsIdMap[item.id] = item;
         }
     }
 
     protected get selectableItems(): Selectable[] {
-        return Object.values(this._selectableItemsIdMap);
+        return Object.values(this._selectableItemsIdMap).sort(this.sortFn);
     }
 
     protected noneItem: Selectable = {

--- a/client/src/app/shared/models/event-management/meeting.ts
+++ b/client/src/app/shared/models/event-management/meeting.ts
@@ -227,6 +227,7 @@ export class Meeting extends BaseModel<Meeting> {
 
     public organization_tag_ids: Id[]; // (organization_tag/meeting_ids)[];
     public is_active_in_organization_id: Id; // (organization/active_meeting_ids)[];
+    public is_archived_organization_id: Id; // (organization/archived_meeting_ids)[];
 
     public constructor(input?: any) {
         super(Meeting.COLLECTION, input);

--- a/client/src/app/shared/models/event-management/organization.ts
+++ b/client/src/app/shared/models/event-management/organization.ts
@@ -27,7 +27,8 @@ export class Organization extends BaseModel<Organization> {
     public committee_ids: Id[]; // (committee/organization_id)[];
     public resource_ids: Id[]; // (resource/organization_id)[];
     public organization_tag_ids: Id[]; // (organization_tag/organization_id)[];
-    public active_meeting_ids: Id[]; // (meeting/is_active_in_organization_id);
+    public active_meeting_ids: Id[]; // (meeting/is_active_in_organization_id)[];
+    public archived_meeting_ids: Id[]; // (meeting/is_archived_in_organization_id)[];
 
     public constructor(input?: any) {
         super(Organization.COLLECTION, input);

--- a/client/src/app/site/users/components/user-detail/user-detail.component.ts
+++ b/client/src/app/site/users/components/user-detail/user-detail.component.ts
@@ -16,7 +16,6 @@ import { BaseModelContextComponent } from 'app/site/base/components/base-model-c
 import { PollService } from 'app/site/polls/services/poll.service';
 import { BehaviorSubject, combineLatest } from 'rxjs';
 
-import { ActiveMeetingService } from '../../../../core/core-services/active-meeting.service';
 import { MemberService } from '../../../../core/core-services/member.service';
 import { PERSONAL_FORM_CONTROLS, UserService } from '../../../../core/ui-services/user.service';
 import { ViewGroup } from '../../models/view-group';
@@ -346,10 +345,7 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
         if (partialUser.is_present) {
             partialUser.is_present_in_meeting_ids = [this.activeMeetingId];
         }
-        if (!partialUser.group_ids?.length) {
-            const defaultGroupId = this.activeMeetingService.meeting.default_group_id;
-            partialUser.group_ids = [defaultGroupId];
-        }
+        this.checkForGroups(partialUser);
 
         await this.repo.create(partialUser);
         this.goToAllUsers();
@@ -357,11 +353,19 @@ export class UserDetailComponent extends BaseModelContextComponent implements On
 
     private async updateUser(): Promise<void> {
         if (this.operator.hasPerms(Permission.userCanManage)) {
+            this.checkForGroups(this.personalInfoFormValue);
             await this.repo.update(this.personalInfoFormValue, this.user);
         } else {
             await this.repo.updateSelf(this.personalInfoFormValue, this.user);
         }
         this.setEditMode(false);
+    }
+
+    private checkForGroups(user: any): void {
+        if (!user?.group_ids.length) {
+            const defaultGroupId = this.activeMeetingService.meeting.default_group_id;
+            user.group_ids = [defaultGroupId];
+        }
     }
 
     private checkFormForErrors(): void {


### PR DESCRIPTION
- Archived meetings can be cloned (Fixes #766)
- Removing every group of a user in a user-detail-view adds them automatically the default group of a meeting (Fixes #844)
- Users can only enter a meeting, if they are assigned to at least one group of the meeting (Fixes #834)
- Committee permissions are calculated correctly (Fixes #839, Fixes #840)
- Editing of motions works correctly (Fixes #843)
- Adds a warning when trying to archive a meeting (Fixes #780)
- Updates the error messages when a user cannot vote (Fixes #845)