### PR TITLE
Fixes motion issues (#1255)

### DIFF
--- a/client/src/app/domain/models/motions/motion.ts
+++ b/client/src/app/domain/models/motions/motion.ts
@@ -59,7 +59,6 @@ export class Motion extends BaseModel<Motion> implements MotionFormattingReprese
     public all_derived_motion_ids!: Id[]; // (motion/origin_id)[];
     public all_origin_ids!: Id[]; // motion/all_derived_motion_ids;
     public state_id!: Id; // motion_state/motion_ids;
-    public workflow_id!: Id;
     public recommendation_id!: Id; // motion_state/motion_recommendation_ids;
     public recommendation_extension_reference_ids!: Fqid[]; // (*/referenced_in_motion_recommendation_extension_ids)[];
     // current option: motion

--- a/client/src/app/gateways/repositories/motions/motion-block-repository.service/motion-block-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-block-repository.service/motion-block-repository.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Identifiable } from 'src/app/domain/interfaces';
 import { ViewMotionBlock } from 'src/app/site/pages/meetings/pages/motions';
-import { DEFAULT_FIELDSET, Fieldsets, ROUTING_FIELDSET } from 'src/app/site/services/model-request-builder';
+import { DEFAULT_FIELDSET, Fieldsets } from 'src/app/site/services/model-request-builder';
 
 import { MotionBlock } from '../../../../domain/models/motions/motion-block';
 import { AgendaItemRepositoryService, createAgendaItem } from '../../agenda';
@@ -44,13 +44,16 @@ export class MotionBlockRepositoryService extends BaseAgendaItemAndListOfSpeaker
     }
 
     public override getFieldsets(): Fieldsets<MotionBlock> {
-        const routingFields: (keyof MotionBlock)[] = [`sequential_number`];
-        const titleFields: (keyof MotionBlock)[] = [`title`];
-        const listFields: (keyof MotionBlock)[] = titleFields.concat([`internal`, `agenda_item_id`]);
+        const listFields: (keyof MotionBlock)[] = [
+            `sequential_number`,
+            `meeting_id`,
+            `title`,
+            `internal`,
+            `agenda_item_id`,
+            `motion_ids`
+        ];
         return {
-            [DEFAULT_FIELDSET]: listFields,
-            [ROUTING_FIELDSET]: routingFields,
-            title: titleFields
+            [DEFAULT_FIELDSET]: listFields
         };
     }
 

--- a/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
@@ -70,7 +70,10 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
         return this.sendBulkActionToBackend(MotionAction.CREATE_FORWARDED, payload);
     }
 
-    public update(update: NullablePartial<Motion>, ...viewMotions: ViewMotion[]): Action<void> {
+    public update(
+        update: NullablePartial<Motion & { workflow_id: Id }>,
+        ...viewMotions: (Motion & { workflow_id: Id })[]
+    ): Action<void> {
         const payload = viewMotions.map(motion => this.getUpdatePayload(update, motion));
         return this.createAction(MotionAction.UPDATE, payload);
     }
@@ -163,7 +166,7 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
         return this.sendBulkActionToBackend(MotionAction.FOLLOW_RECOMMENDATION, payload);
     }
 
