### PR TITLE
Non group-related meeting user updates no longer set group to standard

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
@@ -232,7 +232,7 @@ export class ParticipantControllerService extends BaseMeetingControllerService<V
                 [this.activeMeetingId!]: participant.structure_level
             },
             group_$_ids: participant.group_$_ids || {
-                [this.activeMeetingId!]: participant.group_ids || [this.activeMeeting.meeting!.default_group_id]
+                [this.activeMeetingId!]: participant.group_ids
             },
             number_$: participant.number_$ || { [this.activeMeetingId!]: participant.number },
             vote_weight_$: participant.vote_weight_$ || {


### PR DESCRIPTION
Closes #1480 

The change in this PR holds some danger of affecting some other functions, that are actually supposed to set groups. 

In essence: 
There _may_ now be problems if you attempt to remove the participant from all groups. Instead of being set to standard, the user _may_ now be kicked out of the meeting instead.

I have tried changing a users group in that way via the dialog in the participant list and also in the edit view and it still worked as intended, so I'm hopeful, but this should definately be tested more thouroughly.