### PR TITLE
[WIP] reduce autoupdate connections

### DIFF
--- a/client/src/app/site/pages/meetings/services/sequential-number-mapping.service.ts
+++ b/client/src/app/site/pages/meetings/services/sequential-number-mapping.service.ts
@@ -87,7 +87,8 @@ export class SequentialNumberMappingService {
         }
         this._modelRequestSubscription = this.autoupdateService.subscribe(
             await this.modelRequestBuilder.build(this.getSequentialNumberRequest()),
-            MODEL_REQUEST_DESCRIPTION
+            MODEL_REQUEST_DESCRIPTION,
+            true
         );
     }
 

--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -216,6 +216,7 @@ export class AutoupdateService {
         }
 
         this._pendingRequests = [];
+        let description = pendingRequests.map(req => req.description).join(`\n`);
 
         const buildStreamFn = (streamId: number) =>
             this.httpStreamService.create<AutoupdateModelData>(
@@ -225,8 +226,8 @@ export class AutoupdateService {
                 },
                 {
                     onMessage: (data, stream) =>
-                        this.handleAutoupdate({ autoupdateData: data, id: stream.id, description: `collection` }),
-                    description: `collection`,
+                        this.handleAutoupdate({ autoupdateData: data, id: stream.id, description }),
+                    description,
                     id: streamId
                 },
                 { bodyFn: () => pendingRequests.map(req => req.request) }

--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import {auditTime, Subject} from 'rxjs';
+import { auditTime, Subject } from 'rxjs';
 
 import { Id, Ids } from '../../../domain/definitions/key-types';
 import { HttpStreamEndpointService, HttpStreamService } from '../../../gateways/http-stream';
@@ -183,7 +183,7 @@ export class AutoupdateService {
                 let streamId = this._activeRequestObjects[id].autoupdateStreamId;
                 const sId = this._activeStreams[streamId].subscriptions.indexOf(id);
                 if (sId !== -1) {
-                    this._activeStreams[streamId].subscriptions.splice(sId, 1)
+                    this._activeStreams[streamId].subscriptions.splice(sId, 1);
 
                     if (!this._activeStreams[streamId].subscriptions.length) {
                         this._activeStreams[streamId].close();
@@ -208,8 +208,8 @@ export class AutoupdateService {
                     },
                     {
                         onMessage: (data, stream) =>
-                            this.handleAutoupdate({ autoupdateData: data, id: stream.id, description: 'collection' }),
-                        description: 'collection',
+                            this.handleAutoupdate({ autoupdateData: data, id: stream.id, description: `collection` }),
+                        description: `collection`,
                         id: streamId
                     },
                     { bodyFn: () => pendingRequests.map(req => req.request) }

--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -220,6 +220,7 @@ export class AutoupdateService {
                 subscriptions: pendingRequests.map(req => req.id),
                 close: () => {
                     closeFn();
+                    delete this._activeStreams[id];
                 }
             };
 


### PR DESCRIPTION
This is a first attempt to resolve #1339.

The PR tries to reduce the open connections by collecting autoupdate subscription requests for a short duration and then sending them in one request. 