### PR TITLE
Fixed motion poll detail view tables

### DIFF
--- a/client/src/app/site/pages/meetings/modules/poll/components/entitled-users-table/entitled-users-table.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/entitled-users-table/entitled-users-table.component.html
@@ -1,29 +1,28 @@
 <div *osPerms="permission.userCanSee">
-    <os-list
-        [listObservable]="entitledUsersObservable"
-        [filterProps]="filterPropsEntitledUsersTable"
-        [fullScreen]="false"
-    >
-        <!-- Content -->
-        <div *osScrollingTableCell="'user_id'; row as entry">
-            <div *osScrollingTableCellLabel>{{ 'Participant' | translate }}</div>
-            <span *ngIf="entry.user">{{ entry.user.getFullName() }}</span>
-            <i *ngIf="!entry.user">{{ 'Anonymous' | translate }}</i>
-        </div>
-        <div *osScrollingTableCell="'voted'; row as entry">
-            <div *osScrollingTableCellLabel>{{ 'Voted' | translate }}</div>
-            <mat-icon *ngIf="entry.voted">check_box</mat-icon>
-        </div>
-        <div *osScrollingTableCell="'delegation'; row as entry">
-            <div *osScrollingTableCellLabel>{{ 'Delegated to' | translate }}</div>
-            <div *ngIf="entry.vote_delegated_to_id">
-                <span class="repr-prefix">represented by</span>
-                &nbsp;
-                <span *ngIf="entry.vote_delegated_to">{{ entry.vote_delegated_to.getFullName() }}</span>
-                <i *ngIf="!entry.vote_delegated_to">{{ 'Anonymous' | translate }}</i>
+    <div *ngIf="isViewingThis">
+        <os-list [listObservable]="entitledUsersObservable" [filterProps]="filterPropsEntitledUsersTable"
+            [fullScreen]="false">
+            <!-- Content -->
+            <div *osScrollingTableCell="'user_id'; row as entry">
+                <div *osScrollingTableCellLabel>{{ 'Participant' | translate }}</div>
+                <span *ngIf="entry.user">{{ entry.user.getFullName() }}</span>
+                <i *ngIf="!entry.user">{{ 'Anonymous' | translate }}</i>
             </div>
-        </div>
-    </os-list>
+            <div *osScrollingTableCell="'voted'; row as entry">
+                <div *osScrollingTableCellLabel>{{ 'Voted' | translate }}</div>
+                <mat-icon *ngIf="entry.voted">check_box</mat-icon>
+            </div>
+            <div *osScrollingTableCell="'delegation'; row as entry">
+                <div *osScrollingTableCellLabel>{{ 'Delegated to' | translate }}</div>
+                <div *ngIf="entry.vote_delegated_to_id">
+                    <span class="repr-prefix">{{ 'represented by' | translate }}</span>
+                    &nbsp;
+                    <span *ngIf="entry.vote_delegated_to">{{ entry.vote_delegated_to.getFullName() }}</span>
+                    <i *ngIf="!entry.vote_delegated_to">{{ 'Anonymous' | translate }}</i>
+                </div>
+            </div>
+        </os-list>
+    </div>
 </div>
 <div class="no-can-see-users" *osPerms="permission.userCanSee; complement: true">
     <i>{{ 'You are not allowed to see all entitled users.' | translate }}</i>

--- a/client/src/app/site/pages/meetings/modules/poll/components/entitled-users-table/entitled-users-table.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/entitled-users-table/entitled-users-table.component.ts
@@ -12,11 +12,23 @@ import { EntitledUsersTableEntry } from '../../definitions/entitled-users-table-
     encapsulation: ViewEncapsulation.None
 })
 export class EntitledUsersTableComponent {
+    private _isViewingThis: boolean = true;
+
     @Input()
     public entitledUsersObservable!: Observable<EntitledUsersTableEntry[]>;
 
     @Input()
     public listStorageKey!: string;
+
+    @Input()
+    public set isViewingThis(value: boolean) {
+        console.log(`IS VIEWING entitled users: `, value);
+        this._isViewingThis = value;
+    }
+
+    public get isViewingThis(): boolean {
+        return this._isViewingThis;
+    }
 
     public readonly permission = Permission;
 

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-detail/motion-poll-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-detail/motion-poll-detail.component.html
@@ -34,9 +34,9 @@
         <os-motion-poll-detail-content [poll]="poll"></os-motion-poll-detail-content>
 
         <!-- Named table: only show if votes are present -->
-        <mat-tab-group *ngIf="showResults && poll.stateHasVotes && poll.isEVoting">
+        <mat-tab-group *ngIf="showResults && poll.stateHasVotes && poll.isEVoting" (selectedTabChange)="onTabChange()">
             <mat-tab label="{{ 'Single votes' | translate }}">
-                <div class="named-result-table">
+                <div class="named-result-table" *ngIf="isViewingVoteslist">
                     <os-list
                         class="single-votes-table"
                         [listObservable]="votesDataObservable"
@@ -76,8 +76,8 @@
                         </div>
                         <div *osScrollingTableCell="'vote'; row as vote" class="vote-cell">
                             <div *osScrollingTableCellLabel>{{ 'Vote' | translate }}</div>
-                            <div class="vote-cell-icon-container" [ngClass]="voteOptionStyle[vote.value].css">
-                                <mat-icon>{{ voteOptionStyle[vote.value].icon }}</mat-icon>
+                            <div class="vote-cell-icon-container" [ngClass]="getVoteCSS(vote.value)">
+                                <mat-icon>{{ getVoteIcon(vote.value) }}</mat-icon>
                             </div>
                             <div>{{ vote.valueVerbose | translate }}</div>
                         </div>
@@ -85,7 +85,7 @@
                 </div>
             </mat-tab>
             <mat-tab label="{{ 'Entitled users' | translate }}">
-                <os-entitled-users-table [entitledUsersObservable]="entitledUsersObservable"></os-entitled-users-table>
+                <os-entitled-users-table [entitledUsersObservable]="entitledUsersObservable" [isViewingThis]="!isViewingVoteslist"></os-entitled-users-table>
             </mat-tab>
         </mat-tab-group>
 

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-detail/motion-poll-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-detail/motion-poll-detail.component.ts
@@ -32,6 +32,12 @@ export class MotionPollDetailComponent extends BasePollDetailComponent<ViewMotio
         return this.hasPerms() || this.poll.isPublished;
     }
 
