### PR TITLE
Added missing firtsLine parameter for text recalculation.

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/motions/modules/motion-slide/components/motion-slide/motion-slide.component.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/motions/modules/motion-slide/components/motion-slide/motion-slide.component.ts
@@ -264,7 +264,8 @@ export class MotionSlideComponent
             crMode: this.crMode,
             changes,
             lineLength: this.lineLength,
-            highlightedLine: this.highlightedLine
+            highlightedLine: this.highlightedLine,
+            firstLine: 1
         });
     }
 

--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/motions/modules/motion-slide/components/motion-slide/motion-slide.component.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/motions/modules/motion-slide/components/motion-slide/motion-slide.component.ts
@@ -265,7 +265,7 @@ export class MotionSlideComponent
             changes,
             lineLength: this.lineLength,
             highlightedLine: this.highlightedLine,
-            firstLine: 1
+            firstLine: this.data.data.start_line_number || 1
         });
     }
 


### PR DESCRIPTION
Fixes #1035. This fix works and motions are shown in the projector, but I dont know if firstLine is always 1 and if its ok to use a constant value here.