### PR TITLE
Repaired participant list behavior when enabling vote weight

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
@@ -70,10 +70,13 @@ export class ParticipantListComponent extends BaseMeetingListViewComponent<ViewU
     }
 
     public get totalVoteWeight(): number {
-        const votes = this.listComponent.source?.reduce(
-            (previous, current) => previous + (current.vote_weight() || 0),
-            0
-        );
+        let votes;
+        if (this.listComponent) {
+            votes = this.listComponent.source?.reduce(
+                (previous, current) => previous + (current.vote_weight() || 0),
+                0
+            );
+        }
         return votes ?? 0;
     }
 


### PR DESCRIPTION
Setting voteweight to enabled previously destroyed the participant list with an error message claiming listComponent to be undefined. This pull addresses that problem.