### PR TITLE
Fixed non-preselected projection defaults

### DIFF
--- a/client/src/app/domain/models/projector/projection-default.ts
+++ b/client/src/app/domain/models/projector/projection-default.ts
@@ -1,6 +1,6 @@
 export enum Projectiondefault {
-    agendaAllItems = `agenda_item`,
-    topics = `topic`,
+    agendaAllItems = `agenda_all_items`,
+    topics = `topics`,
     listOfSpeakers = `list_of_speakers`,
     currentListOfSpeakers = `current_list_of_speakers`,
     motion = `motion`,
@@ -10,6 +10,8 @@ export enum Projectiondefault {
     user = `user`,
     mediafile = `mediafile`,
     projectorMessage = `projector_message`,
-    projectorCountdown = `projector_countdown`,
+    projectorCountdown = `projector_countdowns`,
+    assignmentPoll = `assignment_poll`,
+    motionPoll = `motion_poll`,
     poll = `poll`
 }

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/components/projection-dialog/projection-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/components/projection-dialog/projection-dialog.component.ts
@@ -42,6 +42,7 @@ export class ProjectionDialogComponent {
             const defaultProjector: ViewProjector | null = this.activeMeetingService.meeting!.default_projector(
                 this.descriptor.projectionDefault
             );
+            console.log(`LOG: `, defaultProjector);
             if (defaultProjector && !this.selectedProjectors.includes(defaultProjector)) {
                 this.selectedProjectors.push(defaultProjector);
             }

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projector-button/components/projector-button/projector-button.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projector-button/components/projector-button/projector-button.component.ts
@@ -97,6 +97,7 @@ export class ProjectorButtonComponent implements OnInit, OnDestroy {
             this.projectorService.toggle(descriptor, [this.projector]);
         } else {
             // open the projection dialog
+            console.log(`LOG: projector-button`);
             this.projectionDialogService.openProjectDialogFor(descriptor);
         }
     }

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/countdown-controls/countdown-controls.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/countdown-controls/countdown-controls.component.ts
@@ -111,6 +111,7 @@ export class CountdownControlsComponent {
      * Brings the projection dialog
      */
     public onBringDialog(): void {
+        console.log(`LOG: countdown-controls`);
         this.projectionDialogService.openProjectDialogFor(this.countdown.getProjectionBuildDescriptor());
     }
 

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/message-controls/message-controls.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/message-controls/message-controls.component.ts
@@ -54,6 +54,7 @@ export class MessageControlsComponent {
      * Brings the projection dialog
      */
     public onBringDialog(): void {
+        console.log(`LOG: message-controls`);
         this.projectionDialogService.openProjectDialogFor(this.message.getProjectionBuildDescriptor());
     }
 


### PR DESCRIPTION
Projectiondialog should now always preselect the correct projection default

It seems to have been a client issue. 
I reversed recent changes changes in the responsible file and that fixed it.