### PR TITLE
Bugfix for max_votes_per_option

### DIFF
--- a/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.html
+++ b/client/src/app/site/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.html
@@ -66,7 +66,7 @@
                             <i *ngIf="!option.content_object">{{ unknownUserLabel | translate }}</i>
                         </div>
 
-                        <ng-container *ngIf="(poll.max_votes_per_option <= 1)">
+                        <ng-container *ngIf="(!poll.max_votes_per_option || poll.max_votes_per_option <= 1)">
                             <div *ngFor="let action of voteActions">
                                 <button
                                     class="vote-button"


### PR DESCRIPTION
Bug: If an election has been created with an older version of OpenSlides in which max_votes_per_option was not implemented no voting buttons will be shown. The elections needed to be recreated.

This commit fixes that bug.