### PR TITLE
Remove category_id from payload for non-admins

### DIFF
--- a/client/src/app/site/motions/modules/motion-detail/components/motion-content/motion-content.component.html
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-content/motion-content.component.html
@@ -165,7 +165,7 @@
     </div>
 
     <!-- Category form -->
-    <div class="content-field" *ngIf="newMotion && hasCategories">
+    <div class="content-field" *ngIf="newMotion && hasCategories && canManageMotions">
         <mat-form-field>
             <os-search-repo-selector
                 formControlName="category_id"

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-content/motion-content.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-content/motion-content.component.ts
@@ -74,6 +74,10 @@ export class MotionContentComponent extends BaseMotionDetailChildComponent {
         return this.operator.hasPerms(Permission.mediafileCanManage);
     }
 
+    public get canManageMotions(): boolean {
+        return this.operator.hasPerms(Permission.motionCanManage);
+    }
+
     /**
      * check if the 'final version edit mode' is active
      *

--- a/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
+++ b/client/src/app/site/motions/modules/motion-detail/components/motion-detail/motion-detail.component.ts
@@ -532,7 +532,9 @@ export class MotionDetailComponent extends BaseModelContextComponent implements 
         motion.lead_motion_id = this._parentId;
         const defaultTitle = `${this.translate.instant(`Amendment to`)} ${parentMotion.numberOrTitle}`;
         motion.title = defaultTitle;
-        motion.category_id = parentMotion.category_id;
+        if (this.operator.hasPerms(Permission.motionCanManage)) {
+            motion.category_id = parentMotion.category_id;
+        }
         motion.tag_ids = parentMotion.tag_ids;
         motion.block_id = parentMotion.block_id;
         const amendmentTextMode = this.meetingSettingService.instant(`motions_amendments_text_mode`);


### PR DESCRIPTION
Fixes the "You are not allowed to perform action motion.create. Forbidden fields: category_id" error when creating an amendment as a non-admin.