### PR TITLE
Stopped HttpService from opening snackbars with undefined error messages

### DIFF
--- a/client/src/app/gateways/http.service.ts
+++ b/client/src/app/gateways/http.service.ts
@@ -62,7 +62,9 @@ export class HttpService {
             if (error instanceof HttpErrorResponse) {
                 const snackBar = OpenSlidesInjector.get(MatSnackBar);
                 const translate = OpenSlidesInjector.get(TranslateService);
-                snackBar.open(`${translate.instant(`Error`)}: ${error.error.message}`, `Ok`);
+                if (!!error.error.message) {
+                    snackBar.open(`${translate.instant(`Error`)}: ${error.error.message}`, `Ok`);
+                }
                 return null;
             } else {
                 throw new ProcessError(error);


### PR DESCRIPTION
A snackbar "Error: undefined" was being opened when requests returned without a proper error message.

For example:
Shut the server down while the client is still running, then do something that sends a request to the server

May be related to #1259 