### PR TITLE
Now shows meeting time in forwarding dialog

### DIFF
--- a/client/src/app/gateways/presenter/get-forwarding-meetings-presenter.service.ts
+++ b/client/src/app/gateways/presenter/get-forwarding-meetings-presenter.service.ts
@@ -11,6 +11,8 @@ interface GetForwardMeetingsPresenterPayload {
 export interface GetForwardingMeetingsPresenterMeeting {
     id: string;
     name: string;
+    start_time: number;
+    end_time: number;
 }
 
 export interface GetForwardingMeetingsPresenter {

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -10,19 +10,11 @@
                     [(ngModel)]="checkboxStateMap[meeting.id]"
                     (change)="onChangeCheckbox($event)"
                 >
-                    <os-icon-container
-                        [swap]="true"
-                        [icon]="isDefaultMeetingFor(meeting, committee) ? 'star' : 'star_outline'"
-                        iconTooltip="{{
-                            (isDefaultMeetingFor(meeting, committee) ? 'Default meeting' : '') | translate
-                        }}"
-                    >
-                        {{ meeting.name }}
-                        <span *ngIf="meeting.start_time || meeting.end_time">
-                            &nbsp;&middot;&nbsp;
-                            <os-meeting-time [startTime]="meeting.start_time" [endTime]="meeting.end_time"></os-meeting-time>
-                        </span>
-                    </os-icon-container>
+                    {{ meeting.name }}
+                    <span *ngIf="meeting.start_time || meeting.end_time">
+                        &nbsp;&middot;&nbsp;
+                        <os-meeting-time [startTime]="meeting.start_time" [endTime]="meeting.end_time"></os-meeting-time>
+                    </span>
                 </mat-checkbox>
             </div>
         </div>

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -18,7 +18,7 @@
                         }}"
                     >
                         {{ meeting.name }}
-                        <span *ngIf="meeting.start_time && meeting.end_time">
+                        <span *ngIf="meeting.start_time || meeting.end_time">
                             &nbsp;&middot;&nbsp;
                             <os-meeting-time [startTime]="meeting.start_time" [endTime]="meeting.end_time"></os-meeting-time>
                         </span>

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -18,6 +18,10 @@
                         }}"
                     >
                         {{ meeting.name }}
+                        <span *ngIf="getMeeting(meeting)">
+                            &nbsp;&middot;&nbsp;
+                            <os-meeting-time [meeting]="getMeeting(meeting)"></os-meeting-time>
+                        </span>
                     </os-icon-container>
                 </mat-checkbox>
             </div>

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -18,10 +18,10 @@
                         }}"
                     >
                         {{ meeting.name }}
+                        <span *ngIf="meeting.start_time && meeting.end_time">
                             &nbsp;&middot;&nbsp;
-                            {{ meeting.start_time | localizedDate: 'll' }}
-                            &nbsp;-&nbsp;
-                            {{ meeting.end_time | localizedDate: 'll' }}
+                            <os-meeting-time [startTime]="meeting.start_time" [endTime]="meeting.end_time"></os-meeting-time>
+                        </span>
                     </os-icon-container>
                 </mat-checkbox>
             </div>

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -18,10 +18,10 @@
                         }}"
                     >
                         {{ meeting.name }}
-                        <span *ngIf="getMeeting(meeting)">
                             &nbsp;&middot;&nbsp;
-                            <os-meeting-time [meeting]="getMeeting(meeting)"></os-meeting-time>
-                        </span>
+                            {{ meeting.start_time | localizedDate: 'll' }}
+                            &nbsp;-&nbsp;
+                            {{ meeting.end_time | localizedDate: 'll' }}
                     </os-icon-container>
                 </mat-checkbox>
             </div>

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -10,7 +10,6 @@ import {
 } from 'src/app/gateways/presenter';
 import { ActiveMeetingService } from 'src/app/site/pages/meetings/services/active-meeting.service';
 import { MeetingControllerService } from 'src/app/site/pages/meetings/services/meeting-controller.service';
