### PR TITLE
Some improvements

### DIFF
--- a/client/src/app/core/core-services/auth.service.ts
+++ b/client/src/app/core/core-services/auth.service.ts
@@ -76,8 +76,7 @@ export class AuthService {
             if (response.success) {
                 // Shutdowning kills all connections. The operator is listening for token changes, so
                 // we must hold them back to this point.
-                this.lifecycleService.shutdown();
-                this.lifecycleService.bootup();
+                this.lifecycleService.reboot();
                 this.resumeTokenSubscription();
                 this.redirectUser(meetingId);
             }

--- a/client/src/app/core/core-services/organization.service.ts
+++ b/client/src/app/core/core-services/organization.service.ts
@@ -64,7 +64,7 @@ export class OrganizationService {
         return {
             viewModelCtor: ViewOrganization,
             ids: [ORGANIZATION_ID],
-            follow: [{ idField: `resource_ids` }, `theme_ids`, `theme_id`],
+            follow: [`theme_ids`, `theme_id`],
             fieldset: `settings`
         };
     }

--- a/client/src/app/management/models/view-committee.ts
+++ b/client/src/app/management/models/view-committee.ts
@@ -26,11 +26,11 @@ export class ViewCommittee extends BaseViewModel<Committee> {
     }
 
     public get hasForwardings(): boolean {
-        return this.forward_to_committee_ids.length > 0;
+        return (this.forward_to_committee_ids || []).length > 0;
     }
 
     public get hasReceivings(): boolean {
-        return this.receive_forwardings_from_committee_ids.length > 0;
+        return (this.receive_forwardings_from_committee_ids || []).length > 0;
     }
 
     public get managerObservable(): Observable<ViewUser[]> {

--- a/client/src/app/shared/components/base-form-field-control.ts
+++ b/client/src/app/shared/components/base-form-field-control.ts
@@ -79,6 +79,9 @@ export abstract class BaseFormFieldControlComponent<T>
         return this._disabled;
     }
 
+    @Input()
+    public shouldPropagateOnRegistering = true;
+
     public abstract get empty(): boolean;
 
     public abstract get controlType(): string;
@@ -131,20 +134,32 @@ export abstract class BaseFormFieldControlComponent<T>
         this.stateChanges.complete();
     }
 
+    ///////////////////////////////////////////////////////
+    // Functions to fulfill the ControlValueAccessor interface
+    ///////////////////////////////////////////////////////
+
     public writeValue(value: T): void {
         this.value = value;
     }
     public registerOnChange(fn: any): void {
         this._onChange = fn;
-        this.push(this.value);
+        if (this.shouldPropagateOnRegistering) {
+            this.push(this.value);
+        }
     }
     public registerOnTouched(fn: any): void {
         this._onTouched = fn;
-        this.push(this.value);
+        if (this.shouldPropagateOnRegistering) {
+            this.push(this.value);
+        }
     }
-    public setDisabledState?(isDisabled: boolean): void {
+    public setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
     }
+
+    ///////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////
 
     public setDescribedByIds(ids: string[]): void {
         this.describedBy = ids.join(` `);

--- a/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/base-search-value-selector/base-search-value-selector.component.ts
@@ -117,7 +117,7 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormFieldCont
     }
 
     public get empty(): boolean {
-        return Array.isArray(this.contentForm.value) ? !this.contentForm.value.length : !this.contentForm.value;
+        return Array.isArray(this._snapshotValue) ? !this._snapshotValue.length : !this._snapshotValue;
     }
 
     public get selectedItems(): Selectable[] {
@@ -153,6 +153,11 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormFieldCont
         id: null
     };
 
+    /**
+     * The synchronized value of the contentForm form control.
+     * Used to determine, if this form control is empty before the timeout is fulfilled.
+     */
+    private _snapshotValue = null;
     private _isFirstUpdate = true;
 
     private _selectableItemsIdMap: { [id: number]: Selectable } = {};
