### PR TITLE
Fix logout on auth error

### DIFF
--- a/client/src/app/gateways/http-stream/http-stream.service.ts
+++ b/client/src/app/gateways/http-stream/http-stream.service.ts
@@ -93,7 +93,7 @@ export class HttpStreamService {
     }
 
     private shouldReconnect({ error }: ShouldReconnectContext): boolean | Promise<boolean> {
-        if (error.error.type === PossibleStreamError.AUTH) {
+        if (error.error?.type === PossibleStreamError.AUTH) {
             this.authService.logout();
             return false;
         }

--- a/client/src/app/gateways/http-stream/http-stream.service.ts
+++ b/client/src/app/gateways/http-stream/http-stream.service.ts
@@ -93,7 +93,7 @@ export class HttpStreamService {
     }
 
     private shouldReconnect({ error }: ShouldReconnectContext): boolean | Promise<boolean> {
-        if (error.type === PossibleStreamError.AUTH) {
+        if (error.error.type === PossibleStreamError.AUTH) {
             this.authService.logout();
             return false;
         }


### PR DESCRIPTION
Minor fix which forced retries on errors because the wrong property was accessed. Test in conjunction with https://github.com/OpenSlides/openslides-auth-service/pull/130 for best results.