### PR TITLE
Made ApplauseService receive messages and separated it from NotifyService

### DIFF
--- a/client/src/app/gateways/base-icc-gateway.service.ts
+++ b/client/src/app/gateways/base-icc-gateway.service.ts
@@ -1,54 +1,78 @@
-import { Directive } from "@angular/core";
+import { Directive } from '@angular/core';
 
-import { HttpMethod } from "../infrastructure/definitions/http";
-import { CommunicationManagerService } from "../site/services/communication-manager.service";
-import { HttpService } from "./http.service";
-import { HttpStreamEndpointService, HttpStreamService } from "./http-stream";
+import { HttpMethod } from '../infrastructure/definitions/http';
+import { ActiveMeetingIdService } from '../site/pages/meetings/services/active-meeting-id.service';
+import { CommunicationManagerService } from '../site/services/communication-manager.service';
+import { HttpService } from './http.service';
+import { HttpStreamEndpointService, HttpStreamService } from './http-stream';
 
 const ICC_ENDPOINT = `icc`;
 
 export const ICC_PATH = `/system/icc`;
 
-export interface ICCRequest<T> {}
-
-export interface ICCSendOptions<T> {}
-
 /**
- * Base sorting service with main functionality for sorting.
+ * Base service for services which listen to the ICC service.
  *
- * Extends sorting services to sort with a consistent function.
+ * Contains the connect, disconnect and send logic.
  */
 @Directive()
 export abstract class BaseICCGatewayService<ICCResponseType> {
+    protected abstract readonly serviceDescription: string;
+
+    /**
+     * Path ending for receiving messages, will automatically be appended to '/system/icc' before usage.
+     */
+    protected abstract readonly receivePath: string;
+
+    /**
+     * Path ending for ssending messages, will automatically be appended to '/system/icc' before usage.
+     */
+    protected abstract readonly sendPath: string;
+
+    private readonly healthPath: string = `${ICC_PATH}/health`;
 
     private connectionClosingFn: (() => void) | undefined;
 
-    protected abstract readonly serviceDescription: string;
-
-    protected abstract readonly healthPath: string;
-    protected abstract readonly receivePath: string;
-    protected abstract readonly sendPath: string;
-
     /**
      * Constructor to create the Service.
+     * Subclasses can call {@link setupConnections} after the super call to initialize automatic meeting-based connection handling.
+     * Otherwise connections need to be managed manually.
      */
     public constructor(
         private httpService: HttpService,
         private httpStreamService: HttpStreamService,
+        protected activeMeetingIdService: ActiveMeetingIdService,
         private communicationManager: CommunicationManagerService,
         private httpEndpointService: HttpStreamEndpointService
     ) {}
 
+    /**
+     * Can be called in the subclasses constructor after the super call.
+     * Sets up automatic connection to and disconnection from the ICC service.
+     */
+    protected setupConnections(): void {
+        this.activeMeetingIdService.meetingIdObservable.subscribe(meetingId => {
+            if (meetingId) {
+                this.connect(meetingId);
+            } else {
+                this.disconnect();
+            }
+        });
+    }
+
     public async connect(meetingId: number): Promise<void> {
-        console.log(`Connect to ICC service with: meeting_id=${meetingId}`);
+        console.log(`${this.serviceDescription}: Connect to ICC service with: meeting_id=${meetingId}`);
         if (!meetingId) {
             throw new Error(`Cannot connect to ICC, no meeting ID was provided`);
         }
 
+        if (!this.receivePath) {
+            throw new Error(`Cannot connect to ICC, no path was provided`);
+        }
+
         this.disconnect();
 
-        const iccMeeting = `${this.receivePath}?meeting_id=${meetingId}`;
-        console.log(`LOG: made path: `, iccMeeting);
+        const iccMeeting = `${ICC_PATH}${this.receivePath}?meeting_id=${meetingId}`;
         this.httpEndpointService.registerEndpoint(ICC_ENDPOINT, iccMeeting, this.healthPath, HttpMethod.GET);
         const buildStreamFn = () =>
             this.httpStreamService.create<ICCResponseType>(ICC_ENDPOINT, {
@@ -60,9 +84,7 @@ export abstract class BaseICCGatewayService<ICCResponseType> {
     }
 
     public disconnect(): void {
-        console.log(`LOG: disconnecting1`);
         if (this.connectionClosingFn) {
-            console.log(`LOG: disconnecting2`);
             try {
                 this.connectionClosingFn();
             } catch (e) {
@@ -72,21 +94,25 @@ export abstract class BaseICCGatewayService<ICCResponseType> {
         }
     }
 
-    protected abstract onMessage(response: ICCResponseType): void;
-
-    protected abstract buildRequest<T>(data: ICCSendOptions<T>): ICCRequest<T>;
+    /**
+     * Define what happens when a message is received from the ICC service.
+     * @param response The message that was received.
+     */
+    protected abstract onMessage(message: ICCResponseType): void;
 
     /**
-     * General send function for messages. Subclasses should call this to build their own specific send functions
+     * General send function for messages. Subclasses should call this to build their own more specific send functions.
      */
-    protected async send<T>(data?: ICCSendOptions<T>): Promise<void> {
-        if (data){
-            const request = this.buildRequest(data);
-            console.debug(`Send following data over ICC:`, this.sendPath, request);
-            await this.httpService.post<unknown>(this.sendPath, request);
+    protected async send<T>(data?: any): Promise<void> {
+        if (!this.sendPath) {
+            throw new Error(`Cannot send to ICC, no path was provided`);
+        }
+        if (data) {
+            console.debug(`Send following data over ICC:`, `${ICC_PATH}${this.sendPath}`, data);
+            await this.httpService.post<unknown>(`${ICC_PATH}${this.sendPath}`, data);
         } else {
-            console.debug(`Send following data over ICC:`, this.sendPath);
-            await this.httpService.post<unknown>(this.sendPath);
+            console.debug(`Send message to ICC with following route:`, `${ICC_PATH}${this.sendPath}`);
+            await this.httpService.post<unknown>(`${ICC_PATH}${this.sendPath}`);
         }
     }
 }

--- a/client/src/app/gateways/base-icc-gateway.service.ts
+++ b/client/src/app/gateways/base-icc-gateway.service.ts
@@ -1,0 +1,92 @@
+import { Directive } from "@angular/core";
+
+import { HttpMethod } from "../infrastructure/definitions/http";
+import { CommunicationManagerService } from "../site/services/communication-manager.service";
+import { HttpService } from "./http.service";
+import { HttpStreamEndpointService, HttpStreamService } from "./http-stream";
+
+const ICC_ENDPOINT = `icc`;
+
+export const ICC_PATH = `/system/icc`;
+
+export interface ICCRequest<T> {}
+
+export interface ICCSendOptions<T> {}
+
+/**
+ * Base sorting service with main functionality for sorting.
+ *
+ * Extends sorting services to sort with a consistent function.
+ */
+@Directive()
+export abstract class BaseICCGatewayService<ICCResponseType> {
+
+    private connectionClosingFn: (() => void) | undefined;
+
+    protected abstract readonly serviceDescription: string;
+
+    protected abstract readonly healthPath: string;
+    protected abstract readonly receivePath: string;
+    protected abstract readonly sendPath: string;
+
+    /**
+     * Constructor to create the Service.
+     */
+    public constructor(
+        private httpService: HttpService,
+        private httpStreamService: HttpStreamService,
+        private communicationManager: CommunicationManagerService,
+        private httpEndpointService: HttpStreamEndpointService
+    ) {}
+
+    public async connect(meetingId: number): Promise<void> {
+        console.log(`Connect to ICC service with: meeting_id=${meetingId}`);
+        if (!meetingId) {
+            throw new Error(`Cannot connect to ICC, no meeting ID was provided`);
+        }
+
+        this.disconnect();
+
+        const iccMeeting = `${this.receivePath}?meeting_id=${meetingId}`;
+        console.log(`LOG: made path: `, iccMeeting);
+        this.httpEndpointService.registerEndpoint(ICC_ENDPOINT, iccMeeting, this.healthPath, HttpMethod.GET);
+        const buildStreamFn = () =>
+            this.httpStreamService.create<ICCResponseType>(ICC_ENDPOINT, {
+                onMessage: (response: ICCResponseType) => this.onMessage(response),
+                description: this.serviceDescription
+            });
+        const { closeFn } = this.communicationManager.registerStreamBuildFn(buildStreamFn);
+        this.connectionClosingFn = closeFn;
+    }
+
+    public disconnect(): void {
+        console.log(`LOG: disconnecting1`);
+        if (this.connectionClosingFn) {
+            console.log(`LOG: disconnecting2`);
+            try {
+                this.connectionClosingFn();
+            } catch (e) {
+                console.warn(`Was not able to properly close previous ICC connection: `, e);
+            }
+            this.connectionClosingFn = undefined;
+        }
+    }
+
+    protected abstract onMessage(response: ICCResponseType): void;
+
+    protected abstract buildRequest<T>(data: ICCSendOptions<T>): ICCRequest<T>;
+
+    /**
+     * General send function for messages. Subclasses should call this to build their own specific send functions
+     */
+    protected async send<T>(data?: ICCSendOptions<T>): Promise<void> {
+        if (data){
+            const request = this.buildRequest(data);
+            console.debug(`Send following data over ICC:`, this.sendPath, request);
+            await this.httpService.post<unknown>(this.sendPath, request);
+        } else {
+            console.debug(`Send following data over ICC:`, this.sendPath);
+            await this.httpService.post<unknown>(this.sendPath);
+        }
+    }
+}

--- a/client/src/app/gateways/notify.service.ts
+++ b/client/src/app/gateways/notify.service.ts
@@ -2,12 +2,11 @@ import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { HttpService } from 'src/app/gateways/http.service';
 import { HttpStreamEndpointService, HttpStreamService } from 'src/app/gateways/http-stream';
-import { HttpMethod } from 'src/app/infrastructure/definitions/http';
 import { CommunicationManagerService } from 'src/app/site/services/communication-manager.service';
-import { LifecycleService } from 'src/app/site/services/lifecycle.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 
 import { ActiveMeetingIdService } from '../site/pages/meetings/services/active-meeting-id.service';
+import { BaseICCGatewayService, ICC_PATH,ICCRequest, ICCSendOptions } from './base-icc-gateway.service';
 
 /**
  * Encapslates the name and content of every message regardless of being a request or response.
@@ -29,7 +28,7 @@ interface NotifyBase<T> {
  * one can give an array of user ids (or the value `true` for all users) and an array of
  * channel names.
  */
-export interface NotifyRequest<T> extends NotifyBase<T> {
+export interface NotifyRequest<T> extends NotifyBase<T>, ICCRequest<T> {
     channel_id: string;
     to_all?: boolean;
 
@@ -81,7 +80,7 @@ interface ChannelIdResponse {
  * @param users Either an array of IDs or `true` meaning of sending this message to all online users clients.
  * @param channels An array of channels to send this message to.
  */
-interface NotifySendOptions<T> {
+interface NotifySendOptions<T> extends ICCSendOptions<T> {
     name: string;
     message: T;
     toAll?: boolean;
@@ -89,17 +88,17 @@ interface NotifySendOptions<T> {
     channels?: string[];
 }
 
-const ICC_ENDPOINT = `icc`;
-
-const ICC_PATH = `/system/icc`;
-const NOTIFY_PATH = `${ICC_PATH}/notify`;
-const PUBLISH_PATH = `${NOTIFY_PATH}/publish`;
-const ICC_HEALTH_PATH = `${ICC_PATH}/health`;
-
 @Injectable({
     providedIn: `root`
 })
-export class NotifyService {
+export class NotifyService extends BaseICCGatewayService<ChannelIdResponse | NotifyResponse<any>> {
+
+    protected serviceDescription = `NotifyService`;
+
+    protected readonly healthPath = `${ICC_PATH}/health`;
+    protected readonly receivePath = `${ICC_PATH}/notify`;
+    protected readonly sendPath = `${this.receivePath}/publish`;
+
     /**
      * A general subject for all messages.
      */
@@ -113,20 +112,20 @@ export class NotifyService {
     } = {};
 
     private channelId: string = ``;
-    private connectionClosingFn: (() => void) | undefined;
 
     /**
      * Constructor to create the NotifyService.
      */
     public constructor(
-        private httpService: HttpService,
-        private httpStreamService: HttpStreamService,
+        httpService: HttpService,
+        httpStreamService: HttpStreamService,
         private operator: OperatorService,
         private activeMeetingIdService: ActiveMeetingIdService,
-        private lifecycleService: LifecycleService,
-        private communicationManager: CommunicationManagerService,
-        private httpEndpointService: HttpStreamEndpointService
+        communicationManager: CommunicationManagerService,
+        httpEndpointService: HttpStreamEndpointService
     ) {
+        super(httpService, httpStreamService, communicationManager, httpEndpointService);
+
         /**
          * watch for both the meeting ID and lifecycle
          * enables logging out to be anonymous ICC and
@@ -194,41 +193,32 @@ export class NotifyService {
         await this.send({ name, message: content, channels });
     }
 
-    public async connect(meetingId: number): Promise<void> {
-        console.log(`Connect to ICC service with: meeting_id=${meetingId}`);
-        if (!meetingId) {
-            throw new Error(`Cannot connect to ICC, no meeting ID was provided`);
+    protected onMessage(response: ChannelIdResponse | NotifyResponse<any>): void {
+        console.log(`onMessage`, response);
+        if ((response as ChannelIdResponse).channel_id) {
+            this.handleChannelIdResponse(response as ChannelIdResponse);
+        } else {
+            this.handleNotifyResponse(response as NotifyResponse<any>);
         }
-
-        this.disconnect();
-
-        const iccMeeting = `${NOTIFY_PATH}?meeting_id=${meetingId}`;
-        this.httpEndpointService.registerEndpoint(ICC_ENDPOINT, iccMeeting, ICC_HEALTH_PATH, HttpMethod.GET);
-        const buildStreamFn = () =>
-            this.httpStreamService.create<NotifyResponse<any> | ChannelIdResponse>(ICC_ENDPOINT, {
-                onMessage: (notify: NotifyResponse<any> | ChannelIdResponse) => {
-                    console.log(`onMessage`, notify);
-                    if ((notify as ChannelIdResponse).channel_id) {
-                        this.handleChannelIdResponse(notify as ChannelIdResponse);
-                    } else {
-                        this.handleNotifyResponse(notify as NotifyResponse<any>);
-                    }
-                },
-                description: `NotifyService`
-            });
-        const { closeFn } = this.communicationManager.registerStreamBuildFn(buildStreamFn);
-        this.connectionClosingFn = closeFn;
     }
 
-    public disconnect(): void {
-        if (this.connectionClosingFn) {
-            try {
-                this.connectionClosingFn();
-            } catch (e) {
-                console.warn(`Was not able to properly close previous ICC connection: `, e);
-            }
-            this.connectionClosingFn = undefined;
+    protected buildRequest<T>(data: NotifySendOptions<T>): NotifyRequest<T> {
+        const notify: NotifyRequest<T> = {
+            name: data.name,
+            message: data.message,
+            channel_id: this.channelId ?? this.activeMeetingIdService.meetingId?.toString(),
+            to_meeting: this.activeMeetingIdService.meetingId!
+        };
+        if (data.toAll === true) {
+            notify.to_all = true;
         }
+        if (data.users) {
+            notify.to_users = data.users;
+        }
+        if (data.channels) {
+            notify.to_channels = data.channels;
+        }
+        return notify;
     }
 
     private handleChannelIdResponse(response: ChannelIdResponse): void {
@@ -248,23 +238,23 @@ export class NotifyService {
     /**
      * General send function for notify messages.
      */
-    private async send<T>({ name, message, toAll, users, channels }: NotifySendOptions<T>): Promise<void> {
-        const notify: NotifyRequest<T> = {
-            name,
-            message,
-            channel_id: this.channelId ?? this.activeMeetingIdService.meetingId?.toString(),
-            to_meeting: this.activeMeetingIdService.meetingId!
-        };
-        if (toAll === true) {
-            notify.to_all = true;
-        }
-        if (users) {
-            notify.to_users = users;
-        }
-        if (channels) {
-            notify.to_channels = channels;
-        }
-        console.debug(`Send following data over ICC:`, PUBLISH_PATH, notify);
-        await this.httpService.post<unknown>(PUBLISH_PATH, notify);
-    }
+    // private async send<T>({ name, message, toAll, users, channels }: NotifySendOptions<T>): Promise<void> {
+    //     const notify: NotifyRequest<T> = {
+    //         name,
+    //         message,
+    //         channel_id: this.channelId ?? this.activeMeetingIdService.meetingId?.toString(),
+    //         to_meeting: this.activeMeetingIdService.meetingId!
+    //     };
+    //     if (toAll === true) {
+    //         notify.to_all = true;
+    //     }
+    //     if (users) {
+    //         notify.to_users = users;
+    //     }
+    //     if (channels) {
+    //         notify.to_channels = channels;
+    //     }
+    //     console.debug(`Send following data over ICC:`, PUBLISH_PATH, notify);
+    //     await this.httpService.post<unknown>(PUBLISH_PATH, notify);
+    // }
 }

--- a/client/src/app/site/pages/meetings/pages/interaction/services/applause.service.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/services/applause.service.ts
@@ -1,12 +1,15 @@
 import { Injectable } from '@angular/core';
-import { combineLatest, distinctUntilChanged, filter, map, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, distinctUntilChanged, filter, map, Observable, Subject } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { ApplauseType } from 'src/app/domain/models/meetings/applause';
+import { BaseICCGatewayService } from 'src/app/gateways/base-icc-gateway.service';
 import { HttpService } from 'src/app/gateways/http.service';
-import { NotifyService } from 'src/app/gateways/notify.service';
+import { HttpStreamEndpointService, HttpStreamService } from 'src/app/gateways/http-stream';
 import { ActiveMeetingService } from 'src/app/site/pages/meetings/services/active-meeting.service';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
+import { CommunicationManagerService } from 'src/app/site/services/communication-manager.service';
 
+import { ActiveMeetingIdService } from '../../../services/active-meeting-id.service';
 import { InteractionServiceModule } from './interaction-service.module';
 
 export interface Applause {
@@ -14,13 +17,33 @@ export interface Applause {
     presentUsers: number;
 }
 
-const APPLAUSE_SEND_PATH = `/system/icc/applause/send`;
-const APPLAUSE_RECEIVE_TOPIC = `applause`; // TODO
-
 @Injectable({
     providedIn: InteractionServiceModule
 })
-export class ApplauseService {
+export class ApplauseService extends BaseICCGatewayService<Applause> {
+    public get showParticles(): Observable<boolean> {
+        return this.applauseTypeObservable.pipe(map(type => type === ApplauseType.particles));
+    }
+
+    public get showBar(): Observable<boolean> {
+        return this.applauseTypeObservable.pipe(map(type => type === ApplauseType.bar));
+    }
+
+    public get showApplauseLevelObservable(): Observable<boolean> {
+        return combineLatest([this.showApplauseLevelConfigObservable, this.applauseLevelObservable]).pipe(
+            map(([enabled, amount]) => enabled && amount > 0)
+        );
+    }
+
+    protected readonly serviceDescription = `ApplauseServiceService`;
+
+    protected readonly receivePath = `/applause`;
+    protected get sendPath(): string {
+        return `${this.receivePath}/send?meeting_id=${this.activeMeetingId}`;
+    }
+
+    private applauseMessageSubject = new BehaviorSubject<Applause>({ level: 0, presentUsers: 1 });
+
     private minApplauseLevel!: number;
     private maxApplauseLevel!: number;
     private presentApplauseUsers!: number;
@@ -41,30 +64,22 @@ export class ApplauseService {
         return this.maxApplauseLevel || this.presentApplauseUsers || 0;
     }
 
-    public get showParticles(): Observable<boolean> {
-        return this.applauseTypeObservable.pipe(map(type => type === ApplauseType.particles));
-    }
-
-    public get showBar(): Observable<boolean> {
-        return this.applauseTypeObservable.pipe(map(type => type === ApplauseType.bar));
-    }
-
-    public get showApplauseLevelObservable(): Observable<boolean> {
-        return combineLatest([this.showApplauseLevelConfigObservable, this.applauseLevelObservable]).pipe(
-            map(([enabled, amount]) => enabled && amount > 0)
-        );
-    }
-
     private get activeMeetingId(): Id {
         return this.activeMeetingService.meetingId!;
     }
 
     public constructor(
         settingService: MeetingSettingsService,
-        private httpService: HttpService,
-        private notifyService: NotifyService,
-        private activeMeetingService: ActiveMeetingService
+        httpService: HttpService,
+        private activeMeetingService: ActiveMeetingService,
+        activeMeetingIdService: ActiveMeetingIdService,
+        httpStreamService: HttpStreamService,
+        communicationManager: CommunicationManagerService,
+        httpEndpointService: HttpStreamEndpointService
     ) {
+        super(httpService, httpStreamService, activeMeetingIdService, communicationManager, httpEndpointService);
+        this.setupConnections();
+
         this.showApplauseObservable = settingService.get(`applause_enable`);
         this.applauseTypeObservable = settingService.get(`applause_type`);
         this.showApplauseLevelConfigObservable = settingService.get(`applause_show_level`);
@@ -82,10 +97,8 @@ export class ApplauseService {
             this.maxApplauseLevel = maxLevel;
         });
 
-        this.notifyService
-            .getMessageObservable<Applause>(APPLAUSE_RECEIVE_TOPIC)
+        this.applauseMessageSubject
             .pipe(
-                map(notify => notify.message as Applause),
                 /**
                  * only updates when the effective applause level changes
                  */
@@ -98,8 +111,12 @@ export class ApplauseService {
             });
     }
 
+    protected onMessage(message: Applause): void {
+        this.applauseMessageSubject.next(message);
+    }
+
     public async sendApplause(): Promise<void> {
-        await this.httpService.post(`${APPLAUSE_SEND_PATH}?meeting_id=${this.activeMeetingId}`);
+        await this.send();
 
         this.sendsApplauseSubject.next(true);
         setTimeout(() => {


### PR DESCRIPTION
Closes #1474 

Created `BaseICCGatewayService` with the ICC connection handling logic and made both the notify- & applause service extend it.