### PR TITLE
Changed the styling of the detail-view-navigator

### DIFF
--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/detail-view-navigator/detail-view-navigator.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/detail-view-navigator/detail-view-navigator.component.html
@@ -1,3 +1,3 @@
-<a [routerLink]="getRouterLink()" class="stretch-to-fill-parent flex-center" [ngClass]="cssClasses">
+<a [routerLink]="getRouterLink()" class="detail-link flex-center" [ngClass]="cssClasses">
     <ng-content></ng-content>
 </a>


### PR DESCRIPTION
Closes #1212 

@GabrielInTheWorld  in a commit of yours that was merged yesterday you had switched one css class for another in the detail-view-navigator template. 
This made the component go haywire whenever it was displayed in a dot menu (as part of the list-of-speakers-button).
For now I've switched it back. It seems like this broke nothing in the other components that use the navigator. 
If this is somehow horribly wrong just tell me, I'll look for a different solution.