### PR TITLE
Adjust mediafiles to handle owner_id

### DIFF
--- a/client/src/app/domain/models/mediafiles/mediafile.ts
+++ b/client/src/app/domain/models/mediafiles/mediafile.ts
@@ -3,6 +3,7 @@ import { Id, Fqid } from '../../definitions/key-types';
 import { HasMeetingId } from '../../interfaces/has-meeting-id';
 import { HasProjectionIds } from '../../interfaces/has-projectable-ids';
 import { HasListOfSpeakersId } from '../../interfaces/has-list-of-speakers-id';
+import { HasOwnerId } from '../../interfaces/has-owner-id';
 
 interface PdfInformation {
     pages?: number;
@@ -57,4 +58,4 @@ export class Mediafile extends BaseModel<Mediafile> {
         return this.is_directory ? `/mediafiles/${this.id}` : `/system/media/get/${this.id}`;
     }
 }
-export interface Mediafile extends HasMeetingId, HasProjectionIds, HasListOfSpeakersId {}
+export interface Mediafile extends HasOwnerId, HasProjectionIds, HasListOfSpeakersId {}

--- a/client/src/app/gateways/repositories/mediafiles/mediafile-repository.service.ts
+++ b/client/src/app/gateways/repositories/mediafiles/mediafile-repository.service.ts
@@ -34,6 +34,7 @@ export class MediafileRepositoryService extends BaseRepository<ViewMediafile, Me
         const fileSelectionFields: TypedFieldset<Mediafile> = [`title`, `is_directory`];
         const fileCreationFields: TypedFieldset<Mediafile> = fileSelectionFields.concat([`parent_id`, `child_ids`]);
         const listFields: TypedFieldset<Mediafile> = fileCreationFields.concat([
+            `owner_id`,
             `mimetype`,
             `filesize`,
             `create_timestamp`,

--- a/client/src/app/site/pages/meetings/pages/mediafiles/view-models/view-mediafile.ts
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/view-models/view-mediafile.ts
@@ -10,6 +10,9 @@ import { VIDEO_MIMETYPES } from '../definitions/index';
 import { ViewGroup } from '../../participants/modules/groups/view-models/view-group';
 import { HasListOfSpeakers } from '../../agenda/modules/list-of-speakers';
 import { StructuredRelation } from '../../../../../../infrastructure/definitions/relations';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { Meeting } from 'src/app/domain/models/meetings/meeting';
+import { collectionIdFromFqid } from 'src/app/infrastructure/utils/transform-functions';
 
 export class ViewMediafile extends BaseProjectableViewModel<Mediafile> {
     public static COLLECTION = Mediafile.COLLECTION;
@@ -25,6 +28,17 @@ export class ViewMediafile extends BaseProjectableViewModel<Mediafile> {
 
     public get timestamp(): string | null {
         return this.mediafile.create_timestamp ? this.mediafile.create_timestamp : null;
+    }
+
+    /**
+     * Only use this if you are sure that you have a meeting mediafile
+     */
+    public get meeting_id(): Id {
+        const [collection, id] = collectionIdFromFqid(this.mediafile.owner_id);
+        if (collection != Meeting.COLLECTION) {
+            throw Error("Mediafile's owner_id is not a meeting");
+        }
+        return id;
     }
 
     // public formatForSearch(): SearchRepresentation {


### PR DESCRIPTION
fixes #1082 

It seems like the mediafile restructure from https://github.com/OpenSlides/openslides-backend/pull/1200 was either not transferred to the client yet or got lost in the restructure (@GabrielInTheWorld?). I adjusted the model and fixed the issue linked above as general as possible, but I don't know if there might be more places which fail because of the mediafile rework. At the very least we'll have to touch this again when implementing the orga-wide mediafiles.