### PR TITLE
Fix chat group deletion error

### DIFF
--- a/client/src/app/site/chat/components/chat-group-detail/chat-group-detail.component.html
+++ b/client/src/app/site/chat/components/chat-group-detail/chat-group-detail.component.html
@@ -101,12 +101,12 @@
             <span>{{ 'Edit' | translate }}</span>
         </button>
         <!-- clear history -->
-        <button mat-menu-item (click)="clearChatGroup()" class="red-warning-text">
+        <button mat-menu-item (click)="clearChatGroup(chatGroup)" class="red-warning-text">
             <mat-icon>format_clear</mat-icon>
             <span>{{ 'Clear' | translate }}</span>
         </button>
         <!-- delete -->
-        <button mat-menu-item (click)="deleteChatGroup()" class="red-warning-text">
+        <button mat-menu-item (click)="deleteChatGroup(chatGroup)" class="red-warning-text">
             <mat-icon>delete</mat-icon>
             <span>{{ 'Delete' | translate }}</span>
         </button>

--- a/client/src/app/site/chat/components/chat-group-detail/chat-group-detail.component.ts
+++ b/client/src/app/site/chat/components/chat-group-detail/chat-group-detail.component.ts
@@ -103,7 +103,10 @@ export class ChatGroupDetailComponent extends BaseComponent implements OnInit, O
 
     public ngOnInit(): void {
         this._hasWritePermissionsObservable = this.chatGroupObservable.pipe(
-            map(chatGroup => this.canManage || this.operator.isInGroupIds(...(chatGroup.write_group_ids || [])))
+            map(
+                chatGroup =>
+                    chatGroup && (this.canManage || this.operator.isInGroupIds(...(chatGroup.write_group_ids || [])))
+            )
         );
         this.chatNotificationService.openChatGroup(this.chatGroup.id);
         this.newMessageForm = this.fb.control(``, [Validators.required, Validators.maxLength(CHAT_MESSAGE_MAX_LENGTH)]);
@@ -150,10 +153,11 @@ export class ChatGroupDetailComponent extends BaseComponent implements OnInit, O
         this.cancelEditingChatMessage();
     }
 
-    public async clearChatGroup(): Promise<void> {
+    public async clearChatGroup(chatGroup: ViewChatGroup): Promise<void> {
         const title = this.translate.instant(`Are you sure you want to clear all messages in this chat?`);
-        if (await this.promptService.open(title)) {
-            await this.repo.clear(this.chatGroup.id).catch(this.raiseError);
+        const content = chatGroup.name;
+        if (await this.promptService.open(title, content)) {
+            await this.repo.clear(chatGroup.id).catch(this.raiseError);
             this.triggerUpdateView();
         }
     }


### PR DESCRIPTION
Also unified the display of the messages & fixed another error message which appeared after a chat group had been deleted.

The chat group list on the left site does not seem to get autoupdates, though: After renaming a chat group, a reload is necessary to see the change on the left site.