### PR TITLE
Several fixes (4.)

### DIFF
--- a/client/src/app/gateways/repositories/agenda/agenda-item-repository.service.ts
+++ b/client/src/app/gateways/repositories/agenda/agenda-item-repository.service.ts
@@ -105,7 +105,6 @@ export class AgendaItemRepositoryService extends BaseMeetingRelatedRepository<Vi
             content_object_id: contentObject.getModel()?.fqid || contentObject.fqid,
             ...this.getOptionalPayload(data)
         }));
-        console.log(`addItemToAgenda`, payload);
         return this.createAction(AgendaItemAction.CREATE, payload);
     }
 

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.ts
@@ -464,7 +464,7 @@ export class AssignmentDetailComponent extends BaseMeetingComponent implements O
     }
 
     public addToAgenda(): void {
-        this.itemRepo.addToAgenda({}, this.assignment);
+        this.itemRepo.addToAgenda({}, this.assignment).resolve();
     }
 
     public removeFromAgenda(): void {

--- a/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-detail-message/chat-group-detail-message.component.ts
+++ b/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-detail-message/chat-group-detail-message.component.ts
@@ -29,7 +29,10 @@ export class ChatGroupDetailMessageComponent {
     }
 
     public get author(): string {
-        return this.user?.username || ``;
+        if (this.user) {
+            return `${this.user.first_name} ${this.user.last_name}`;
+        }
+        return ``;
     }
 
     public get text(): string {

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
@@ -70,9 +70,9 @@
         (click)="openEditInfo(user, $event)"
     >
         <div class="groupsCell">
-            <div *ngIf="getUserGroups(user)?.length">
+            <div *ngIf="user.groups()?.length">
                 <os-icon-container icon="people" [noWrap]="true">
-                    <span *ngFor="let group of getUserGroups(user); let last = last" class="inline-flex">
+                    <span *ngFor="let group of user.groups(); let last = last" class="inline-flex">
                         {{ group.getTitle() | translate }}
                         <span *ngIf="!last">,&nbsp;</span>
                     </span>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
@@ -167,17 +167,6 @@ export class ParticipantListComponent extends BaseMeetingListViewComponent<ViewU
         this.router.navigate([`new`], { relativeTo: this.route });
     }
 
-    /**
-     * Filters the default group of a meeting
-     *
-     * @param user Their groups will be retrieved
-     *
-     * @returns The groups the given user is assigned to, except the default group of a current meeting
-     */
-    public getUserGroups(user: ViewUser): ViewGroup[] {
-        return user.groups().filter(group => !group.isDefaultGroup);
-    }
-
     public isUserPresent(user: ViewUser): boolean {
         return user.isPresentInMeeting();
     }

--- a/client/src/app/site/pages/meetings/services/meeting-controller.service.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-controller.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Action } from 'src/app/gateways/actions';
+import { ImportMeeting } from 'src/app/gateways/repositories/meeting-repository.service';
 import { BaseController } from 'src/app/site/base/base-controller';
 
 import { Identifiable } from '../../../../domain/interfaces';
