### PR TITLE
Fix & beautify workflow detail view

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-detail/workflow-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-detail/workflow-detail.component.html
@@ -25,8 +25,7 @@
     <!-- Detail -->
     <div *ngIf="workflow">
         <div class="title-line">
-            <span>{{ 'First state' | translate }}</span>
-            :
+            <span>{{ 'First state' | translate }}</span>:
             <span *ngIf="workflow.first_state">{{ workflow.first_state.name | translate }}</span>
         </div>
 
@@ -123,7 +122,7 @@
                     </td>
                 </ng-container>
 
-                <tr mat-header-row *matHeaderRowDef="headerRowDef"></tr>
+                <tr mat-header-row *matHeaderRowDef="headerRowDef; sticky: true"></tr>
                 <tr mat-row *matRowDef="let row; columns: headerRowDef"></tr>
             </table>
         </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-detail/workflow-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-detail/workflow-detail.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, TemplateRef, ViewChild } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
@@ -67,8 +67,7 @@ interface RestrictionShape {
 @Component({
     selector: `os-workflow-detail`,
     templateUrl: `./workflow-detail.component.html`,
-    styleUrls: [`./workflow-detail.component.scss`],
-    changeDetection: ChangeDetectionStrategy.OnPush
+    styleUrls: [`./workflow-detail.component.scss`]
 })
 export class WorkflowDetailComponent extends BaseMeetingComponent {
     public readonly COLLECTION = ViewMotionWorkflow.COLLECTION;
@@ -121,8 +120,9 @@ export class WorkflowDetailComponent extends BaseMeetingComponent {
 
     private set workflow(workflow: ViewMotionWorkflow) {
         this._workflow = workflow;
+        console.log(`Workflow set:`, workflow);
         this.updateRowDef();
-        this.updateView();
+        this.cd.markForCheck();
     }
 
     private _workflow!: ViewMotionWorkflow;
@@ -309,7 +309,7 @@ export class WorkflowDetailComponent extends BaseMeetingComponent {
      */
     public getRestrictionLabel(restriction: string): string {
         const entry = this.restrictions.find(r => r.key === restriction);
-        return entry ? entry.label : ``;
+        return entry?.label ?? ``;
     }
 
     /**
@@ -370,8 +370,6 @@ export class WorkflowDetailComponent extends BaseMeetingComponent {
      */
     public getTableDataSource(): MatTableDataSource<StatePerm> {
         return new MatTableDataSource<StatePerm>(this._statePermissionsList);
-        // dataSource.data = this._statePermissionsList;
-        // return dataSource;
     }
 
     /**
@@ -390,10 +388,6 @@ export class WorkflowDetailComponent extends BaseMeetingComponent {
         // reset the rowDef list first
         this.headerRowDef = [`perm`];
         if (this.workflow) {
-            /**
-             * FIXME:
-             * relations work. Why is states of length 0?
-             */
             this.workflowStates.forEach(state => {
                 this.headerRowDef.push(this.getColumnDef(state));
             });
@@ -429,11 +423,7 @@ export class WorkflowDetailComponent extends BaseMeetingComponent {
     }
 
     private handleRequest(request: Promise<any>): void {
-        request.then(() => this.updateView(), this.raiseError);
-    }
-
-    private updateView(): void {
-        this.cd.detectChanges();
+        request.catch(this.raiseError);
     }
 
     private loadWorkflow(): void {
@@ -441,7 +431,11 @@ export class WorkflowDetailComponent extends BaseMeetingComponent {
             this.workflowRepo.getViewModelObservable(this._workflowId).subscribe(newWorkflow => {
                 if (newWorkflow) {
                     this.workflow = newWorkflow;
-                    this.cd.markForCheck();
+                }
+            }),
+            this.stateRepo.getViewModelListObservable().subscribe(states => {
+                if (states) {
+                    this.updateRowDef();
                 }
             })
         );

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-detail/workflow-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-detail/workflow-detail.component.ts
@@ -120,7 +120,6 @@ export class WorkflowDetailComponent extends BaseMeetingComponent {
 
     private set workflow(workflow: ViewMotionWorkflow) {
         this._workflow = workflow;
-        console.log(`Workflow set:`, workflow);
         this.updateRowDef();
         this.cd.markForCheck();
     }

--- a/client/src/assets/styles/tables.scss
+++ b/client/src/assets/styles/tables.scss
@@ -76,10 +76,4 @@
     .mat-cell > * {
         z-index: 2;
     }
-
-    // important is necessary, since the "sticky" attribute does not alter the real `.mat-table-sticky-class`
-    // but rather "patches" the DOM tree.
-    .mat-table-sticky {
-        z-index: 3 !important;
-    }
 }


### PR DESCRIPTION
fixes #1389 

I switched the change detection back to the default one, because this seemed to work way better. I don't know what the initial reasoning was for the `OnPush` method.

I also beautified the view by removing the space before the colon and fixing the sticky rows/columns. I removed a section from `tables.scss` for that, which might also influence other tables - I didn't find any problems, but it would be good to double-check it.