@@ -245,7 +250,6 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormFieldCont
         }
         this.setNextValue(nextValue);
         this.selectedIds = (nextValue as []) ?? [];
-        this.triggerUpdate();
     }
 
     /**
@@ -270,6 +274,10 @@ export abstract class BaseSearchValueSelectorComponent extends BaseFormFieldCont
     }
 
     private setNextValue(value: any): void {
-        setTimeout(() => this.contentForm.setValue(value));
+        this._snapshotValue = value;
+        setTimeout(() => {
+            this.contentForm.setValue(value);
+            this.triggerUpdate();
+        });
     }
 }

--- a/client/src/app/shared/components/search-selector/search-repo-selector/search-repo-selector.component.ts
+++ b/client/src/app/shared/components/search-selector/search-repo-selector/search-repo-selector.component.ts
@@ -103,7 +103,7 @@ export class SearchRepoSelectorComponent extends BaseSearchValueSelectorComponen
         if (this.defaultDataConfigKey) {
             this.subscriptions.push(
                 this.meetingSettingService.get(this.defaultDataConfigKey).subscribe(value => {
-                    if (!this.value) {
+                    if (this.empty) {
                         this.value = value as any;
                     }
                 })

--- a/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.html
+++ b/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.html
@@ -44,6 +44,7 @@
                         [showChips]="false"
                         [errorStateMatcher]="matcher"
                         [inputListValues]="groupObservable"
+                        [shouldPropagateOnRegistering]="false"
                     ></os-search-value-selector>
                 </ng-template>
 

--- a/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.ts
+++ b/client/src/app/site/meeting-settings/components/meeting-settings-field/meeting-settings-field.component.ts
@@ -117,15 +117,6 @@ export class MeetingSettingsFieldComponent extends BaseComponent implements OnIn
      */
     private _firstValue: any;
 
-    /**
-     * The usual component constructor. datetime pickers will set their locale
-     * to the current language chosen
-     *
-     * @param titleService Title
-     * @param translate TranslateService
-     * @param formBuilder FormBuilder
-     * @param cd ChangeDetectorRef
-     */
     public constructor(
         componentServiceCollector: ComponentServiceCollector,
         protected translate: TranslateService,
@@ -172,10 +163,13 @@ export class MeetingSettingsFieldComponent extends BaseComponent implements OnIn
             time: [``]
         });
         this.translatedValue = this.value ?? this.meetingSettingsDefinitionProvider.getDefaultValue(this.setting);
