### PR TITLE
Pdf export revise

### DIFF
--- a/client/src/app/core/pdf-services/html-to-pdf.service.ts
+++ b/client/src/app/core/pdf-services/html-to-pdf.service.ts
@@ -161,6 +161,7 @@ export class HtmlToPdfService {
         }
 
         // Cleanup of dirty html would happen here
+        htmlText = htmlText.replace(/\s+<br class="os-line-break">/g, `<br class="os-line-break">`);
 
         // Create a HTML DOM tree out of html string
         const parser = new DOMParser();

--- a/client/src/app/core/pdf-services/pdf-document.service.ts
+++ b/client/src/app/core/pdf-services/pdf-document.service.ts
@@ -420,17 +420,11 @@ export class PdfDocumentService {
     public download(docDefinition: object, filename: string, metadata?: object, exportInfo?: MotionExportInfo): void {
         this.showProgress();
 
-        const pageSize = this.meetingSettingsService.instant(`export_pdf_pagesize`);
-        const pageMarginLeft = this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_left`));
-        const pageMarginTop = this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_top`));
-        const pageMarginRight = this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_right`));
-        const pageMarginBottom = this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_bottom`));
-
         const pageMargins: [number, number, number, number] = [
-            pageMarginLeft,
-            pageMarginTop,
-            pageMarginRight,
-            pageMarginBottom
+            this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_left`)),
+            this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_top`)),
+            this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_bottom`)),
+            this.mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_bottom`))
         ];
 
         this.getStandardPaper(docDefinition, pageMargins, metadata, exportInfo, null).then(doc => {

--- a/client/src/app/core/pdf-services/pdf-document.service.ts
+++ b/client/src/app/core/pdf-services/pdf-document.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
 import { ProgressSnackBarComponent } from 'app/shared/components/progress-snack-bar/progress-snack-bar.component';
+import { PDF_OPTIONS } from 'app/site/motions/motions.constants';
 import { MotionExportInfo } from 'app/site/motions/services/motion-export.service';
 import { saveAs } from 'file-saver';
 import * as moment from 'moment';
@@ -155,13 +156,17 @@ export class PdfDocumentService {
                 font: `PdfFont`,
                 fontSize: this.meetingSettingsService.instant(`export_pdf_fontsize`)
             },
-            header: this.getHeader([pageMargins[0], pageMargins[2]]),
+            header: {},
             // real footer gets created in the worker
             tmpfooter: this.getFooter([pageMargins[0], pageMargins[2]], exportInfo),
             info: metadata,
             content: documentContent,
             styles: this.getStandardPaperStyles()
         };
+
+        if (exportInfo && exportInfo.pdfOptions && exportInfo.pdfOptions.includes(PDF_OPTIONS.Header)) {
+            result.header = this.getHeader([pageMargins[0], pageMargins[2]]);
+        }
 
         // DEBUG: printing the following. Do not remove, just comment out
         // console.log('MakePDF result :\n---\n', JSON.stringify(result), '\n---\n');

--- a/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
@@ -80,7 +80,7 @@
                 <mat-button-toggle value="date">
                     <span>{{ 'Current date' | translate }}</span>
                 </mat-button-toggle>
-                <mat-button-toggle value="addBreaks">
+                <mat-button-toggle value="addBreaks" #addBreaks>
                     <span>{{ 'Enforce page breaks' | translate }}</span>
                 </mat-button-toggle>
                 <mat-button-toggle value="continuousText">

--- a/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.html
@@ -74,6 +74,9 @@
                 <mat-button-toggle value="toc" #toc>
                     <span>{{ 'Table of contents' | translate }}</span>
                 </mat-button-toggle>
+                <mat-button-toggle value="header">
+                    <span>{{ 'Header' | translate }}</span>
+                </mat-button-toggle>
                 <mat-button-toggle value="page">
                     <span>{{ 'Page numbers' | translate }}</span>
                 </mat-button-toggle>

--- a/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.ts
@@ -66,7 +66,7 @@ export class MotionExportDialogComponent implements OnInit {
     private defaults: MotionExportInfo = {
         format: ExportFileFormat.PDF,
         content: [`text`, `reason`],
-        pdfOptions: [PDF_OPTIONS.Toc, PDF_OPTIONS.Page, PDF_OPTIONS.AddBreaks],
+        pdfOptions: [PDF_OPTIONS.Toc, PDF_OPTIONS.Header, PDF_OPTIONS.Page, PDF_OPTIONS.AddBreaks],
         metaInfo: [`submitters`, `state`, `recommendation`, `category`, `origin`, `tags`, `block`, `polls`]
     };
 

--- a/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/motions/modules/shared-motion/motion-export-dialog/motion-export-dialog.component.ts
@@ -66,7 +66,7 @@ export class MotionExportDialogComponent implements OnInit {
     private defaults: MotionExportInfo = {
         format: ExportFileFormat.PDF,
         content: [`text`, `reason`],
-        pdfOptions: [`toc`, `page`, `addBreaks`],
+        pdfOptions: [PDF_OPTIONS.Toc, PDF_OPTIONS.Page, PDF_OPTIONS.AddBreaks],
         metaInfo: [`submitters`, `state`, `recommendation`, `category`, `origin`, `tags`, `block`, `polls`]
     };
 
@@ -103,8 +103,14 @@ export class MotionExportDialogComponent implements OnInit {
     /**
      * To deactivate the toc button.
      */
-    @ViewChild(`toc`, { static: true })
+    @ViewChild(PDF_OPTIONS.Toc)
     public tocButton: MatButtonToggle;
+
+    /**
+     * To deactivate the addBreaks button.
+     */
+    @ViewChild(PDF_OPTIONS.AddBreaks)
+    public addBreaksButton: MatButtonToggle;
 
     /**
      * Constructor
@@ -192,9 +198,13 @@ export class MotionExportDialogComponent implements OnInit {
      */
     private onPdfOptionsChange(pdfOptions: string[]): void {
         if (pdfOptions && pdfOptions.includes(PDF_OPTIONS.ContinuousText)) {
+            this.tocButton.checked = false;
             this.tocButton.disabled = true;
+            this.addBreaksButton.checked = false;
+            this.addBreaksButton.disabled = true;
         } else {
             this.tocButton.disabled = false;
+            this.addBreaksButton.disabled = false;
         }
     }
 

--- a/client/src/app/site/motions/motions.constants.ts
+++ b/client/src/app/site/motions/motions.constants.ts
@@ -21,6 +21,7 @@ export const PERSONAL_NOTE_ID = -1;
  */
 export const PDF_OPTIONS = {
     Toc: `toc`,
+    Header: `header`,
     Page: `page`,
     Date: `date`,
     AddBreaks: `addBreaks`,

--- a/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
+++ b/client/src/app/site/motions/services/motion-pdf-catalog.service.ts
@@ -52,9 +52,10 @@ export class MotionPdfCatalogService {
     public motionListToDocDef(motions: ViewMotion[], exportInfo: MotionExportInfo): object {
         let doc = [];
         const motionDocList = [];
-        const printToc = exportInfo.pdfOptions.includes(`toc`);
-        const enforcePageBreaks = exportInfo.pdfOptions.includes(`addBreaks`);
+        const printToc = exportInfo.pdfOptions.includes(PDF_OPTIONS.Toc);
         const hasContinuousText = exportInfo.pdfOptions.includes(PDF_OPTIONS.ContinuousText);
+        // Do not enforce page breaks when continuous text is selected.
+        const enforcePageBreaks = exportInfo.pdfOptions.includes(PDF_OPTIONS.AddBreaks) && !hasContinuousText;
 
         for (let motionIndex = 0; motionIndex < motions.length; ++motionIndex) {
             let continuousText = hasContinuousText;


### PR DESCRIPTION
These are still things that can be improved. These are the things with high priority for now.

There is still a bug in there. If 'Table of Contents' and 'Force Page Breaks' are active and then disabled by 'Continuous Text' the buttons remain disabled. When the export dialog is called again, these buttons can be selected again.