### PR TITLE
Implemented autoupdate decompression in the client

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,6 +34,7 @@
         "core-js": "^3.21.1",
         "exceljs": "^4.3.0",
         "file-saver": "^2.0.5",
+        "fzstd": "^0.0.4",
         "jszip": "^3.7.1",
         "lz4js": "^0.2.0",
         "material-design-icons-iconfont": "^6.4.1",
@@ -9300,6 +9301,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fzstd": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.0.4.tgz",
+      "integrity": "sha512-GNZEyoB2+mGNGhBBdRiPF1WE3xRK5VTOXFNiM8YqUmo5Lo/XeyvLtSSrWLN3NS7JRnwolabqsmE970MiqI69Ug=="
     },
     "node_modules/gauge": {
       "version": "4.0.4",
@@ -24541,6 +24547,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+    },
+    "fzstd": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.0.4.tgz",
+      "integrity": "sha512-GNZEyoB2+mGNGhBBdRiPF1WE3xRK5VTOXFNiM8YqUmo5Lo/XeyvLtSSrWLN3NS7JRnwolabqsmE970MiqI69Ug=="
     },
     "gauge": {
       "version": "4.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
     "core-js": "^3.21.1",
     "exceljs": "^4.3.0",
     "file-saver": "^2.0.5",
+    "fzstd": "^0.0.4",
     "jszip": "^3.7.1",
     "lz4js": "^0.2.0",
     "material-design-icons-iconfont": "^6.4.1",

--- a/client/src/app/gateways/http-stream/http-stream.ts
+++ b/client/src/app/gateways/http-stream/http-stream.ts
@@ -1,4 +1,5 @@
 import { HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpHeaderResponse } from '@angular/common/http';
+import * as fzstd from 'fzstd';
 import { firstValueFrom, Observable, Subscription } from 'rxjs';
 
 import { EndpointConfiguration } from './endpoint-configuration';
@@ -104,7 +105,8 @@ class StreamMessageParser<T> {
     public constructor(
         private readonly onMessage: (content: T) => void,
         private readonly onError: (type: ErrorType, errorContent: string, reason: string) => void,
-        private readonly description: string
+        private readonly description: string,
+        private url?: string
     ) {}
 
     public read(event: HttpEvent<string>): void {
@@ -146,7 +148,8 @@ class StreamMessageParser<T> {
     }
 
     private handleContent(content: string, errorReason: string = `Reported by server`): void {
-        const parsedContent = this.parse(content);
+        const decompressedContent = this.decompressContent(content);
+        const parsedContent = this.parse(decompressedContent);
         if (parsedContent instanceof ErrorDescription) {
             this.propagateError(content, parsedContent.reason, parsedContent.type);
         } else if (isCommunicationError(parsedContent) || isCommunicationErrorWrapper(parsedContent)) {
@@ -154,6 +157,21 @@ class StreamMessageParser<T> {
         } else {
             this.propagateMessage(parsedContent);
         }
+    }
+
+    private decompressContent(content: string): string {
+        // only try to decode if the message came from the autoupdate service
+        if (!!this.url && this.url.split(`/`)[1] === `system` && /autoupdate/.test(this.url.split(`/`)[2])) {
+            try {
+                const atobbed = Uint8Array.from(atob(content), c => c.charCodeAt(0));
+                const decompressedArray = fzstd.decompress(atobbed);
+                const decompressedString = new TextDecoder().decode(decompressedArray);
+                return decompressedString;
+            } catch (e) {
+                console.warn(`Decompress failed`, e.message);
+            }
+        }
+        return content;
     }
 
     private parse(content: string): T | ErrorDescription {
@@ -228,7 +246,7 @@ export class HttpStream<T> {
         this._shouldReconnectOnFailure = config.shouldReconnectOnFailure ?? false;
         this._reconnectTimeout = config.reconnectTimeout ?? 2000;
 
-        this.buildMessageParser();
+        this.buildMessageParser(this.endpoint.url);
 
         if (config.shouldStartImmediately) {
             this.open();
@@ -347,11 +365,12 @@ export class HttpStream<T> {
         }, Math.abs(timeout));
     }
 
-    private buildMessageParser(): void {
+    private buildMessageParser(url: string): void {
         this._parser = new StreamMessageParser<T>(
             content => this.handleParsedContent(content),
             (type, errorContent, reason) => this.handleCommunicationError(type, errorContent, reason),
-            `${this.id}`
+            `${this.id}`,
+            url
         );
     }
 

--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -55,6 +55,10 @@ interface AutoupdateConnectConfig {
      * Selects the last n updates to the requested fields. `true` is equivalent to `n = 1`.
      */
     single?: true | number;
+    /**
+     * Determines if the autoupdate service should compress the data, defaults to 1 (=true)
+     */
+    compress?: number;
 }
 
 interface AutoupdateSubscriptionMap {
@@ -94,6 +98,7 @@ export class AutoupdateService {
         private httpStreamService: HttpStreamService,
         private viewmodelStoreUpdate: ViewModelStoreUpdateService
     ) {
+        this.setAutoupdateConfig(null);
         this.httpEndpointService.registerEndpoint(
             AUTOUPDATE_DEFAULT_ENDPOINT,
             new AutoupdateEndpoint(`/system/autoupdate`)
@@ -116,7 +121,9 @@ export class AutoupdateService {
     }
 
     public setAutoupdateConfig(config: AutoupdateConnectConfig | null): void {
-        this._currentQueryParams = config as QueryParams;
+        this._currentQueryParams = (
+            !!config ? (typeof config.compress === `number` ? config : { ...config, compress: 1 }) : { compress: 1 }
+        ) as QueryParams;
     }
 
     /**


### PR DESCRIPTION
The autoupdate service recently got a feature where it could compress the data it sends out (see OpenSlides/openslides-autoupdate-service#507 ), this pull request updates the client to utilize that feature.