### PR TITLE
Don't try to warn others users via ICC when creating a new motion

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
@@ -197,7 +197,8 @@
         [newMotion]="newMotion"
         [osListenEditing]="{
             editMode: editMotion,
-            model: motion
+            model: motion,
+            listen: !newMotion
         }"
         (save)="saveMotion($event)"
         (formChanged)="temporaryMotion = $event"

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/modules/directives/listen-editing/listen-editing.directive.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/modules/directives/listen-editing/listen-editing.directive.ts
@@ -64,6 +64,7 @@ interface EditNotification {
 interface EditObject {
     editMode: boolean;
     model: BaseModel;
+    listen: boolean;
 }
 
 @Directive({
@@ -74,10 +75,12 @@ export class ListenEditingDirective extends BaseUiComponent implements OnDestroy
     public set osListenEditing(editObject: EditObject) {
         this.isEditing = editObject.editMode;
         this.baseModel = editObject.model;
-        if (this.isEditing && this.baseModel) {
-            this.enterEditMode();
-        } else {
-            this.leaveEditMode();
+        if (editObject.listen) {
+            if (this.isEditing && this.baseModel) {
+                this.enterEditMode();
+            } else {
+                this.leaveEditMode();
+            }
         }
     }
 


### PR DESCRIPTION
fixes #1413

@MSoeb I removed the error when creating a new motion, although you will not be able to test it correctly because the error does not happen in the dev setup. You can test it in production after the update rolls out, but as you said, it should not have an impact on motion creation.

The other problem is that the whole "warning per ICC" system does not work. I will open a new issue for this.