### PR TITLE
Changed styling for meeting preview participant badges for big numbers

### DIFF
--- a/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.html
@@ -64,13 +64,13 @@
 </mat-card>
 
 <ng-template #canNotManageUsersTemplate>
-    <div class="fake-button-no-touch" matTooltip="{{ 'Participants' | translate }}">
-        <mat-icon [class.smaller-badge-text]="shouldUseSmallerBadgeText" [matBadgeHidden]="!showUserAmount" [matBadge]="userAmount" [matBadgeColor]="'accent'">group</mat-icon>
+    <div class="fake-button-no-touch" matTooltip="{{ userAmount }} {{ 'participants' | translate }}">
+        <mat-icon [class.smaller-badge-text]="shouldUseSmallerBadgeText" [matBadgeHidden]="!showUserAmount" [matBadge]="formattedUserAmount" [matBadgeColor]="'accent'">group</mat-icon>
     </div>
 </ng-template>
 <ng-template #canManageUsersTemplate>
-    <button mat-icon-button matTooltip="{{ 'Participants' | translate }}" (click)="changeToMeetingUsers()">
-        <mat-icon [class.smaller-badge-text]="shouldUseSmallerBadgeText" [matBadgeHidden]="!showUserAmount" [matBadge]="userAmount" [matBadgeColor]="'accent'">group</mat-icon>
+    <button mat-icon-button matTooltip="{{ userAmount }} {{ 'participants' | translate }}" (click)="changeToMeetingUsers()">
+        <mat-icon [class.smaller-badge-text]="shouldUseSmallerBadgeText" [matBadgeHidden]="!showUserAmount" [matBadge]="formattedUserAmount" [matBadgeColor]="'accent'">group</mat-icon>
     </button>
 </ng-template>
 

--- a/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.html
@@ -65,12 +65,12 @@
 
 <ng-template #canNotManageUsersTemplate>
     <div class="fake-button-no-touch" matTooltip="{{ 'Participants' | translate }}">
-        <mat-icon [matBadgeHidden]="!showUserAmount" [matBadge]="userAmount" [matBadgeColor]="'accent'">group</mat-icon>
+        <mat-icon [class.smaller-badge-text]="shouldUseSmallerBadgeText" [matBadgeHidden]="!showUserAmount" [matBadge]="userAmount" [matBadgeColor]="'accent'">group</mat-icon>
     </div>
 </ng-template>
 <ng-template #canManageUsersTemplate>
     <button mat-icon-button matTooltip="{{ 'Participants' | translate }}" (click)="changeToMeetingUsers()">
-        <mat-icon [matBadgeHidden]="!showUserAmount" [matBadge]="userAmount" [matBadgeColor]="'accent'">group</mat-icon>
+        <mat-icon [class.smaller-badge-text]="shouldUseSmallerBadgeText" [matBadgeHidden]="!showUserAmount" [matBadge]="userAmount" [matBadgeColor]="'accent'">group</mat-icon>
     </button>
 </ng-template>
 

--- a/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.scss
+++ b/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.scss
@@ -42,6 +42,12 @@
         right: 0.5em;
         bottom: 0;
     }
+
+    .smaller-badge-text {
+        .mat-badge-content {
+            font-size: 9px;
+        }
+    }
 }
 
 .prev-content {

--- a/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.ts
@@ -48,7 +48,7 @@ export class CommitteeMeetingPreviewComponent {
     }
 
     public get showUserAmount(): boolean {
-        return (this.userAmount > 0 && this.userAmount < 10000) || false;
+        return (this.userAmount > 0 && this.userAmount < 100000) || false;
     }
 
     public get isTemplateMeeting(): boolean {

--- a/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.ts
@@ -35,12 +35,16 @@ export class CommitteeMeetingPreviewComponent {
         return this.meeting?.description || ``;
     }
 
+    public get shouldUseSmallerBadgeText(): boolean {
+        return this.userAmount > 999;
+    }
+
     public get userAmount(): number {
         return this.meeting?.user_ids?.length || 0;
     }
 
     public get showUserAmount(): boolean {
-        return (this.userAmount > 0 && this.userAmount < 1000) || false;
+        return (this.userAmount > 0 && this.userAmount < 10000) || false;
     }
 
     public get isTemplateMeeting(): boolean {

--- a/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.ts
@@ -36,11 +36,15 @@ export class CommitteeMeetingPreviewComponent {
     }
 
     public get shouldUseSmallerBadgeText(): boolean {
-        return this.userAmount > 999;
+        return this.userAmount > 9999;
     }
 
     public get userAmount(): number {
         return this.meeting?.user_ids?.length || 0;
+    }
+
+    public get formattedUserAmount(): string {
+        return this.userAmount < 1000 ? `${this.userAmount}` : `>${Math.floor(this.userAmount / 1000)}k`;
     }
 
     public get showUserAmount(): boolean {


### PR DESCRIPTION
… up to 9999

closes #1410 

Part of the problem was, that the badges (i.e. the blue circles) weren't big enough to fit 4-digit numbers. They'd be displayed as something like '1...', '2...', and so on, which is why such numbers were hidden.

This PR addresses this by making the font size smaller for numbers that are bigger than 9999 and raising the maximum limit to 99999 (after which the numbers will still be hidden). Numbers bigger than 999 will be shown as >1k, >2k, >3k, ...