### PR TITLE
Fixed scrolling table checkboxes

### DIFF
--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
@@ -34,7 +34,7 @@
                     (click)="onRowClick($event, item)"
                 >
                     <div *ngIf="isSelectionMode" class="selection-cell scrolling-table-cell flex-vertical-center">
-                        <mat-checkbox [checked]="isSelected(item)" (change)="onChange($event, item)"></mat-checkbox>
+                        <mat-checkbox [class.mat-checkbox-disabled]="false" [checked]="isSelected(item)" disabled></mat-checkbox>
                     </div>
                     <ng-container *ngFor="let definition of definitions">
                         <div

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -223,7 +223,6 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
         const rows = Object.values(this._dataSourceMap)
             .filter(provider => provider.isSelected)
             .map(provider => provider.row);
-        this.buildDataTable();
         this.selectionChanged.emit({ affectedRows, selected: rows.length, selectedRows: rows });
     }
 

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -1,7 +1,6 @@
 import { TemplatePortal } from '@angular/cdk/portal';
 import { AfterViewInit, Component, Input, OnInit, Output } from '@angular/core';
 import { ChangeDetectorRef, EventEmitter, HostListener, OnDestroy } from '@angular/core';
-import { MatCheckboxChange } from '@angular/material/checkbox';
 import { BehaviorSubject, map, Observable } from 'rxjs';
 import { Identifiable } from 'src/app/domain/interfaces';
 import { Mapable, Mutable } from 'src/app/infrastructure/utils';
@@ -160,10 +159,6 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
         this.changeSelection(rows, true);
     }
 
-    public onChange(event: MatCheckboxChange, row: T): void {
-        this.changeSelection([row], event.checked);
-    }
-
     public onRowClick(event: Event, row: T): void {
         event.stopPropagation();
         if (this.isSelectionMode) {
@@ -228,6 +223,7 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
         const rows = Object.values(this._dataSourceMap)
             .filter(provider => provider.isSelected)
             .map(provider => provider.row);
+        this.buildDataTable();
         this.selectionChanged.emit({ affectedRows, selected: rows.length, selectedRows: rows });
     }
 


### PR DESCRIPTION
Closes #1304

The checkboxes are now secretly disabled and their value is set programmatically when the virtual scrolling container encasing them is clicked.