### PR TITLE
Participant import now writes into meeting-specific fields

### DIFF
--- a/client/src/app/domain/models/users/user.constants.ts
+++ b/client/src/app/domain/models/users/user.constants.ts
@@ -9,8 +9,22 @@ export const userHeadersAndVerboseNames: { [key in keyof User]?: string } = {
     default_password: `Initial password`,
     email: `Email`,
     username: `Username`,
-    gender: `Gender`,
+    gender: `Gender`
+};
+
+export const accountHeadersAndVerboseNames: { [key in keyof User]?: string } = {
+    ...userHeadersAndVerboseNames,
     default_number: `Participant number`,
     default_structure_level: `Structure level`,
     default_vote_weight: `Vote weight`
+}
+
+export const participantHeadersAndVerboseNames: { [key in keyof User]?: string } = {
+    ...userHeadersAndVerboseNames,
+    number: `Participant number`,
+    structure_level: `Structure level`,
+    vote_weight: `Vote weight`,
+    comment: `Comment`,
+    is_present_in_meeting_ids: `Is present`,
+    group_ids: `Groups`
 };

--- a/client/src/app/domain/models/users/user.constants.ts
+++ b/client/src/app/domain/models/users/user.constants.ts
@@ -11,20 +11,3 @@ export const userHeadersAndVerboseNames: { [key in keyof User]?: string } = {
     username: `Username`,
     gender: `Gender`
 };
-
-export const accountHeadersAndVerboseNames: { [key in keyof User]?: string } = {
-    ...userHeadersAndVerboseNames,
-    default_number: `Participant number`,
-    default_structure_level: `Structure level`,
-    default_vote_weight: `Vote weight`
-};
-
-export const participantHeadersAndVerboseNames: { [key in keyof User]?: string } = {
-    ...userHeadersAndVerboseNames,
-    number: `Participant number`,
-    structure_level: `Structure level`,
-    vote_weight: `Vote weight`,
-    comment: `Comment`,
-    is_present_in_meeting_ids: `Is present`,
-    group_ids: `Groups`
-};

