### PR TITLE
Removed url_name from client

### DIFF
--- a/client/src/app/domain/models/meetings/meeting.ts
+++ b/client/src/app/domain/models/meetings/meeting.ts
@@ -35,7 +35,6 @@ export class Settings {
 
     // TODO: Move to meeting. these are not settings anymore, if the meeting-detail-view
     // in the committee-list-view is finished.
-    public url_name!: string; // For unique urls.
     public is_template!: boolean; // Unique within a committee
     public enable_anonymous!: boolean;
 

--- a/client/src/app/gateways/repositories/meeting-repository.service.ts
+++ b/client/src/app/gateways/repositories/meeting-repository.service.ts
@@ -61,7 +61,6 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
             `user_ids`,
             `description`,
             `location`,
-            `url_name`,
             `organization_tag_ids`
         ]);
         const listFields: TypedFieldset<Meeting> = sharedFields.concat([


### PR DESCRIPTION
It has been removed from the backend and requests including this value were causing autoupdate errors on older production setups that had demo meetings