### PR TITLE
Fix strange numbers in the assignment poll detail view

### DIFF
--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-detail/assignment-poll-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-detail/assignment-poll-detail.component.html
@@ -31,13 +31,8 @@
         </div>
 
         <div class="assignment-result-wrapper" *ngIf="poll">
-            <!-- Result Table -->
+            <!-- Result -->
             <os-assignment-poll-detail-content [poll]="poll"></os-assignment-poll-detail-content>
-
-            <!-- Result Chart -->
-            <div class="chart-wrapper" *ngIf="showResults && poll.stateHasVotes">
-                <os-chart class="assignment-result-chart" [labels]="candidatesLabels" [data]="chartData"></os-chart>
-            </div>
 
             <mat-tab-group *ngIf="showResults && poll.stateHasVotes && poll.isEVoting"  (selectedTabChange)="onTabChange()">
                 <mat-tab label="{{ 'Single votes' | translate }}">


### PR DESCRIPTION
 * I am not sure what this HTML section is needed for. The Result Chart is
   created in os-assignment-poll-detail-content. I think this is a leftover
   fragment. But maybe someone knows more about it.
* fix #1297