-        if (this.setting.type === `string` || this.setting.type === `markupText` || this.setting.type === `text`) {
-            if (typeof this.value === `string` && this.value !== ``) {
-                this.translatedValue = this.translate.instant(this.value);
-            }
+        if (
+            (typeof this.value === `string` && this.value !== ``) ||
+            this.setting.type === `string` ||
+            this.setting.type === `markupText` ||
+            this.setting.type === `text`
+        ) {
+            this.translatedValue = this.translate.instant(this.value);
         }
         if ((this.setting.type === `datetime` || this.setting.type === `date`) && this.value) {
             const datetimeObj = this.getRestrictedValue(this.unixToDateAndTime(this.value as number));

--- a/client/src/app/site/motions/models/view-motion.ts
+++ b/client/src/app/site/motions/models/view-motion.ts
@@ -28,6 +28,7 @@ import { ViewMotionCommentSection } from './view-motion-comment-section';
 import { ViewMotionState } from './view-motion-state';
 import { ViewMotionStatuteParagraph } from './view-motion-statute-paragraph';
 import { ViewMotionSubmitter } from './view-motion-submitter';
+import { ViewMotionWorkflow } from './view-motion-workflow';
 
 export interface HasReferencedMotionsInRecommendationExtension extends HasReferencedMotionInRecommendationExtensionIds {
     referenced_in_motion_recommendation_extension: ViewMotion[];
@@ -46,6 +47,14 @@ export class ViewMotion extends BaseProjectableViewModel<Motion> {
 
     public get motion(): Motion {
         return this._model;
+    }
+
+    public get workflow_id(): Id {
+        return this.state?.workflow_id;
+    }
+
+    public get workflow(): ViewMotionWorkflow {
+        return this.state?.workflow;
     }
 
     public get submittersAsUsers(): ViewUser[] {

--- a/client/src/app/site/motions/modules/motion-detail/components/amendment-create-wizard/amendment-create-wizard.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/amendment-create-wizard/amendment-create-wizard.component.ts
@@ -170,7 +170,7 @@ export class AmendmentCreateWizardComponent extends BaseModelContextComponent im
             motion_block_id: this.motion.block_id,
             lead_motion_id: this.motion.id,
             amendment_paragraph_$: amendmentParagraphs,
-            workflow_id: this.meetingSettingsService.instant(`motions_default_workflow_id`)
+            workflow_id: this.meetingSettingsService.instant(`motions_default_amendment_workflow_id`)
         };
 
         const response = await this.repo.createParagraphBased(motionCreate);

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -437,6 +437,9 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
                         idField: `state_id`,
                         follow: [
                             {
+                                idField: `previous_state_ids`
+                            },
+                            {
                                 idField: `next_state_ids`
                             },
                             GET_POSSIBLE_RECOMMENDATIONS

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-manage-polls/motion-manage-polls.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-manage-polls/motion-manage-polls.component.html
@@ -7,7 +7,7 @@
         create-poll-button
         mat-stroked-button
         (click)="openDialog()"
-        *osPerms="permission.motionCanManagePolls"
+        *osPerms="permission.motionCanManagePolls; and: canStateHavePolls"
     >
         <mat-icon class="main-nav-color">add</mat-icon>
         <span>{{ 'New vote' | translate }}</span>

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-manage-polls/motion-manage-polls.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-manage-polls/motion-manage-polls.component.ts
@@ -16,6 +16,10 @@ export class MotionManagePollsComponent extends BaseComponent {
     @Input()
     public motion: ViewMotion;
 
+    public get canStateHavePolls(): boolean {
+        return this.motion.state?.allow_create_poll || false;
+    }
+
     public constructor(
         componentCollector: ComponentServiceCollector,
         translate: TranslateService,

--- a/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
+++ b/client/src/app/site/motions/modules/motion-poll/motion-poll/motion-poll.component.html
@@ -75,7 +75,12 @@
 
     <!-- Detail link -->
     <div class="poll-detail-button-wrapper">
-        <a mat-icon-button [routerLink]="pollLink" matTooltip="{{ 'More' | translate }}" *ngIf="poll.isPublished">
+        <a
+            mat-icon-button
+            [routerLink]="getDetailLink()"
+            matTooltip="{{ 'More' | translate }}"
+            *ngIf="poll.isPublished"
+        >
             <mat-icon class="icon-18">visibility</mat-icon>
         </a>
     </div>
@@ -88,7 +93,7 @@
 </ng-template>
 
 <ng-template #viewTemplate>
-    <os-motion-poll-detail-content [poll]="poll" [routerLink]="pollLink"></os-motion-poll-detail-content>
+    <os-motion-poll-detail-content [poll]="poll" [routerLink]="getDetailLink()"></os-motion-poll-detail-content>
 </ng-template>
 
 <ng-template #emptyTemplate>


### PR DESCRIPTION
- Default values in search-selectors are displayed in startup (Fixes #915)
- Filters of committee-list work (Fixes #874)
- A timeout for TCP connections should be tackled (Fixes #931)
- One can go one state back in a workflow (Fixes #774)
- Fixes 'has changes' in a settings list (Fixes #847)
- Fixes configs in a search-selector (Fixes #932)
- Fixes detail link and creation of polls, as well as the correct workflow in a motion's update view (Fixes #934)
- Fixes translations of default settings (Fixes #935)
- Fixes default workflow of a paragraph based amendment (Fixes #936)