### PR TITLE
Fix multiple errors with the mediafile list

### DIFF
--- a/client/src/app/site/pages/meetings/services/meeting-collection-mapper.service.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-collection-mapper.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { BaseMeetingRelatedRepository } from 'src/app/gateways/repositories/base-meeting-related-repository';
+import { MediafileRepositoryService } from 'src/app/gateways/repositories/mediafiles/mediafile-repository.service';
 import {
     CollectionMappedTypes,
     CollectionMapperService,
@@ -29,7 +30,7 @@ export class MeetingCollectionMapperService extends CollectionMapperService impl
         if (!repo) {
             return false;
         }
-        return repo instanceof BaseMeetingRelatedRepository;
+        return repo instanceof BaseMeetingRelatedRepository || repo instanceof MediafileRepositoryService;
     }
 
     private registerMeetingRepository(mapping: CollectionMappedTypes<any, any>): void {


### PR DESCRIPTION
fixes #1354 
fixes #1192

These were actually two different errors: The visibility of mediafiles belonging to another meeting stemmed from a missing deletion of files from the local cache, while the corrupt view of the mediafile list came from a missing appliance of an autoupdate.