### PR TITLE
Fix sorting by calllist

### DIFF
--- a/client/src/app/domain/models/motions/motion.ts
+++ b/client/src/app/domain/models/motions/motion.ts
@@ -43,6 +43,11 @@ export class Motion extends BaseModel<Motion> implements MotionFormattingReprese
     public state_extension!: string;
     public recommendation_extension!: string;
     public sort_weight!: number;
+    /**
+     * Client-calculated field: The tree_weight indicates the position of a motion in a list of
+     * motions in regard to the call list.
+     */
+    public tree_weight!: number;
     public created!: number;
     public forwarded!: number; // It's a timestamp
     public last_modified!: number;

--- a/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
@@ -13,6 +13,7 @@ import {
     ROUTING_FIELDSET,
     TypedFieldset
 } from 'src/app/site/services/model-request-builder';
+import { TreeService } from 'src/app/ui/modules/sorting/modules/sorting-tree/services';
 
 import { Motion } from '../../../../domain/models/motions/motion';
 import { AgendaItemRepositoryService, createAgendaItem } from '../../agenda';
@@ -38,7 +39,8 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
 
     constructor(
         repositoryServiceCollector: RepositoryMeetingServiceCollectorService,
-        agendaItemRepo: AgendaItemRepositoryService
+        agendaItemRepo: AgendaItemRepositoryService,
+        private treeService: TreeService
     ) {
         super(repositoryServiceCollector, Motion, agendaItemRepo);
         this.meetingSettingsService.get(`motions_default_sorting`).subscribe(conf => {
@@ -336,6 +338,10 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
         viewModel.getProjectorTitle = () => this.getProjectorTitle(viewModel);
 
         return viewModel;
+    }
+
+    protected override tapViewModels(viewModels: ViewMotion[]): void {
+        this.treeService.injectFlatNodeInformation(viewModels, `sort_weight`, `sort_parent_id`);
     }
 
     private getCreatePayload(partialMotion: any): any {

--- a/client/src/app/infrastructure/utils/overload-js-functions.ts
+++ b/client/src/app/infrastructure/utils/overload-js-functions.ts
@@ -21,6 +21,12 @@ declare global {
          */
         difference(other: T[], symmetric?: boolean): T[];
         /**
+         * Compares two arrays element-wise for object equality to determine if the arrays contain
+         * the same items. Same functionality as `difference(other, true).length > 0`, but
+         * potentially faster for large arrays.
+         */
+        equals(other: T[]): boolean;
+        /**
          * A function to "tap" a whole array and take it to manipulate it or anything else.
          *
          * @param callbackFn A function that receives the whole array and has to return nothing.
@@ -28,7 +34,7 @@ declare global {
         tap(callbackFn: (self: T[]) => void): T[];
         mapToObject(f: (item: T, index: number) => { [key: string]: any }): { [key: string]: any };
         /**
-         * TODO: Remove this, when ES 2019 (or in whatever spec `at` is defined) is the target for our tsconfig
+         * TODO: Remove this, when ES2022 is the target for our tsconfig
          *
          * @param index The index of an element in the array one expects
          */
@@ -100,6 +106,13 @@ function overloadArrayFunctions(): void {
                 }
             }
             return Array.from(difference);
+        },
+        enumerable: false
+    });
+
+    Object.defineProperty(Array.prototype, `equals`, {
+        value<T>(other: T[]): boolean {
+            return this.length == other.length && this.every((val, idx) => val === other[idx]);
         },
         enumerable: false
     });

--- a/client/src/app/site/base/base-sort.service/base-sort-list.service.ts
+++ b/client/src/app/site/base/base-sort.service/base-sort-list.service.ts
@@ -181,12 +181,12 @@ export abstract class BaseSortListService<V extends BaseViewModel>
         }
     }
 
+    /**
+     * Determines if the given properties are either the same property or both arrays of the same
+     * properties.
+     */
     private getPropertiesEqual(a: OsSortProperty<V>, b: OsSortProperty<V>): boolean {
-        if (Array.isArray(a) && Array.isArray(b)) {
-            return a.every((val, idx) => val === b[idx]);
-        } else {
-            return !Array.isArray(a) && !Array.isArray(b) && a === b;
-        }
+        return Array.isArray(a) && Array.isArray(b) ? a.equals(b) : a === b;
     }
 
     /**

--- a/client/src/app/site/base/base-sort.service/base-sort-list.service.ts
+++ b/client/src/app/site/base/base-sort.service/base-sort-list.service.ts
@@ -74,7 +74,7 @@ export abstract class BaseSortListService<V extends BaseViewModel>
      * @param property a part of a view model
      */
     public set sortProperty(property: OsSortProperty<V>) {
-        if (this.sortDefinition!.sortProperty === property) {
+        if (this.getPropertiesEqual(this.sortDefinition!.sortProperty, property)) {
             this.ascending = !this.ascending;
         } else {
             this.sortDefinition!.sortProperty = property;
@@ -172,12 +172,20 @@ export abstract class BaseSortListService<V extends BaseViewModel>
      */
     public getSortIcon(option: OsSortingOption<V>): string | null {
         if (this.sortDefinition) {
-            if (this.sortProperty && this.sortProperty !== option.property) {
+            if (!this.sortProperty || !this.getPropertiesEqual(this.sortProperty, option.property)) {
                 return ``;
             }
             return this.ascending ? `arrow_upward` : `arrow_downward`;
         } else {
             return null;
+        }
+    }
+
+    private getPropertiesEqual(a: OsSortProperty<V>, b: OsSortProperty<V>): boolean {
+        if (Array.isArray(a) && Array.isArray(b)) {
+            return a.every((val, idx) => val === b[idx]);
+        } else {
+            return !Array.isArray(a) && !Array.isArray(b) && a === b;
         }
     }
 

--- a/client/src/app/site/pages/meetings/pages/motions/services/list/motion-list-sort.service/motion-list-sort.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/list/motion-list-sort.service/motion-list-sort.service.ts
@@ -32,7 +32,7 @@ export class MotionListSortService extends BaseSortListService<ViewMotion> {
      * Define the sort options
      */
     protected motionSortOptions: OsSortingOption<ViewMotion>[] = [
-        { property: `sort_weight`, label: `Call list` },
+        { property: [`tree_weight`, `id`], label: `Call list` },
         { property: `number` },
         { property: `title` },
         { property: `submitters` },


### PR DESCRIPTION
fixes https://github.com/OpenSlides/openslides-client/issues/1312

fixes an error in the tree service where it was always assumed that the children property was named `children` and also changed it. Also fixes another error where sorting by an array of fields was not correctly saved and loaded.