### PR TITLE
General bug fixes and improvements for user imports

### DIFF
--- a/client/src/app/domain/models/users/user.constants.ts
+++ b/client/src/app/domain/models/users/user.constants.ts
@@ -9,5 +9,6 @@ export const userHeadersAndVerboseNames: { [key in keyof User]?: any } = {
     default_password: `Initial password`,
     email: `Email`,
     username: `Username`,
-    gender: `Gender`
+    gender: `Gender`,
+    pronoun: `Pronoun`
 };

--- a/client/src/app/domain/models/users/user.export.ts
+++ b/client/src/app/domain/models/users/user.export.ts
@@ -11,4 +11,5 @@ export interface UserExport {
     default_number?: string | number;
     default_structure_level?: string;
     default_vote_weight?: string | number;
+    pronoun?: string;
 }

--- a/client/src/app/site/base/base-import.service/base-import.service.ts
+++ b/client/src/app/site/base/base-import.service/base-import.service.ts
@@ -683,7 +683,7 @@ export abstract class BaseImportService<MainModel extends Identifiable> implemen
             const { importModel, allImportModels } = config;
             return config.importFindHandler.findByName(value, { importModel, allImportModels });
         }
-        value = this.pipeParseValue(value, config.header) || value;
+        value = this.pipeParseValue(value, config.header) ?? value;
         return value;
     }
 

--- a/client/src/app/site/base/base-user-import.service.ts
+++ b/client/src/app/site/base/base-user-import.service.ts
@@ -1,12 +1,14 @@
 import { Directive } from '@angular/core';
 
-import { User } from '../../domain/models/users/user';
+import { GENDERS, User } from '../../domain/models/users/user';
 import { ImportServiceCollectorService } from '../services/import-service-collector.service';
 import { BaseImportService } from './base-import.service';
 
 @Directive()
 export abstract class BaseUserImportService extends BaseImportService<User> {
     public override requiredHeaderLength = 3;
+
+    private readonly currentLangGenders = GENDERS.map(gender => this.translate.instant(gender));
 
     public constructor(importServiceCollector: ImportServiceCollectorService) {
         super(importServiceCollector);
@@ -15,6 +17,10 @@ export abstract class BaseUserImportService extends BaseImportService<User> {
     protected override pipeParseValue(value: string, header: keyof User): any {
         if (header === `is_active` || header === `is_physical_person`) {
             return this.toBoolean(value);
+        }
+
+        if (header === `gender`) {
+            return this.getGenderInEnglish(value);
         }
 
         if (header === `first_name` || header === `last_name` || header === `username`) {
@@ -36,5 +42,19 @@ export abstract class BaseUserImportService extends BaseImportService<User> {
         } else {
             throw new TypeError(`Value cannot be translated into boolean: ` + data);
         }
+    }
+
+    /**
+     * translates gender string to the english version if necessary
+     *
+     * @param data
+     * @returns a boolean from the string
+     */
+    private getGenderInEnglish(data: string): string {
+        const location = this.currentLangGenders.findIndex(gender => gender === data);
+        if (location !== -1) {
+            return GENDERS[location];
+        }
+        return data;
     }
 }

--- a/client/src/app/site/base/base-user-import.service.ts
+++ b/client/src/app/site/base/base-user-import.service.ts
@@ -8,7 +8,9 @@ import { BaseImportService } from './base-import.service';
 export abstract class BaseUserImportService extends BaseImportService<User> {
     public override requiredHeaderLength = 3;
 
-    private readonly currentLangGenders = GENDERS.map(gender => this.translate.instant(gender));
+    private get currentLangGenders(): string[] {
+        return GENDERS.map(gender => this.translate.instant(gender));
+    }
 
     public constructor(importServiceCollector: ImportServiceCollectorService) {
         super(importServiceCollector);

--- a/client/src/app/site/pages/meetings/pages/participants/export/participant-csv-export.service/participant-csv-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/export/participant-csv-export.service/participant-csv-export.service.ts
@@ -45,7 +45,8 @@ export class ParticipantCsvExportService {
                 { property: `email` },
                 { property: `username` },
                 { property: `gender` },
-                { property: `vote_weight`, label: `Vote weight` }
+                { property: `vote_weight`, label: `Vote weight` },
+                { property: `pronoun`, label: `Pronoun` }
             ],
             this.translate.instant(`Participants`) + `.csv`
         );

--- a/client/src/app/site/pages/meetings/pages/participants/export/participants-export-example.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/export/participants-export-example.ts
@@ -10,6 +10,7 @@ export const participantsExportExample: any = [
         default_password: `initialPassword`,
         username: `mmustermann`,
         gender: `male`,
+        pronoun: `Er`,
         default_number: 1234567890,
         default_structure_level: `Berlin`,
         default_vote_weight: 1.0,

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.html
@@ -166,7 +166,7 @@
                 <os-editor formControlName="about_me"></os-editor>
             </div>
 
-            <div *ngIf="isAllowed('seeExtra')">
+            <div *ngIf="isAllowed('manage')">
                 <!-- Comment -->
                 <mat-form-field>
                     <input matInput placeholder="{{ 'Comment' | translate }}" formControlName="comment" />
@@ -239,7 +239,7 @@
             </div>
         </div>
 
-        <div *ngIf="isAllowed('seeExtra')">
+        <div *ngIf="isAllowed('manage')">
             <!-- Comment -->
             <div *ngIf="user?.comment()">
                 <h4>{{ 'Comment' | translate }}</h4>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
@@ -224,7 +224,7 @@
                                 <os-editor formControlName="about_me"></os-editor>
                             </div>
 
-                            <div *ngIf="isAllowedFn('seeExtra')">
+                            <div *ngIf="isAllowedFn('manage')">
                                 <!-- Comment -->
                                 <mat-form-field>
                                     <input

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
@@ -113,7 +113,9 @@
             </mat-icon>
 
             <!-- Has comment indicator -->
-            <mat-icon inline *ngIf="!!user.comment()" matTooltip="{{ user.comment() }}">comment</mat-icon>
+            <div *osPerms="permission.userCanManage">
+                <mat-icon inline *ngIf="!!user.comment()" matTooltip="{{ user.comment() }}">comment</mat-icon>
+            </div>
 
             <!--<os-icon-container *ngIf="user.isSamlUser" icon="device_hub"
                 ><span>{{ 'Is SAML user' | translate }}</span></os-icon-container

--- a/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
@@ -243,6 +243,9 @@ export class ParticipantControllerService extends BaseMeetingControllerService<V
             },
             vote_delegations_$_from_ids: participant.vote_delegations_$_from_ids || {
                 [this.activeMeetingId!]: participant.vote_delegations_from_ids
+            },
+            comment_$: participant.comment_$ || {
+                [this.activeMeetingId!]: participant.comment
             }
         };
     }


### PR DESCRIPTION
Closes #1406 

Done:

- Can use gender terms of selected language
- Pronouns included in imports/exports
- Fixed problem with boolean fields (where only true values were accepted)
- Comments can now be imported/exported and can be set/viewed by users with user.can_manage permission
- I believe the application of new data after referencing should work now

TODO:

- [x] Look if the account import is functioning correctly