### PR TITLE
Fixes participants issues

### DIFF
--- a/client/src/app/domain/definitions/permission.config.ts
+++ b/client/src/app/domain/definitions/permission.config.ts
@@ -59,13 +59,6 @@ export const PERMISSIONS: AppPermission[] = [
         ]
     },
     {
-        name: `Files`,
-        permissions: [
-            { display_name: `Can see the list of files`, value: Permission.mediafileCanSee },
-            { display_name: `Can manage files`, value: Permission.mediafileCanManage }
-        ]
-    },
-    {
         name: `Participants`,
         permissions: [
             { display_name: `Can see participants`, value: Permission.userCanSee },
@@ -74,6 +67,13 @@ export const PERMISSIONS: AppPermission[] = [
                 value: Permission.userCanManagePresence
             },
             { display_name: `Can manage participants`, value: Permission.userCanManage }
+        ]
+    },
+    {
+        name: `Files`,
+        permissions: [
+            { display_name: `Can see the list of files`, value: Permission.mediafileCanSee },
+            { display_name: `Can manage files`, value: Permission.mediafileCanManage }
         ]
     },
     {

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
@@ -13,12 +13,12 @@
 
     <!-- Next-button -->
     <div class="extra-controls-slot">
-        <div *ngIf="matStepper.selectedIndex !== FILL_FORM_PARTICIPANT_STEP">
+        <div *ngIf="(currentStepIndexObservable | async) !== FILL_FORM_PARTICIPANT_STEP">
             <button type="button" mat-button (click)="matStepper.previous()">
                 <span class="upper">{{ 'Previous' | translate }}</span>
             </button>
         </div>
-        <div *ngIf="matStepper.selectedIndex !== CREATE_PARTICIPANT_STEP">
+        <div *ngIf="(currentStepIndexObservable | async) !== CREATE_PARTICIPANT_STEP">
             <button mat-button (click)="matStepper.next()">
                 <span class="upper">{{ 'Next' | translate }}</span>
             </button>
@@ -27,7 +27,7 @@
 </os-head-bar>
 
 <form [formGroup]="createUserForm">
-    <mat-horizontal-stepper
+    <mat-stepper
         #matStepper
         [linear]="true"
         [selectedIndex]="currentStepIndexObservable | async"
@@ -240,5 +240,5 @@
                 </os-user-detail-view>
             </ng-template>
         </mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
 </form>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
@@ -160,7 +160,7 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
         this._currentStepIndexSubject.next(index);
     }
 
-    public async onStepChanged(event: StepperSelectionEvent): Promise<void> {
+    public onStepChanged(event: StepperSelectionEvent): void {
         if (event.selectedIndex === this.CHOOSE_PARTICIPANT_STEP) {
             this.onChooseAccount();
         }

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
@@ -17,12 +17,11 @@
     </div>
 </os-head-bar>
 
-<os-projectable-list
+<os-list
     [listObservableProvider]="repo"
     [filterService]="filterService"
     [sortService]="sortService"
     [filterProps]="filterProps"
-    [showListOfSpeakers]="false"
     [multiSelect]="isMultiSelect"
     [hiddenInMobile]="['group', 'presence']"
     [(selectedRows)]="selectedRows"
@@ -51,7 +50,7 @@
             </div>
             <div class="icon-group">
                 <mat-icon matTooltip="{{ 'Is no natural person' | translate }}" *ngIf="!user.is_physical_person">
-                    auto_awesome_mosaic
+                    account_balance
                 </mat-icon>
                 <mat-icon matTooltip="{{ 'Inactive' | translate }}" *ngIf="!user.is_active && canManage">
                     block
@@ -146,7 +145,7 @@
             <mat-icon>more_vert</mat-icon>
         </button>
     </div>
-</os-projectable-list>
+</os-list>
 
 <!-- Menu for mobile entries -->
 <mat-menu #singleItemMenu="matMenu">

--- a/client/src/app/ui/modules/user-components/components/user-detail-view/user-detail-view.component.html
+++ b/client/src/app/ui/modules/user-components/components/user-detail-view/user-detail-view.component.html
@@ -145,8 +145,14 @@
                     &nbsp;
                     <span>({{ user.pronoun }})</span>
                 </ng-container>
-                <mat-icon *ngIf="!user.is_active && isAllowed('seeExtra')" matTooltip="{{ 'Inactive' | translate }}">
+                <mat-icon *ngIf="!user.is_active && isAllowed('manage')" matTooltip="{{ 'Inactive' | translate }}">
                     block
+                </mat-icon>
+                <mat-icon
+                    *ngIf="!user.is_physical_person && isAllowed('manage')"
+                    matTooltip="{{ 'Is no natural person' | translate }}"
+                >
+                    account_balance
                 </mat-icon>
             </span>
         </div>


### PR DESCRIPTION
- Re-orders the group matrix (section "participants" is above section "files")
- For non-natural persons, the "old" icon "account_balance" is used
- Removes the projector buttons on the participant list
- On the detail view of a participant, it is shown if a participant is active, a natural person, ... (Fixes #958)

Fixes #1254