@@ -72,6 +73,10 @@ export class MeetingControllerService extends BaseController<ViewMeeting, Meetin
 
     public getGeneralViewModelObservable(): Observable<ViewMeeting> {
         return this.repo.getGeneralViewModelObservable();
+    }
+
+    public import(committeeId: Id, meeting: ImportMeeting): Promise<Identifiable> {
+        return this.repo.import(committeeId, meeting);
     }
 
     public parseUnixToMeetingTime(time?: number): string {

--- a/client/src/app/site/pages/organization/config/model-subscription.ts
+++ b/client/src/app/site/pages/organization/config/model-subscription.ts
@@ -1,0 +1,19 @@
+import { map, Observable } from 'rxjs';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { MEETING_LIST_SUBSCRIPTION } from 'src/app/site/pages/meetings/view-models/view-meeting';
+import { ORGANIZATION_ID } from 'src/app/site/pages/organization/services/organization.service';
+import { ViewOrganization } from 'src/app/site/pages/organization/view-models/view-organization';
+
+export const getMeetingListSubscriptionConfig = (getNextMeetingIdObservable: () => Observable<Id | null>) => ({
+    modelRequest: {
+        viewModelCtor: ViewOrganization,
+        ids: [ORGANIZATION_ID],
+        follow: [
+            { idField: `active_meeting_ids`, fieldset: `list` },
+            { idField: `archived_meeting_ids`, fieldset: `list` },
+            { idField: `template_meeting_ids`, fieldset: `list` }
+        ]
+    },
+    subscriptionName: MEETING_LIST_SUBSCRIPTION,
+    hideWhen: getNextMeetingIdObservable().pipe(map(id => !!id))
+});

--- a/client/src/app/site/pages/organization/pages/accounts/components/account-main/account-main.component.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/components/account-main/account-main.component.ts
@@ -7,6 +7,7 @@ import {
     ModelRequestConfig
 } from 'src/app/site/base/base-model-request-handler.component';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { getMeetingListSubscriptionConfig } from 'src/app/site/pages/organization/config/model-subscription';
 import { ModelRequestService } from 'src/app/site/services/model-request.service';
 import { OpenSlidesRouterService } from 'src/app/site/services/openslides-router.service';
 
@@ -49,7 +50,8 @@ export class AccountMainComponent extends BaseModelRequestHandlerComponent {
                 subscriptionName: `${ACCOUNT_LIST_SUBSCRIPTION}_${uniqueSubscriptionNumber}`,
                 hideWhen: this.getNextMeetingIdObservable().pipe(map(id => !!id))
             },
-            getCommitteeListSubscriptionConfig(() => this.getNextMeetingIdObservable())
+            getCommitteeListSubscriptionConfig(() => this.getNextMeetingIdObservable()),
+            getMeetingListSubscriptionConfig(() => this.getNextMeetingIdObservable())
         ];
     }
 }

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list-main/account-list-main.component.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list-main/account-list-main.component.ts
@@ -1,39 +1,9 @@
 import { Component } from '@angular/core';
 import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
 
-const ACCOUNT_LIST_SUBSCRIPTION = `account_list`;
-
-let uniqueSubscriptionNumber = 0;
-
 @Component({
     selector: `os-account-list-main`,
     templateUrl: `./account-list-main.component.html`,
     styleUrls: [`./account-list-main.component.scss`]
 })
-export class AccountListMainComponent extends BaseModelRequestHandlerComponent {
-    // private _accountIds: Ids = [];
-    // public constructor(
-    //     modelRequestService: ModelRequestService,
-    //     router: Router,
-    //     openslidesRouter: OpenSlidesRouterService,
-    //     private controller: AccountControllerService
-    // ) {
-    //     super(modelRequestService, router, openslidesRouter);
-    // }
-    // protected override async onBeforeModelRequests(): Promise<void> {
-    //     this._accountIds = await this.controller.fetchAccountIds();
-    // }
-    // protected override onCreateModelRequests(): void | ModelRequestConfig[] {
-    //     return [
-    //         {
-    //             modelRequest: {
-    //                 viewModelCtor: ViewUser,
-    //                 ids: this._accountIds,
-    //                 fieldset: `accountList`
-    //             },
-    //             subscriptionName: `${ACCOUNT_LIST_SUBSCRIPTION}_${uniqueSubscriptionNumber}`,
-    //             hideWhen: this.getNextMeetingIdObservable().pipe(map(id => !!id))
-    //         }
-    //     ];
-    // }
-}
+export class AccountListMainComponent extends BaseModelRequestHandlerComponent {}

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
@@ -21,7 +21,7 @@ import { AccountSortService } from '../../services/account-list-sort.service/acc
     templateUrl: `./account-list.component.html`,
     styleUrls: [`./account-list.component.scss`]
 })
