### PR TITLE
Fix relative links in TinyMCE

### DIFF
--- a/client/src/app/ui/modules/editor/components/editor/editor.component.ts
+++ b/client/src/app/ui/modules/editor/components/editor/editor.component.ts
@@ -33,6 +33,7 @@ export class EditorComponent extends BaseFormControlComponent<string> implements
         browser_spellcheck: true,
         image_advtab: true,
         image_description: false,
+        relative_urls: false,
         link_title: false,
         height: 320,
         plugins: `autolink charmap code fullscreen image imagetools


### PR DESCRIPTION
fixes #1045

The issue stemmed form the fact that TinyMCE automatically tries to convert all URLs to relative ones if not told otherwise and will try to use its full current path as the base, so everything except the differing motion id will be stripped. With `relative_urls` set to `false`, it will only trim the protocol and host, which should work for all situations (and even still works in case the domain is changed by us).

Another plus: TinyMCE seems to automatically recognize old, "wrong" urls and automatically fixes them after this patch has been applied once the motion is opened to edit and saved once.