-    public createTextBased(partialMotion: Partial<Motion>): Action<CreateResponse> {
+    public createTextBased(partialMotion: Partial<Motion & { workflow_id: Id }>): Action<CreateResponse> {
         const payload = {
             meeting_id: this.activeMeetingIdService.meetingId,
             lead_motion_id: partialMotion.lead_motion_id,
@@ -186,7 +189,7 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
         return this.createAction(AmendmentAction.CREATE_TEXTBASED_AMENDMENT, payload);
     }
 
-    public createParagraphBased(partialMotion: Partial<Motion>): Action<CreateResponse> {
+    public createParagraphBased(partialMotion: Partial<Motion & { workflow_id: Id }>): Action<CreateResponse> {
         const payload = {
             meeting_id: this.activeMeetingIdService.meetingId,
             lead_motion_id: partialMotion.lead_motion_id,
@@ -209,7 +212,7 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
         return this.createAction(AmendmentAction.CREATE_PARAGRAPHBASED_AMENDMENT, payload);
     }
 
-    public createStatuteAmendment(partialMotion: Partial<Motion>): Action<CreateResponse> {
+    public createStatuteAmendment(partialMotion: Partial<Motion & { workflow_id: Id }>): Action<CreateResponse> {
         const payload = {
             meeting_id: this.activeMeetingIdService.meetingId,
             title: partialMotion.title,
@@ -265,7 +268,6 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
             `sort_weight`,
             `sort_parent_id`,
             `state_id`,
-            `workflow_id`,
             `text`,
             `change_recommendation_ids`,
             `attachment_ids`
@@ -357,9 +359,9 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
         };
     }
 
-    private getUpdatePayload(update: any, viewMotion: ViewMotion): any {
+    private getUpdatePayload(update: any, viewMotion: Motion & { workflow_id: Id }): any {
         const updatePayload = Object.keys(update).mapToObject(key => {
-            if (JSON.stringify(update[key]) !== JSON.stringify(viewMotion[key as keyof ViewMotion])) {
+            if (JSON.stringify(update[key]) !== JSON.stringify(viewMotion[key as keyof Motion & { workflow_id: Id }])) {
                 return { [key]: update[key] };
             }
             return {};

--- a/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/agenda-item-list.module.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/agenda-item-list.module.ts
@@ -15,7 +15,6 @@ import { IconContainerModule } from 'src/app/ui/modules/icon-container/icon-cont
 import { ListModule } from 'src/app/ui/modules/list';
 import { PromptDialogModule } from 'src/app/ui/modules/prompt-dialog';
 
-import { TagCommonServiceModule } from '../../../motions';
 import { AgendaItemCommonServiceModule } from '../../services/agenda-item-common-service.module';
 import { AgendaItemListRoutingModule } from './agenda-item-list-routing.module';
 import { AgendaItemInfoDialogComponent } from './components/agenda-item-info-dialog/agenda-item-info-dialog.component';
@@ -48,7 +47,6 @@ const OS_MODULES = [
         AgendaItemListRoutingModule,
         AgendaItemListServiceModule,
         AgendaItemCommonServiceModule,
-        TagCommonServiceModule,
         ...NG_MODULES,
         ...OS_MODULES
     ]

--- a/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-list-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-list-service.module.ts
@@ -1,9 +1,7 @@
 import { NgModule } from '@angular/core';
 import { MeetingPdfExportModule } from 'src/app/site/pages/meetings/services/export';
 
-import { TagCommonServiceModule } from '../../../../motions/modules/tags/tag-common-service.module';
-
 @NgModule({
-    imports: [TagCommonServiceModule, MeetingPdfExportModule]
+    imports: [MeetingPdfExportModule]
 })
 export class AgendaItemListServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-multiselect/motion-multiselect.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-multiselect/motion-multiselect.module.ts
@@ -8,13 +8,6 @@ import { DirectivesModule } from 'src/app/ui/directives';
 import { ChoiceDialogModule } from 'src/app/ui/modules/choice-dialog';
 
 import { AgendaItemCommonServiceModule } from '../../../agenda/services/agenda-item-common-service.module';
-import {
-    MotionBlockCommonServiceModule,
-    MotionSubmitterCommonServiceModule,
-    PersonalNoteServiceModule,
-    TagCommonServiceModule
-} from '../../modules';
-import { MotionWorkflowCommonServiceModule } from '../../modules/workflows/motion-workflow-common-service.module';
 import { MotionMultiselectActionsComponent } from './components/motion-multiselect-actions/motion-multiselect-actions.component';
 import { MotionMultiselectServiceModule } from './services/motion-multiselect-service.module';
 
@@ -25,7 +18,6 @@ const DECLARATIONS = [MotionMultiselectActionsComponent];
     exports: DECLARATIONS,
     imports: [
         CommonModule,
-        MotionBlockCommonServiceModule,
         MotionMultiselectServiceModule,
         MatIconModule,
         MatDividerModule,
@@ -33,11 +25,7 @@ const DECLARATIONS = [MotionMultiselectActionsComponent];
         ChoiceDialogModule,
         DirectivesModule,
         OpenSlidesTranslationModule.forChild(),
-        AgendaItemCommonServiceModule,
-        MotionSubmitterCommonServiceModule,
-        MotionWorkflowCommonServiceModule,
-        TagCommonServiceModule,
-        PersonalNoteServiceModule
+        AgendaItemCommonServiceModule
     ]
 })
 export class MotionMultiselectModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-multiselect/services/motion-multiselect.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-multiselect/services/motion-multiselect.service.ts
@@ -23,7 +23,6 @@ import { TagControllerService } from '../../../modules/tags/services';
 import { MotionWorkflowControllerService } from '../../../modules/workflows/services';
 import { MotionControllerService } from '../../../services/common/motion-controller.service';
 import { ViewMotion } from '../../../view-models';
-// import { MotionMultiselectModule } from '../motion-multiselect.module';
 import { MotionMultiselectServiceModule } from './motion-multiselect-service.module';
 
 @Injectable({

--- a/client/src/app/site/pages/meetings/pages/motions/modules/categories/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/categories/index.ts
@@ -1,2 +1,1 @@
-export * from './motion-categorie-common-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/categories/motion-categorie-common-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/categories/motion-categorie-common-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class MotionCategoryCommonServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/comments/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/comments/index.ts
@@ -1,2 +1,1 @@
-export * from './motion-comment-common-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/comments/motion-comment-common-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/comments/motion-comment-common-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class MotionCommentCommonServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/comments/services/motion-comment-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/comments/services/motion-comment-controller.service.ts
@@ -5,11 +5,10 @@ import { MotionCommentRepositoryService } from 'src/app/gateways/repositories/mo
 import { BaseMeetingControllerService } from 'src/app/site/pages/meetings/base/base-meeting-controller.service';
 import { MeetingControllerServiceCollectorService } from 'src/app/site/pages/meetings/services/meeting-controller-service-collector.service';
 
-import { MotionCommentCommonServiceModule } from '../motion-comment-common-service.module';
 import { ViewMotionComment } from '../view-models';
 
 @Injectable({
-    providedIn: MotionCommentCommonServiceModule
+    providedIn: `root`
 })
 export class MotionCommentControllerService extends BaseMeetingControllerService<ViewMotionComment, MotionComment> {
     constructor(

--- a/client/src/app/site/pages/meetings/pages/motions/modules/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/index.ts
@@ -1,6 +1,5 @@
 export * from './categories';
 export * from './change-recommendations';
-export * from './change-recommendations';
 export * from './comments';
 export * from './motion-blocks';
 export * from './personal-notes';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-blocks/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-blocks/index.ts
@@ -1,2 +1,1 @@
-export * from './motion-block-common-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-blocks/motion-block-common-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-blocks/motion-block-common-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class MotionBlockCommonServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-blocks/services/motion-block-controller.service/motion-block-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-blocks/services/motion-block-controller.service/motion-block-controller.service.ts
@@ -6,14 +6,13 @@ import { BaseMeetingControllerService } from 'src/app/site/pages/meetings/base/b
 import { MeetingControllerServiceCollectorService } from 'src/app/site/pages/meetings/services/meeting-controller-service-collector.service';
 
 import { MotionControllerService } from '../../../../services/common/motion-controller.service/motion-controller.service';
-import { MotionBlockCommonServiceModule } from '../../motion-block-common-service.module';
 import { ViewMotionBlock } from '../../view-models';
 
 @Injectable({
-    providedIn: MotionBlockCommonServiceModule
+    providedIn: `root`
 })
 export class MotionBlockControllerService extends BaseMeetingControllerService<ViewMotionBlock, MotionBlock> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MotionBlockRepositoryService,
         private motionRepo: MotionControllerService

--- a/client/src/app/site/pages/meetings/pages/motions/modules/personal-notes/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/personal-notes/index.ts
@@ -1,2 +1,1 @@
-export * from './personal-note-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/personal-notes/personal-note-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/personal-notes/personal-note-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class PersonalNoteServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/personal-notes/services/personal-note-controller.service/personal-note-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/personal-notes/services/personal-note-controller.service/personal-note-controller.service.ts
@@ -9,11 +9,10 @@ import { BaseViewModel } from 'src/app/site/base/base-view-model';
 import { BaseMeetingControllerService } from 'src/app/site/pages/meetings/base/base-meeting-controller.service';
 import { MeetingControllerServiceCollectorService } from 'src/app/site/pages/meetings/services/meeting-controller-service-collector.service';
 
-import { PersonalNoteServiceModule } from '../../personal-note-service.module';
 import { HasPersonalNote, ViewPersonalNote } from '../../view-models';
 
 @Injectable({
-    providedIn: PersonalNoteServiceModule
+    providedIn: `root`
 })
 export class PersonalNoteControllerService extends BaseMeetingControllerService<ViewPersonalNote, PersonalNote> {
     public constructor(

--- a/client/src/app/site/pages/meetings/pages/motions/modules/states/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/states/index.ts
@@ -1,2 +1,1 @@
-export * from './motion-state-common-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/states/motion-state-common-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/states/motion-state-common-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class MotionStateCommonServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/states/services/motion-state-controller.service/motion-state-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/states/services/motion-state-controller.service/motion-state-controller.service.ts
@@ -5,11 +5,10 @@ import { MotionStateRepositoryService } from 'src/app/gateways/repositories/moti
 import { BaseMeetingControllerService } from 'src/app/site/pages/meetings/base/base-meeting-controller.service';
 import { MeetingControllerServiceCollectorService } from 'src/app/site/pages/meetings/services/meeting-controller-service-collector.service';
 
-import { MotionStateCommonServiceModule } from '../../motion-state-common-service.module';
 import { ViewMotionState } from '../../view-models';
 
 @Injectable({
-    providedIn: MotionStateCommonServiceModule
+    providedIn: `root`
 })
 export class MotionStateControllerService extends BaseMeetingControllerService<ViewMotionState, MotionState> {
     constructor(

--- a/client/src/app/site/pages/meetings/pages/motions/modules/statute-paragraphs/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/statute-paragraphs/index.ts
@@ -1,2 +1,1 @@
-export * from './motion-statute-paragraph-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/statute-paragraphs/motion-statute-paragraph-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/statute-paragraphs/motion-statute-paragraph-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class MotionStatuteParagraphServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/submitters/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/submitters/index.ts
@@ -1,2 +1,1 @@
-export * from './motion-submitter-common-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/submitters/motion-submitter-common-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/submitters/motion-submitter-common-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class MotionSubmitterCommonServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/submitters/services/motion-submitter-controller.service/motion-submitter-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/submitters/services/motion-submitter-controller.service/motion-submitter-controller.service.ts
@@ -6,11 +6,10 @@ import { MotionSubmitterRepositoryService } from 'src/app/gateways/repositories/
 import { BaseMeetingControllerService } from 'src/app/site/pages/meetings/base/base-meeting-controller.service';
 import { MeetingControllerServiceCollectorService } from 'src/app/site/pages/meetings/services/meeting-controller-service-collector.service';
 
-import { MotionSubmitterCommonServiceModule } from '../../motion-submitter-common-service.module';
 import { ViewMotionSubmitter } from '../../view-models';
 
 @Injectable({
-    providedIn: MotionSubmitterCommonServiceModule
+    providedIn: `root`
 })
 export class MotionSubmitterControllerService extends BaseMeetingControllerService<
     ViewMotionSubmitter,

--- a/client/src/app/site/pages/meetings/pages/motions/modules/tags/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/tags/index.ts
@@ -1,2 +1,1 @@
-export * from './tag-common-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/tags/tag-common-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/tags/tag-common-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class TagCommonServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/modules/workflows/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/workflows/index.ts
@@ -1,2 +1,1 @@
-export * from './motion-workflow-common-service.module';
 export * from './view-models';

--- a/client/src/app/site/pages/meetings/pages/motions/modules/workflows/motion-workflow-common-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/workflows/motion-workflow-common-service.module.ts
@@ -1,8 +1,0 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-
-@NgModule({
-    declarations: [],
-    imports: [CommonModule]
-})
-export class MotionWorkflowCommonServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/pages/amendments/components/amendment-list/amendment-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/amendments/components/amendment-list/amendment-list.component.ts
@@ -9,7 +9,6 @@ import { MeetingComponentServiceCollectorService } from 'src/app/site/pages/meet
 
 import { MotionExportDialogService } from '../../../../components/motion-export-dialog/services/motion-export-dialog.service';
 import { MotionMultiselectService } from '../../../../components/motion-multiselect/services/motion-multiselect.service';
-import { DiffLinesInParagraph } from '../../../../definitions/index';
 import { LineNumberingService } from '../../../../modules/change-recommendations/services/line-numbering.service/line-numbering.service';
 import { AmendmentControllerService } from '../../../../services/common/amendment-controller.service/amendment-controller.service';
 import { MotionControllerService } from '../../../../services/common/motion-controller.service/motion-controller.service';

--- a/client/src/app/site/pages/meetings/pages/motions/pages/amendments/components/amendment-list/amendment-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/amendments/components/amendment-list/amendment-list.component.ts
@@ -135,7 +135,7 @@ export class AmendmentListComponent extends BaseMeetingListViewComponent<ViewMot
     }
 
     public getAmendmentDiffLines(amendment: ViewMotion): string {
-        const diffLines = amendment.getAmendmentParagraphLines() as DiffLinesInParagraph[];
+        const diffLines = amendment.getAmendmentParagraphLines();
         if (diffLines.length) {
             return diffLines.map(diffLine => this.linenumberingService.stripLineNumbers(diffLine.text)).join(`[...]`);
         } else {

--- a/client/src/app/site/pages/meetings/pages/motions/pages/categories/categories.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/categories/categories.module.ts
@@ -14,10 +14,10 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { MeetingsComponentCollectorModule } from 'src/app/site/pages/meetings/modules/meetings-component-collector';
 import { DirectivesModule } from 'src/app/ui/directives';
+import { ChoiceDialogModule } from 'src/app/ui/modules/choice-dialog';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
 import { SortingModule } from 'src/app/ui/modules/sorting';
 
-import { MotionCategoryCommonServiceModule } from '../../modules';
 import { CategoriesRoutingModule } from './categories-routing.module';
 import { CategoryDetailComponent } from './components/category-detail/category-detail.component';
 import { CategoryDetailSortComponent } from './components/category-detail-sort/category-detail-sort.component';
@@ -34,7 +34,6 @@ import { CategoryListSortComponent } from './components/category-list-sort/categ
     imports: [
         CommonModule,
         CategoriesRoutingModule,
-        MotionCategoryCommonServiceModule,
         MatDialogModule,
         MatFormFieldModule,
         MatMenuModule,
@@ -50,6 +49,7 @@ import { CategoryListSortComponent } from './components/category-list-sort/categ
         MeetingsComponentCollectorModule,
         HeadBarModule,
         DirectivesModule,
+        ChoiceDialogModule,
         OpenSlidesTranslationModule.forChild()
     ]
 })

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
@@ -35,7 +35,7 @@
                 *osPerms="[permission.motionCanManage, permission.motionCanManageMetadata]"
                 mat-button
                 (click)="onFollowRecButton()"
-                [disabled]="isFollowingProhibited()"
+                [disabled]="isFollowButtonDisabledObservable() | async"
             >
                 <os-icon-container icon="done_all">
                     <span>{{ 'Follow recommendations for all motions' | translate }}</span>
@@ -112,7 +112,7 @@
         </div>
 
         <!-- Remove from block column -->
-        <div *osScrollingTableCell="'remove'; row as motion" class="cell-slot fill">
+        <div *osScrollingTableCell="'remove'; row as motion; config: { width: 60 }" class="cell-slot fill">
             <button
                 type="button"
                 mat-icon-button
@@ -158,7 +158,7 @@
             *osPerms="[permission.motionCanManage, permission.motionCanManageMetadata]"
             mat-menu-item
             (click)="onFollowRecButton()"
-            [disabled]="isFollowingProhibited()"
+            [disabled]="isFollowButtonDisabledObservable() | async"
         >
             <mat-icon>done_all</mat-icon>
             <span>{{ 'Follow recommendations for all motions' | translate }}</span>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.ts
@@ -3,6 +3,7 @@ import { UntypedFormGroup } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
+import { map, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Permission } from 'src/app/domain/definitions/permission';
 import { MotionBlock } from 'src/app/domain/models/motions/motion-block';
@@ -145,12 +146,16 @@ export class MotionBlockDetailComponent extends BaseMeetingListViewComponent<Vie
      * Determine if following the recommendations should be possible.
      * Following a recommendation implies, that a valid recommendation exists.
      */
-    public isFollowingProhibited(): boolean {
-        if (this.listComponent?.source) {
-            return this.listComponent.source.every(motion => motion.isInFinalState() || !motion.recommendation_id);
-        } else {
-            return false;
-        }
+    public isFollowButtonDisabledObservable(): Observable<boolean> {
+        return this.filterService.getViewModelListObservable().pipe(
+            map(motions => {
+                if (motions.length) {
+                    return motions.every(motion => motion.isInFinalState() || !motion.recommendation_id);
+                } else {
+                    return false;
+                }
+            })
+        );
     }
 
     /**

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-edit-dialog/motion-block-edit-dialog.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-edit-dialog/motion-block-edit-dialog.module.ts
@@ -1,14 +1,14 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 
 import { MotionBlockEditDialogComponent } from './components/motion-block-edit-dialog/motion-block-edit-dialog.component';
-import { MatButtonModule } from '@angular/material/button';
-import { MatInputModule } from '@angular/material/input';
 
 @NgModule({
     declarations: [MotionBlockEditDialogComponent],

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-edit-dialog/motion-block-edit-dialog.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-edit-dialog/motion-block-edit-dialog.module.ts
@@ -7,12 +7,16 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 
 import { MotionBlockEditDialogComponent } from './components/motion-block-edit-dialog/motion-block-edit-dialog.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatInputModule } from '@angular/material/input';
 
 @NgModule({
     declarations: [MotionBlockEditDialogComponent],
     imports: [
         CommonModule,
         ReactiveFormsModule,
+        MatButtonModule,
+        MatInputModule,
         MatCheckboxModule,
         MatDialogModule,
         MatFormFieldModule,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-list/motion-block-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-list/motion-block-list.component.html
@@ -44,7 +44,7 @@
     </div>
 
     <!-- Amount -->
-    <div *osScrollingTableCell="'amount'; row as block" class="cell-slot fill">
+    <div *osScrollingTableCell="'amount'; row as block; config: { width: 60 }" class="cell-slot fill">
         <span class="os-amount-chip" matTooltip="{{ 'Motions' | translate }}">{{ getMotionAmount(block) }}</span>
     </div>
 

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/motion-blocks.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/motion-blocks.module.ts
@@ -12,7 +12,6 @@ import { HeadBarModule } from 'src/app/ui/modules/head-bar';
 import { IconContainerModule } from 'src/app/ui/modules/icon-container/icon-container.module';
 
 import { AgendaItemCommonServiceModule } from '../../../agenda/services/agenda-item-common-service.module';
-import { MotionBlockCommonServiceModule } from '../../modules';
 import { MotionBlockCreateDialogModule } from './components/motion-block-create-dialog/motion-block-create-dialog.module';
 import { MotionBlockDetailComponent } from './components/motion-block-detail/motion-block-detail.component';
 import { MotionBlockEditDialogModule } from './components/motion-block-edit-dialog/motion-block-edit-dialog.module';
@@ -25,7 +24,6 @@ import { MotionBlockServiceModule } from './services/motion-block-service.module
     imports: [
         CommonModule,
         MotionBlocksRoutingModule,
-        MotionBlockCommonServiceModule,
         MotionBlockServiceModule,
         MotionBlockCreateDialogModule,
         MotionBlockEditDialogModule,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/services/motion-block-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/services/motion-block-service.module.ts
@@ -1,20 +1,6 @@
 import { NgModule } from '@angular/core';
 
-import {
-    MotionCommentCommonServiceModule,
-    MotionWorkflowCommonServiceModule,
-    TagCommonServiceModule
-} from '../../../modules';
-import { MotionCategoryCommonServiceModule } from '../../../modules/categories/motion-categorie-common-service.module';
-import { MotionBlockCommonServiceModule } from '../../../modules/motion-blocks/motion-block-common-service.module';
-
 @NgModule({
-    imports: [
-        MotionBlockCommonServiceModule,
-        MotionCategoryCommonServiceModule,
-        TagCommonServiceModule,
-        MotionWorkflowCommonServiceModule,
-        MotionCommentCommonServiceModule
-    ]
+    imports: []
 })
 export class MotionBlockServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-call-list/motion-call-list.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-call-list/motion-call-list.module.ts
@@ -9,7 +9,6 @@ import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
 import { SortingModule } from 'src/app/ui/modules/sorting';
 
-import { MotionCategoryCommonServiceModule, TagCommonServiceModule } from '../../modules';
 import { MotionsExportModule } from '../../services/export/motions-export.module';
 import { MotionCallListComponent } from './components/motion-call-list/motion-call-list.component';
 import { MotionCallListRoutingModule } from './motion-call-list-routing.module';
@@ -20,8 +19,6 @@ import { MotionCallListRoutingModule } from './motion-call-list-routing.module';
         CommonModule,
         MotionCallListRoutingModule,
         MotionsExportModule,
-        MotionCategoryCommonServiceModule,
-        TagCommonServiceModule,
         MatMenuModule,
         MatIconModule,
         MatCardModule,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-content/motion-content.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-content/motion-content.component.ts
@@ -41,6 +41,9 @@ interface MotionFormFields {
 
     // For agenda creations
     agenda_parent_id: Id;
+
+    // Motion
+    workflow_id: Id;
 }
 
 type MotionFormControlsConfig = { [key in keyof MotionFormFields]?: any } & { [key in keyof Motion]?: any };
@@ -330,9 +333,8 @@ export class MotionContentComponent extends BaseMotionDetailChildComponent {
         }
         if (this.isExisting) {
             const contentPatch: { [key: string]: any } = {};
-            const tmp: any = deepCopy(this.motion.motion);
             Object.keys(this.contentForm.controls).forEach(ctrl => {
-                contentPatch[ctrl] = tmp[ctrl];
+                contentPatch[ctrl] = this.motion[ctrl];
             });
 
             if (this.isParagraphBasedAmendment) {

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/motion-detail.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/motion-detail.module.ts
@@ -34,9 +34,7 @@ import { ParticipantSearchSelectorModule } from '../../../../modules/participant
 import { AgendaItemCommonServiceModule } from '../../../agenda/services/agenda-item-common-service.module';
 import { ParticipantCommonServiceModule } from '../../../participants/services/common/participant-common-service.module';
 import { MotionForwardDialogModule } from '../../components/motion-forward-dialog/motion-forward-dialog.module';
-import { PersonalNoteServiceModule } from '../../modules';
 import { MotionPollModule } from '../../modules/motion-poll';
-import { MotionSubmitterCommonServiceModule } from '../../modules/submitters/motion-submitter-common-service.module';
 import { MotionsExportModule } from '../../services/export/motions-export.module';
 import { MotionsListServiceModule } from '../../services/list/motions-list-service.module';
 import { AmendmentCreateWizardComponent } from './components/amendment-create-wizard/amendment-create-wizard.component';
@@ -124,8 +122,6 @@ import { MotionDetailServiceModule } from './services/motion-detail-service.modu
         ParticipantSearchSelectorModule,
 
         // Detail view
-        MotionSubmitterCommonServiceModule,
-        PersonalNoteServiceModule,
         ScrollingModule,
         MatBadgeModule,
 

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-import/services/motions-import-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-import/services/motions-import-service.module.ts
@@ -1,16 +1,9 @@
 import { NgModule } from '@angular/core';
 
 import { ParticipantCommonServiceModule } from '../../../../participants/services/common/participant-common-service.module';
-import { MotionBlockCommonServiceModule } from '../../../modules';
-import { MotionsCommonServiceModule } from '../../../services/common/motions-service.module';
 import { MotionsExportModule } from '../../../services/export/motions-export.module';
 
 @NgModule({
-    imports: [
-        MotionsCommonServiceModule,
-        MotionBlockCommonServiceModule,
-        ParticipantCommonServiceModule,
-        MotionsExportModule
-    ]
+    imports: [ParticipantCommonServiceModule, MotionsExportModule]
 })
 export class MotionsImportServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
@@ -237,7 +237,7 @@
         </div>
 
         <!-- Categories -->
-        <div *ngIf="perms.isAllowed('manage') || categories.length">
+        <div *ngIf="perms.isAllowed('manage') || hasCategories">
             <button mat-menu-item routerLink="categories">
                 <mat-icon>category</mat-icon>
                 <span>{{ 'Categories' | translate }}</span>
@@ -245,7 +245,7 @@
         </div>
 
         <!-- Motion blocks -->
-        <div *ngIf="perms.isAllowed('manage') || motionBlocks.length">
+        <div *ngIf="perms.isAllowed('manage') || hasMotionBlocks">
             <button mat-menu-item routerLink="blocks">
                 <mat-icon>widgets</mat-icon>
                 <span>{{ 'Motion blocks' | translate }}</span>
@@ -254,7 +254,7 @@
 
         <mat-divider
             *ngIf="
-                (categories.length || motionBlocks.length || hasAmendments() || perms.isAllowed('manage')) &&
+                (hasCategories || hasMotionBlocks || hasAmendments() || perms.isAllowed('manage')) &&
                 (perms.isAllowed('manage') || selectedView === 'list' || perms.isAllowed('can_manage_config'))
             "
         ></mat-divider>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/motion-list.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/motion-list.module.ts
@@ -19,7 +19,6 @@ import { PipesModule } from 'src/app/ui/pipes/pipes.module';
 import { MotionExportDialogModule } from '../../components/motion-export-dialog/motion-export-dialog.module';
 import { MotionForwardDialogModule } from '../../components/motion-forward-dialog/motion-forward-dialog.module';
 import { MotionMultiselectModule } from '../../components/motion-multiselect/motion-multiselect.module';
-import { MotionCategoryCommonServiceModule } from '../../modules/categories/motion-categorie-common-service.module';
 import { MotionsListServiceModule } from '../../services/list/motions-list-service.module';
 import { MotionListComponent } from './components/motion-list/motion-list.component';
 import { MotionListInfoDialogModule } from './modules/motion-list-info-dialog/motion-list-info-dialog.module';
@@ -34,7 +33,6 @@ import { MotionListRoutingModule } from './motion-list-routing.module';
         MotionListInfoDialogModule,
         MotionForwardDialogModule,
         MotionExportDialogModule,
-        MotionCategoryCommonServiceModule,
         MotionMultiselectModule,
         MatIconModule,
         MatCardModule,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/tags/tags.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/tags/tags.module.ts
@@ -10,7 +10,6 @@ import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
 import { ListModule } from 'src/app/ui/modules/list';
 
-import { TagCommonServiceModule } from '../../modules';
 import { TagListComponent } from './components/tag-list/tag-list.component';
 import { TagsRoutingModule } from './tags-routing.module';
 
@@ -19,7 +18,6 @@ import { TagsRoutingModule } from './tags-routing.module';
     imports: [
         CommonModule,
         TagsRoutingModule,
-        TagCommonServiceModule,
         MatIconModule,
         MatFormFieldModule,
         MatButtonModule,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/services/motion-workflow-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/services/motion-workflow-service.module.ts
@@ -1,8 +1,6 @@
 import { NgModule } from '@angular/core';
 
-import { MotionStateCommonServiceModule } from '../../../modules/states/motion-state-common-service.module';
-
 @NgModule({
-    imports: [MotionStateCommonServiceModule]
+    imports: []
 })
 export class MotionWorkflowServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/workflows.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/workflows.module.ts
@@ -17,7 +17,6 @@ import { MeetingsComponentCollectorModule } from 'src/app/site/pages/meetings/mo
 import { FileUploadModule } from 'src/app/ui/modules/file-upload';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
 
-import { MotionWorkflowCommonServiceModule } from '../../modules/workflows/motion-workflow-common-service.module';
 import { WorkflowDetailComponent } from './components/workflow-detail/workflow-detail.component';
 import { WorkflowImportComponent } from './components/workflow-import/workflow-import.component';
 import { WorkflowListComponent } from './components/workflow-list/workflow-list.component';
@@ -29,7 +28,6 @@ import { WorkflowsRoutingModule } from './workflows-routing.module';
     imports: [
         CommonModule,
         WorkflowsRoutingModule,
-        MotionWorkflowCommonServiceModule,
         MotionWorkflowServiceModule,
         MeetingsComponentCollectorModule,
         FileUploadModule,

--- a/client/src/app/site/pages/meetings/pages/motions/services/common/motion-controller.service/motion-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/common/motion-controller.service/motion-controller.service.ts
@@ -39,7 +39,10 @@ export class MotionControllerService extends BaseMeetingControllerService<ViewMo
         return this.repo.create(...motions);
     }
 
-    public update(update?: NullablePartial<Motion>, ...motions: ViewMotion[]): Action<void> {
+    public update(
+        update?: NullablePartial<Motion & { workflow_id: Id }>,
+        ...motions: (Motion & { workflow_id: Id })[]
+    ): Action<void> {
         if (update) {
             return this.repo.update(update, ...motions);
         }

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motions-export.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motions-export.module.ts
@@ -2,14 +2,7 @@ import { NgModule } from '@angular/core';
 import { MotionPollModule } from 'src/app/site/pages/meetings/pages/motions/modules/motion-poll';
 import { MeetingPdfExportModule } from 'src/app/site/pages/meetings/services/export';
 
-import { MotionCommentCommonServiceModule, MotionStatuteParagraphServiceModule } from '../../modules';
-
 @NgModule({
-    imports: [
-        MotionCommentCommonServiceModule,
-        MotionStatuteParagraphServiceModule,
-        MotionPollModule,
-        MeetingPdfExportModule
-    ]
+    imports: [MotionPollModule, MeetingPdfExportModule]
 })
 export class MotionsExportModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/services/list/motions-list-service.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/list/motions-list-service.module.ts
@@ -1,20 +1,6 @@
 import { NgModule } from '@angular/core';
 
-import {
-    MotionBlockCommonServiceModule,
-    MotionCommentCommonServiceModule,
-    MotionWorkflowCommonServiceModule,
-    TagCommonServiceModule
-} from '../../modules';
-import { MotionCategoryCommonServiceModule } from '../../modules/categories/motion-categorie-common-service.module';
-
 @NgModule({
-    imports: [
-        MotionBlockCommonServiceModule,
-        MotionCategoryCommonServiceModule,
-        MotionWorkflowCommonServiceModule,
-        MotionCommentCommonServiceModule,
-        TagCommonServiceModule
-    ]
+    imports: []
 })
 export class MotionsListServiceModule {}

--- a/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
@@ -50,12 +50,12 @@ export class ViewMotion extends BaseProjectableViewModel<Motion> {
         return this._model;
     }
 
-    public get workflow_id(): Id {
-        return this.state!.workflow_id;
+    public get workflow_id(): Id | null {
+        return this.state?.workflow_id || null;
     }
 
-    public get workflow(): ViewMotionWorkflow {
-        return this.state!.workflow;
+    public get workflow(): ViewMotionWorkflow | null {
+        return this.state?.workflow || null;
     }
 
     public get submittersAsUsers(): ViewUser[] {
@@ -225,7 +225,7 @@ export class ViewMotion extends BaseProjectableViewModel<Motion> {
     /**
      * @warning This is injected. Do not use it!
      */
-    public getAmendmentParagraphLines: (includeUnchanged?: boolean) => DiffLinesInParagraph[] | null = () => null;
+    public getAmendmentParagraphLines: (includeUnchanged?: boolean) => DiffLinesInParagraph[] = () => [];
     public getParagraphTitleByParagraph!: (paragraph: DiffLinesInParagraph) => string | null;
     // This is set by the repository
     public getNumberOrTitle!: () => string;

--- a/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
@@ -183,29 +183,6 @@ export class ParticipantControllerService extends BaseMeetingControllerService<V
         return responseMessage;
     }
 
-    public bulkAddGroupsToUsers(groupIds: Ids, ...users: ViewUser[]): Promise<void> {
-        this.repo.preventAlterationOnDemoUsers(users);
-        const patchFn = (user: ViewUser) => {
-            groupIds = groupIds.concat(user.group_ids());
-            return {
-                id: user.id,
-                group_$_ids: {
-                    [this.activeMeetingId!]: groupIds.filter((groupId, index, self) => self.indexOf(groupId) === index)
-                }
-            };
-        };
-        return this.repo.update(patchFn, ...users).resolve() as Promise<void>;
-    }
-
-    public bulkRemoveGroupsFromUsers(groupIds: Ids, ...users: ViewUser[]): Promise<void> {
-        this.repo.preventAlterationOnDemoUsers(users);
-        const patchFn = (user: ViewUser) => ({
-            id: user.id,
-            group_$_ids: { [this.activeMeetingId!]: user.group_ids().filter(groupId => !groupIds.includes(groupId)) }
-        });
-        return this.repo.update(patchFn, ...users).resolve() as Promise<void>;
-    }
-
     public setPresent(isPresent: boolean, ...users: ViewUser[]): Action<void> {
         this.repo.preventAlterationOnDemoUsers(users);
         const payload: any[] = users.map(user => ({

--- a/client/src/app/ui/modules/search-selector/components/repo-search-selector/repo-search-selector.component.ts
+++ b/client/src/app/ui/modules/search-selector/components/repo-search-selector/repo-search-selector.component.ts
@@ -48,9 +48,11 @@ export class RepoSearchSelectorComponent extends BaseSearchSelectorComponent imp
         private meetingSettingService: MeetingSettingsService
     ) {
         super(formBuilder, focusMonitor, element, ngControl);
+        this.shouldPropagateOnRegistering = false;
     }
 
     public override ngOnInit(): void {
+        super.ngOnInit();
         this.init();
     }
 


### PR DESCRIPTION
- Removes a NullInjectorError for the ChoiceService when sorting motions within a category
- A delegate could see the menu entry for motion blocks if any are available
- The number of assigned motions to a motion block is shown in the list of motion blocks
- The button "Follow the recommendation for every motion" works
- When editing a motion its correct workflow is shown
- When removing groups from a participant by using the multiselection, the participant will still stay in their meeting (Fixes #1271)

Fixes #1255 
Fixes #1269