### PR TITLE
Fixes updating of new groups (#985)

### DIFF
--- a/client/src/app/core/repositories/users/group-repository.service.ts
+++ b/client/src/app/core/repositories/users/group-repository.service.ts
@@ -105,7 +105,7 @@ export class GroupRepositoryService
         const payload: GroupAction.SetPermissionPayload = {
             id: group.id,
             permission,
-            set: !group.permissions.includes(permission)
+            set: !group.hasPermission(permission)
         };
         return this.sendActionToBackend(GroupAction.SET_PERMISSION, payload);
     }


### PR DESCRIPTION
Fixes #985.

Unfortunately, a similar error is occurring in the backend, when updating the permissions of a new group (see OpenSlides/openslides-backend#1302).