--- a/client/src/app/domain/models/users/user.constants.ts
+++ b/client/src/app/domain/models/users/user.constants.ts
@@ -17,7 +17,7 @@ export const accountHeadersAndVerboseNames: { [key in keyof User]?: string } = {
     default_number: `Participant number`,
     default_structure_level: `Structure level`,
     default_vote_weight: `Vote weight`
-}
+};
 
 export const participantHeadersAndVerboseNames: { [key in keyof User]?: string } = {
     ...userHeadersAndVerboseNames,

--- a/client/src/app/site/pages/meetings/pages/participants/export/participant-csv-export.service/participant-csv-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/export/participant-csv-export.service/participant-csv-export.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { participantHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { UserExport } from 'src/app/domain/models/users/user.export';
 import { CsvExportService } from 'src/app/gateways/export/csv-export.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 
+import { participantHeadersAndVerboseNames } from '../../pages/participant-import/definitions';
 import { ParticipantExportModule } from '../participant-export.module';
 import { participantsExportExample } from '../participants-export-example';
 

--- a/client/src/app/site/pages/meetings/pages/participants/export/participant-csv-export.service/participant-csv-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/export/participant-csv-export.service/participant-csv-export.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { participantHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { UserExport } from 'src/app/domain/models/users/user.export';
 import { CsvExportService } from 'src/app/gateways/export/csv-export.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 
-import { PARTICIPANT_HEADERS_AND_VERBOSE_NAMES } from '../../pages/participant-import/definitions/index';
 import { ParticipantExportModule } from '../participant-export.module';
 import { participantsExportExample } from '../participants-export-example';
 
@@ -54,7 +54,7 @@ export class ParticipantCsvExportService {
     public exportCsvExample(): void {
         const rows: UserExport[] = participantsExportExample;
         this.csvExport.dummyCSVExport<UserExport>(
-            PARTICIPANT_HEADERS_AND_VERBOSE_NAMES,
+            participantHeadersAndVerboseNames,
             rows,
             `${this.translate.instant(`participants-example`)}.csv`
         );

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.ts
@@ -2,10 +2,10 @@ import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { User } from 'src/app/domain/models/users/user';
-import { participantHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { BaseUserImportListComponent } from 'src/app/site/base/base-user-import-list.component';
 import { MeetingComponentServiceCollectorService } from 'src/app/site/pages/meetings/services/meeting-component-service-collector.service';
 
+import { participantHeadersAndVerboseNames } from '../../definitions';
 import { ParticipantImportService } from '../../services';
 
 @Component({

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.ts
@@ -2,10 +2,10 @@ import { Component } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { User } from 'src/app/domain/models/users/user';
+import { participantHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { BaseUserImportListComponent } from 'src/app/site/base/base-user-import-list.component';
 import { MeetingComponentServiceCollectorService } from 'src/app/site/pages/meetings/services/meeting-component-service-collector.service';
 
-import { PARTICIPANT_HEADERS_AND_VERBOSE_NAMES } from '../../definitions';
 import { ParticipantImportService } from '../../services';
 
 @Component({
@@ -23,7 +23,7 @@ export class ParticipantImportListComponent extends BaseUserImportListComponent 
         formBuilder: FormBuilder,
         public override readonly importer: ParticipantImportService
     ) {
-        super(componentServiceCollector, translate, importer, formBuilder, PARTICIPANT_HEADERS_AND_VERBOSE_NAMES);
+        super(componentServiceCollector, translate, importer, formBuilder, participantHeadersAndVerboseNames);
     }
 
     /**

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/definitions/index.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/definitions/index.ts
@@ -1,0 +1,12 @@
+import { User } from 'src/app/domain/models/users/user';
+import { userHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
+
+export const participantHeadersAndVerboseNames: { [key in keyof User]?: string } = {
+    ...userHeadersAndVerboseNames,
+    number: `Participant number`,
+    structure_level: `Structure level`,
+    vote_weight: `Vote weight`,
+    comment: `Comment`,
+    is_present_in_meeting_ids: `Is present`,
+    group_ids: `Groups`
+};

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/definitions/index.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/definitions/index.ts
@@ -1,9 +1,0 @@
-import { User } from 'src/app/domain/models/users/user';
-import { userHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
-
-export const PARTICIPANT_HEADERS_AND_VERBOSE_NAMES: { [key in keyof User]?: string } = {
-    ...userHeadersAndVerboseNames,
-    comment: `Comment`,
-    is_present_in_meeting_ids: `Is present`,
-    group_ids: `Groups`
-};

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -3,7 +3,6 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Identifiable } from 'src/app/domain/interfaces';
 import { User } from 'src/app/domain/models/users/user';
-import { participantHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { SearchUsersByNameOrEmailPresenterService } from 'src/app/gateways/presenter/search-users-by-name-or-email-presenter.service';
 import { ImportModel } from 'src/app/infrastructure/utils/import/import-model';
 import { ImportStepPhase } from 'src/app/infrastructure/utils/import/import-step';
@@ -18,6 +17,7 @@ import { ImportServiceCollectorService } from 'src/app/site/services/import-serv
 
 import { ParticipantCsvExportService } from '../../../../export/participant-csv-export.service/participant-csv-export.service';
 import { GroupControllerService } from '../../../../modules';
+import { participantHeadersAndVerboseNames } from '../../definitions';
 import { ParticipantImportServiceModule } from '../participant-import-service.module';
 
 const GROUP_PROPERTY = `group_ids`;

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -3,7 +3,7 @@ import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Identifiable } from 'src/app/domain/interfaces';
 import { User } from 'src/app/domain/models/users/user';
-import { userHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
+import { participantHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { SearchUsersByNameOrEmailPresenterService } from 'src/app/gateways/presenter/search-users-by-name-or-email-presenter.service';
 import { ImportModel } from 'src/app/infrastructure/utils/import/import-model';
 import { ImportStepPhase } from 'src/app/infrastructure/utils/import/import-step';
@@ -104,7 +104,7 @@ export class ParticipantImportService extends BaseUserImportService {
 
     protected getConfig(): ImportConfig<User> {
         return {
-            modelHeadersAndVerboseNames: userHeadersAndVerboseNames,
+            modelHeadersAndVerboseNames: participantHeadersAndVerboseNames,
             verboseNameFn: plural => this.repo.getVerboseName(plural),
             createFn: (entries: any[]) => this.createUsers(entries),
             shouldCreateModelFn: user => user.status === `new`

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-import/components/account-import-list/account-import-list.component.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-import/components/account-import-list/account-import-list.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { User } from 'src/app/domain/models/users/user';
-import { userHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
+import { accountHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { BaseUserImportListComponent } from 'src/app/site/base/base-user-import-list.component';
 import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 
@@ -22,7 +22,7 @@ export class AccountImportListComponent extends BaseUserImportListComponent impl
         public override importer: AccountImportService,
         private accountController: AccountControllerService
     ) {
-        super(componentServiceCollector, translate, importer, formBuilder, userHeadersAndVerboseNames);
+        super(componentServiceCollector, translate, importer, formBuilder, accountHeadersAndVerboseNames);
     }
 
     public override ngOnInit(): void {

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-import/components/account-import-list/account-import-list.component.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-import/components/account-import-list/account-import-list.component.ts
@@ -2,11 +2,11 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { User } from 'src/app/domain/models/users/user';
-import { accountHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { BaseUserImportListComponent } from 'src/app/site/base/base-user-import-list.component';
 import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 
 import { AccountControllerService } from '../../../../services/common/account-controller.service';
+import { accountHeadersAndVerboseNames } from '../../definitions';
 import { AccountImportService } from '../../services/account-import.service/account-import.service';
 
 @Component({

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-import/definitions/index.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-import/definitions/index.ts
@@ -1,0 +1,9 @@
+import { User } from 'src/app/domain/models/users/user';
+import { userHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
+
+export const accountHeadersAndVerboseNames: { [key in keyof User]?: string } = {
+    ...userHeadersAndVerboseNames,
+    default_number: `Participant number`,
+    default_structure_level: `Structure level`,
+    default_vote_weight: `Vote weight`
+};

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-import/services/account-import.service/account-import.service.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-import/services/account-import.service/account-import.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { User } from 'src/app/domain/models/users/user';
-import { userHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
+import { accountHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { ImportConfig } from 'src/app/infrastructure/utils/import/import-utils';
 import { BaseUserImportService } from 'src/app/site/base/base-user-import.service';
 import { ImportServiceCollectorService } from 'src/app/site/services/import-service-collector.service';
@@ -36,7 +36,7 @@ export class AccountImportService extends BaseUserImportService {
 
     protected getConfig(): ImportConfig<User> {
         return {
-            modelHeadersAndVerboseNames: userHeadersAndVerboseNames,
+            modelHeadersAndVerboseNames: accountHeadersAndVerboseNames,
             verboseNameFn: plural => (plural ? `Accounts` : `Account`),
             getDuplicatesFn: (entry: Partial<User>) =>
                 this.repo.getViewModelList().filter(user => user.username === entry.username),

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-import/services/account-import.service/account-import.service.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-import/services/account-import.service/account-import.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { User } from 'src/app/domain/models/users/user';
-import { accountHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { ImportConfig } from 'src/app/infrastructure/utils/import/import-utils';
 import { BaseUserImportService } from 'src/app/site/base/base-user-import.service';
 import { ImportServiceCollectorService } from 'src/app/site/services/import-service-collector.service';
 import { UserControllerService } from 'src/app/site/services/user-controller.service';
 
 import { AccountExportService } from '../../../../services/account-export.service';
+import { accountHeadersAndVerboseNames } from '../../definitions';
 import { AccountImportServiceModule } from '../account-import-service.module';
 
 @Injectable({

--- a/client/src/app/site/pages/organization/pages/accounts/services/account-export.service/account-export.service.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/services/account-export.service/account-export.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { userHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
+import { accountHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { UserExport } from 'src/app/domain/models/users/user.export';
 import { CsvExportService } from 'src/app/gateways/export/csv-export.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
@@ -16,7 +16,7 @@ export class AccountExportService {
 
     public downloadCsvImportExample(): void {
         this.csvExportService.dummyCSVExport<UserExport>(
-            userHeadersAndVerboseNames,
+            accountHeadersAndVerboseNames,
             AccountCsvExportExample,
             `${this.translate.instant(`account-example`)}.csv`
         );
@@ -25,7 +25,7 @@ export class AccountExportService {
     public downloadAccountCsvFile(dataSource: ViewUser[]): void {
         this.csvExportService.export(
             dataSource,
-            Object.entries(userHeadersAndVerboseNames).map(([key, value]) => ({
+            Object.entries(accountHeadersAndVerboseNames).map(([key, value]) => ({
                 property: key as keyof ViewUser,
                 label: value
             })),

--- a/client/src/app/site/pages/organization/pages/accounts/services/account-export.service/account-export.service.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/services/account-export.service/account-export.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { accountHeadersAndVerboseNames } from 'src/app/domain/models/users/user.constants';
 import { UserExport } from 'src/app/domain/models/users/user.export';
 import { CsvExportService } from 'src/app/gateways/export/csv-export.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 
 import { AccountCsvExportExample } from '../../export/csv-export-example';
+import { accountHeadersAndVerboseNames } from '../../pages/account-import/definitions';
 import { AccountExportServiceModule } from '../account-export-service.module';
 
 @Injectable({


### PR DESCRIPTION
Instead of writing number, structure_level and vote_weight into the corresponding default-fields, they are now written into the meeting-specific ones.

Closes #1182 