-import { ViewMeeting } from 'src/app/site/pages/meetings/view-models/view-meeting';
 
 @Component({
     selector: `os-motion-forward-dialog`,
@@ -59,10 +58,6 @@ export class MotionForwardDialogComponent implements OnInit {
 
     public isActiveMeeting(meeting: GetForwardingMeetingsPresenterMeeting): boolean {
         return +meeting.id === this.activeMeeting.meetingId;
-    }
-
-    public getMeeting(meeting: GetForwardingMeetingsPresenterMeeting): ViewMeeting | null {
-        return this.meetingController.getViewModel(+meeting.id) ?? null;
     }
 
     private initStateMap(): void {

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -9,6 +9,8 @@ import {
     GetForwardingMeetingsPresenterService
 } from 'src/app/gateways/presenter';
 import { ActiveMeetingService } from 'src/app/site/pages/meetings/services/active-meeting.service';
+import { MeetingControllerService } from 'src/app/site/pages/meetings/services/meeting-controller.service';
+import { ViewMeeting } from 'src/app/site/pages/meetings/view-models/view-meeting';
 
 @Component({
     selector: `os-motion-forward-dialog`,
@@ -28,7 +30,8 @@ export class MotionForwardDialogComponent implements OnInit {
     public constructor(
         private dialogRef: MatDialogRef<MotionForwardDialogComponent, Id[]>,
         private presenter: GetForwardingMeetingsPresenterService,
-        private activeMeeting: ActiveMeetingService
+        private activeMeeting: ActiveMeetingService,
+        private meetingController: MeetingControllerService
     ) {}
 
     public async ngOnInit(): Promise<void> {
@@ -56,6 +59,10 @@ export class MotionForwardDialogComponent implements OnInit {
 
     public isActiveMeeting(meeting: GetForwardingMeetingsPresenterMeeting): boolean {
         return +meeting.id === this.activeMeeting.meetingId;
+    }
+
+    public getMeeting(meeting: GetForwardingMeetingsPresenterMeeting): ViewMeeting | null {
+        return this.meetingController.getViewModel(+meeting.id) ?? null;
     }
 
     private initStateMap(): void {

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -37,6 +37,7 @@ export class MotionForwardDialogComponent implements OnInit {
     public async ngOnInit(): Promise<void> {
         const result = await this.presenter.call({ meeting_id: this.activeMeeting.meetingId! });
         this.committeesSubject.next(result);
+        console.log(`COMMITTEES: `, result);
         this.selectedMeetings = new Set(this.getDefaultMeetingsIds());
         this.initStateMap();
     }
@@ -63,6 +64,11 @@ export class MotionForwardDialogComponent implements OnInit {
 
     public getMeeting(meeting: GetForwardingMeetingsPresenterMeeting): ViewMeeting | null {
         return this.meetingController.getViewModel(+meeting.id) ?? null;
+    }
+
+    public getConvertedTime(timestamp: number): string {
+        console.log(`TIMESTAMP: `, timestamp.toLocaleString().split(` `)[0]);
+        return timestamp.toLocaleString().split(` `)[0];
     }
 
     private initStateMap(): void {

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -37,7 +37,6 @@ export class MotionForwardDialogComponent implements OnInit {
     public async ngOnInit(): Promise<void> {
         const result = await this.presenter.call({ meeting_id: this.activeMeeting.meetingId! });
         this.committeesSubject.next(result);
-        console.log(`COMMITTEES: `, result);
         this.selectedMeetings = new Set(this.getDefaultMeetingsIds());
         this.initStateMap();
     }
@@ -64,11 +63,6 @@ export class MotionForwardDialogComponent implements OnInit {
 
     public getMeeting(meeting: GetForwardingMeetingsPresenterMeeting): ViewMeeting | null {
         return this.meetingController.getViewModel(+meeting.id) ?? null;
-    }
-
-    public getConvertedTime(timestamp: number): string {
-        console.log(`TIMESTAMP: `, timestamp.toLocaleString().split(` `)[0]);
-        return timestamp.toLocaleString().split(` `)[0];
     }
 
     private initStateMap(): void {

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -49,13 +49,6 @@ export class MotionForwardDialogComponent implements OnInit {
         this.selectedMeetings[fn](+source.value);
     }
 
-    public isDefaultMeetingFor(
-        meeting: GetForwardingMeetingsPresenterMeeting,
-        committee: GetForwardingMeetingsPresenter
-    ): boolean {
-        return +meeting.id === committee.default_meeting_id;
-    }
-
     public isActiveMeeting(meeting: GetForwardingMeetingsPresenterMeeting): boolean {
         return +meeting.id === this.activeMeeting.meetingId;
     }

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/motion-forward-dialog.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/motion-forward-dialog.module.ts
@@ -6,6 +6,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { IconContainerModule } from 'src/app/ui/modules/icon-container';
+import { MeetingTimeModule } from 'src/app/ui/modules/meeting-time/meeting-time.module';
 
 import { MotionForwardDialogComponent } from './components/motion-forward-dialog/motion-forward-dialog.component';
 
@@ -16,6 +17,7 @@ import { MotionForwardDialogComponent } from './components/motion-forward-dialog
         MatCheckboxModule,
         MatDialogModule,
         MatButtonModule,
+        MeetingTimeModule,
         FormsModule,
         IconContainerModule,
         OpenSlidesTranslationModule.forChild()

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/motion-forward-dialog.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/motion-forward-dialog.module.ts
@@ -6,7 +6,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { IconContainerModule } from 'src/app/ui/modules/icon-container';
-import { MeetingTimeModule } from 'src/app/ui/modules/meeting-time/meeting-time.module';
+import { PipesModule } from 'src/app/ui/pipes';
 
 import { MotionForwardDialogComponent } from './components/motion-forward-dialog/motion-forward-dialog.component';
 
@@ -17,9 +17,9 @@ import { MotionForwardDialogComponent } from './components/motion-forward-dialog
         MatCheckboxModule,
         MatDialogModule,
         MatButtonModule,
-        MeetingTimeModule,
         FormsModule,
         IconContainerModule,
+        PipesModule,
         OpenSlidesTranslationModule.forChild()
     ]
 })

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/motion-forward-dialog.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/motion-forward-dialog.module.ts
@@ -6,7 +6,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { IconContainerModule } from 'src/app/ui/modules/icon-container';
-import { PipesModule } from 'src/app/ui/pipes';
+import { MeetingTimeModule } from 'src/app/ui/modules/meeting-time/meeting-time.module';
 
 import { MotionForwardDialogComponent } from './components/motion-forward-dialog/motion-forward-dialog.component';
 
@@ -19,7 +19,7 @@ import { MotionForwardDialogComponent } from './components/motion-forward-dialog
         MatButtonModule,
         FormsModule,
         IconContainerModule,
-        PipesModule,
+        MeetingTimeModule,
         OpenSlidesTranslationModule.forChild()
     ]
 })


### PR DESCRIPTION
Closes #1181 

Currently only works if the meetings have been loaded already, which is suboptimal, because it is possible that the user hasn't loaded them/isn't allowed to load them.

start- and end_time should be added to the `get_forwarding_meetings`-presenter response