+    public get isViewingVoteslist(): boolean {
+        return this._isViewingVoteslist;
+    }
+
+    private _isViewingVoteslist = true;
+
     public constructor(
         componentServiceCollector: MeetingComponentServiceCollectorService,
         protected override translate: TranslateService,
@@ -61,6 +67,14 @@ export class MotionPollDetailComponent extends BasePollDetailComponent<ViewMotio
         );
     }
 
+    public getVoteIcon(voteValue: string): string {
+        return this.voteOptionStyle[voteValue]?.icon;
+    }
+
+    public getVoteCSS(voteValue: string): string {
+        return this.voteOptionStyle[voteValue]?.css;
+    }
+
     protected createVotesData(): BaseVoteData[] {
         return this.poll?.options[0]?.votes;
     }
@@ -75,5 +89,9 @@ export class MotionPollDetailComponent extends BasePollDetailComponent<ViewMotio
 
     protected hasPerms(): boolean {
         return this.operator.hasPerms(Permission.motionCanManagePolls);
+    }
+
+    public onTabChange(): void {
+        this._isViewingVoteslist = !this.isViewingVoteslist;
     }
 }

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -61,6 +61,7 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
             source.subscribe(items => {
                 this._source = items;
                 this.buildDataTable();
+                console.log(`NEW DATA: \n`, items);
             })
         );
     }
@@ -130,7 +131,12 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
 
     public ngOnInit(): void {
         this.manageService.currentScrollingTableComponent = this;
-        this.subscriptions.push(this.manageService.cellDefinitionsObservable.subscribe(() => this.cd.markForCheck()));
+        this.subscriptions.push(
+            this.manageService.cellDefinitionsObservable.subscribe(def => {
+                console.log(`NEW CELL DEFINITIONS: `, def);
+                this.cd.markForCheck();
+            })
+        );
     }
 
     public override ngOnDestroy(): void {

--- a/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell-is-hidden.directive.ts
+++ b/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell-is-hidden.directive.ts
@@ -1,0 +1,22 @@
+import { CdkPortal } from '@angular/cdk/portal';
+import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+
+import { ScrollingTableCellDirective } from './scrolling-table-cell.directive';
+
+@Directive({
+    selector: `[osScrollingTableCellIsHidden]`
+})
+export class ScrollingTableCellIsHiddenDirective extends CdkPortal {
+    @Input()
+    public set osScrollingTableCellIsHidden(property: boolean) {
+        this.host.isHidden = property; // Propagate the template to the host
+    }
+
+    public constructor(
+        template: TemplateRef<HTMLElement>,
+        viewContainer: ViewContainerRef,
+        private host: ScrollingTableCellDirective
+    ) {
+        super(template, viewContainer);
+    }
+}

--- a/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
+++ b/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
@@ -40,6 +40,10 @@ export class ScrollingTableCellDirective implements OnInit, ScrollingTableCellDe
         setTimeout(() => (this._labelTemplate = template));
     }
 
+    public set isHidden(template: any) {
+        setTimeout(() => (this._isHidden = template));
+    }
+
     public get labelTemplate(): any {
         return this._labelTemplate;
     }

--- a/client/src/app/ui/modules/scrolling-table/scrolling-table.module.ts
+++ b/client/src/app/ui/modules/scrolling-table/scrolling-table.module.ts
@@ -8,6 +8,7 @@ import { MatTableModule } from '@angular/material/table';
 
 import { ScrollingTableComponent } from './components/scrolling-table/scrolling-table.component';
 import { ScrollingTableCellDirective } from './directives/scrolling-table-cell.directive';
+import { ScrollingTableCellIsHiddenDirective } from './directives/scrolling-table-cell-is-hidden.directive';
 import { ScrollingTableCellLabelDirective } from './directives/scrolling-table-cell-label.directive';
 import { ScrollingTableNoDataDirective } from './directives/scrolling-table-no-data.directive';
 import { ScrollingTableServiceModule } from './services/scrolling-table-service.module';
@@ -16,6 +17,7 @@ const DECLARATIONS = [
     ScrollingTableComponent,
     ScrollingTableCellDirective,
     ScrollingTableCellLabelDirective,
+    ScrollingTableCellIsHiddenDirective,
     ScrollingTableNoDataDirective
 ];
 


### PR DESCRIPTION
The typeerror is gone (Closes #1296 )
The Lists look alright again, but there is this one new bug, where switching over to the entitled users list-tab will permanently empty every row of the voteslist-tab.

This is because _somehow_ the scrollingtablecomponent doesn't recognize the new tablecells.

TODO: Fix that