-export class AccountListComponent extends BaseListViewComponent<ViewUser> implements OnInit {
+export class AccountListComponent extends BaseListViewComponent<ViewUser> {
     public tableColumnDefinition: PblColumnDefinition[] = [
         {
             prop: `short_name`,
@@ -51,10 +51,6 @@ export class AccountListComponent extends BaseListViewComponent<ViewUser> implem
         super(componentServiceCollector, translate);
         super.setTitle(`Accounts`);
         this.canMultiSelect = true;
-    }
-
-    public ngOnInit(): void {
-        this.loadUsers();
     }
 
     public createNewMember(): void {
@@ -90,7 +86,7 @@ export class AccountListComponent extends BaseListViewComponent<ViewUser> implem
                 throw new Error(`Wrong meeting selected`);
             }
             if (selectedChoice.action === ADD) {
-                this.controller.bulkAddUserToMeeting(this.selectedRows, selectedMeeting);
+                this.controller.bulkAddUserToMeeting(this.selectedRows, selectedMeeting).resolve();
             } else {
                 this.controller.bulkRemoveUserFromMeeting(this.selectedRows, selectedMeeting).resolve();
             }
@@ -104,6 +100,4 @@ export class AccountListComponent extends BaseListViewComponent<ViewUser> implem
     public getOmlByUser(user: ViewUser): string {
         return getOmlVerboseName(user.organization_management_level as keyof OMLMapping);
     }
-
-    private async loadUsers(start_index: number = 0, entries: number = 500): Promise<void> {}
 }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/committee-detail-routing.module.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/committee-detail-routing.module.ts
@@ -19,7 +19,6 @@ const routes: Routes = [
             })),
             {
                 path: `:committeeId`,
-                // component: CommitteeDetailComponent,
                 children: [
                     {
                         path: ``,

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/components/committee-detail/committee-detail.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/components/committee-detail/committee-detail.component.ts
@@ -1,14 +1,11 @@
 import { Component } from '@angular/core';
-import { map } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { COMMITTEE_DETAIL_SUBSCRIPTION } from 'src/app/domain/models/comittees/committee';
 import {
     BaseModelRequestHandlerComponent,
     ModelRequestConfig
 } from 'src/app/site/base/base-model-request-handler.component/base-model-request-handler.component';
-import { MEETING_LIST_SUBSCRIPTION } from 'src/app/site/pages/meetings/view-models/view-meeting';
-import { ORGANIZATION_ID } from 'src/app/site/pages/organization/services/organization.service';
-import { ViewOrganization } from 'src/app/site/pages/organization/view-models/view-organization';
+import { getMeetingListSubscriptionConfig } from 'src/app/site/pages/organization/config/model-subscription';
 import { DEFAULT_FIELDSET } from 'src/app/site/services/model-request-builder';
 
 import { ViewCommittee } from '../../../../view-models';
@@ -22,20 +19,7 @@ export class CommitteeDetailComponent extends BaseModelRequestHandlerComponent {
     private committeeId: Id | null = null;
 
     protected override onCreateModelRequests(): void | ModelRequestConfig[] {
-        return [
-            {
-                modelRequest: {
-                    viewModelCtor: ViewOrganization,
-                    ids: [ORGANIZATION_ID],
-                    follow: [
-                        { idField: `active_meeting_ids`, fieldset: `list` },
-                        { idField: `archived_meeting_ids`, fieldset: `list` }
-                    ]
-                },
-                subscriptionName: MEETING_LIST_SUBSCRIPTION,
-                hideWhen: this.getNextMeetingIdObservable().pipe(map(id => !!id))
-            }
-        ];
+        return [getMeetingListSubscriptionConfig(() => this.getNextMeetingIdObservable())];
     }
 
     protected override onParamsChanged(params: any): void {

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/committee-detail-meeting-routing.module.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/committee-detail-meeting-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { CommitteeDetailMeetingMainComponent } from './components/committee-detail-meeting-main/committee-detail-meeting-main.component';
 import { MeetingEditComponent } from './components/meeting-edit/meeting-edit.component';
+import { MeetingImportComponent } from './components/meeting-import/meeting-import.component';
 
 const routes: Routes = [
     {
@@ -12,6 +13,10 @@ const routes: Routes = [
             {
                 path: `create`,
                 component: MeetingEditComponent
+            },
+            {
+                path: `import`,
+                component: MeetingImportComponent
             },
             {
                 path: `edit`,

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/committee-detail-meeting.module.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/committee-detail-meeting.module.ts
@@ -7,6 +7,7 @@ import { MatInputModule } from '@angular/material/input';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { AccountSearchSelectorModule } from 'src/app/site/pages/organization/modules/account-search-selector';
 import { DirectivesModule } from 'src/app/ui/directives';
+import { FileUploadModule } from 'src/app/ui/modules/file-upload';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
 import { OpenSlidesDateAdapterModule } from 'src/app/ui/modules/openslides-date-adapter/openslides-date-adapter.module';
 import { SearchSelectorModule } from 'src/app/ui/modules/search-selector';
@@ -15,9 +16,10 @@ import { OrganizationTagCommonServiceModule } from '../../../../../organization-
 import { CommitteeDetailMeetingRoutingModule } from './committee-detail-meeting-routing.module';
 import { CommitteeDetailMeetingMainComponent } from './components/committee-detail-meeting-main/committee-detail-meeting-main.component';
 import { MeetingEditComponent } from './components/meeting-edit/meeting-edit.component';
+import { MeetingImportComponent } from './components/meeting-import/meeting-import.component';
 
 @NgModule({
-    declarations: [MeetingEditComponent, CommitteeDetailMeetingMainComponent],
+    declarations: [MeetingEditComponent, CommitteeDetailMeetingMainComponent, MeetingImportComponent],
     imports: [
         CommonModule,
         CommitteeDetailMeetingRoutingModule,
@@ -32,7 +34,8 @@ import { MeetingEditComponent } from './components/meeting-edit/meeting-edit.com
         OpenSlidesTranslationModule.forChild(),
         OpenSlidesDateAdapterModule,
         FormsModule,
-        DirectivesModule
+        DirectivesModule,
+        FileUploadModule
     ]
 })
 export class CommitteeDetailMeetingModule {}

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.html
@@ -1,0 +1,14 @@
+<os-head-bar [nav]="false" [goBack]="true">
+    <!-- Title -->
+    <div class="title-slot">
+        <h2>{{ 'Import meeting' | translate }}</h2>
+    </div>
+</os-head-bar>
+
+<mat-card class="os-card">
+    <os-file-upload
+        [columns]="columns"
+        [uploadFileFn]="getUploadFileFn()"
+        (uploadSucceeded)="onUploadSucceeded()"
+    ></os-file-upload>
+</mat-card>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.spec.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MeetingImportComponent } from './meeting-import.component';
+
+describe(`MeetingImportComponent`, () => {
+    let component: MeetingImportComponent;
+    let fixture: ComponentFixture<MeetingImportComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [MeetingImportComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(MeetingImportComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it(`should create`, () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
@@ -1,0 +1,66 @@
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { PblColumnDefinition } from '@pebula/ngrid';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { Identifiable } from 'src/app/domain/interfaces';
+import { ImportMeeting } from 'src/app/gateways/repositories/meeting-repository.service';
+import { BaseComponent } from 'src/app/site/base/base.component';
+import { MeetingControllerService } from 'src/app/site/pages/meetings/services/meeting-controller.service';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
+import { OpenSlidesRouterService } from 'src/app/site/services/openslides-router.service';
+import { FileData } from 'src/app/ui/modules/file-upload/components/file-upload/file-upload.component';
+
+@Component({
+    selector: `os-meeting-import`,
+    templateUrl: `./meeting-import.component.html`,
+    styleUrls: [`./meeting-import.component.scss`]
+})
+export class MeetingImportComponent extends BaseComponent implements OnInit {
+    public columns: PblColumnDefinition[] = [
+        {
+            prop: `title`,
+            label: this.translate.instant(`Title`)
+        }
+    ];
+
+    private committeeId: Id | null = null;
+
+    public constructor(
+        componentServiceCollector: ComponentServiceCollectorService,
+        protected override translate: TranslateService,
+        private repo: MeetingControllerService,
+        private osRouter: OpenSlidesRouterService,
+        private location: Location
+    ) {
+        super(componentServiceCollector, translate);
+    }
+
+    public ngOnInit(): void {
+        this.subscriptions.push(
+            this.osRouter.currentParamMap.subscribe(params => {
+                if (params[`committeeId`]) {
+                    this.committeeId = +params[`committeeId`];
+                }
+            })
+        );
+    }
+
+    public onUploadSucceeded(): void {
+        this.location.back();
+    }
+
+    public getUploadFileFn(): (file: FileData) => Promise<Identifiable> {
+        return async file => {
+            const meeting = await new Promise<ImportMeeting>(resolve => {
+                const reader = new FileReader();
+                reader.addEventListener(`load`, progress => {
+                    const result = JSON.parse(progress.target.result as string);
+                    resolve(result);
+                });
+                reader.readAsText(file.mediafile);
+            });
+            return this.repo.import(this.committeeId, meeting);
+        };
+    }
+}

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
@@ -115,7 +115,7 @@
                 <mat-icon>edit</mat-icon>
                 <span>{{ 'Edit committee' | translate }}</span>
             </a>
-            <a mat-menu-item type="button" [routerLink]="['import-meeting']">
+            <a mat-menu-item type="button" [routerLink]="['meeting', 'import']">
                 <mat-icon>cloud_upload</mat-icon>
                 <span>
                     {{ 'Import meeting' | translate }}

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-main/components/dashboard-main/dashboard-main.component.ts
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-main/components/dashboard-main/dashboard-main.component.ts
@@ -1,12 +1,9 @@
 import { Component } from '@angular/core';
-import { map } from 'rxjs';
 import {
     BaseModelRequestHandlerComponent,
     ModelRequestConfig
 } from 'src/app/site/base/base-model-request-handler.component/base-model-request-handler.component';
-import { MEETING_LIST_SUBSCRIPTION } from 'src/app/site/pages/meetings/view-models/view-meeting';
-import { ORGANIZATION_ID } from 'src/app/site/pages/organization/services/organization.service';
-import { ViewOrganization } from 'src/app/site/pages/organization/view-models/view-organization';
+import { getMeetingListSubscriptionConfig } from 'src/app/site/pages/organization/config/model-subscription';
 
 @Component({
     selector: `os-dashboard-main`,
@@ -15,20 +12,6 @@ import { ViewOrganization } from 'src/app/site/pages/organization/view-models/vi
 })
 export class DashboardMainComponent extends BaseModelRequestHandlerComponent {
     protected override onCreateModelRequests(): void | ModelRequestConfig[] {
-        return [
-            {
-                modelRequest: {
-                    viewModelCtor: ViewOrganization,
-                    ids: [ORGANIZATION_ID],
-                    follow: [
-                        { idField: `active_meeting_ids`, fieldset: `list` },
-                        { idField: `archived_meeting_ids`, fieldset: `list` },
-                        { idField: `template_meeting_ids`, fieldset: `list` }
-                    ]
-                },
-                subscriptionName: MEETING_LIST_SUBSCRIPTION,
-                hideWhen: this.getNextMeetingIdObservable().pipe(map(id => !!id))
-            }
-        ];
+        return [getMeetingListSubscriptionConfig(() => this.getNextMeetingIdObservable())];
     }
 }


### PR DESCRIPTION
- The first- and surname of a user is shown as author at chat messages instead of their username (Fixes #1180)
- The import view of meetings is accessible (Fixes #1188)
- Accounts can be assigned to meetings by the multiselection of accounts (Fixes #1185)
- An election can be added to the agenda (Fixes #1184)
- The name of the default group of a meeting is displayed in the participant list view (Fixes #1171)