### PR TITLE
Validation of meeting time

### DIFF
--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/committee-detail-meeting.module.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/committee-detail-meeting.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { AccountSearchSelectorModule } from 'src/app/site/pages/organization/modules/account-search-selector';
@@ -28,6 +29,7 @@ import { MeetingImportComponent } from './components/meeting-import/meeting-impo
         MatFormFieldModule,
         MatCardModule,
         MatInputModule,
+        MatIconModule,
         AccountSearchSelectorModule,
         SearchSelectorModule,
         ReactiveFormsModule,

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
@@ -1,7 +1,7 @@
 <os-head-bar
     [nav]="false"
     [editMode]="true"
-    [isSaveButtonEnabled]="meetingForm?.valid"
+    [isSaveButtonEnabled]="isValid"
     [saveAction]="getSaveAction()"
     (cancelEditEvent)="onCancel()"
 >
@@ -57,6 +57,17 @@
             <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
             <mat-datepicker #endDatePicker></mat-datepicker>
         </mat-form-field>
+
+        <div class="potential-warning">
+            <ng-container *ngIf="!isTimeValid">
+                <mat-icon inline color="warn">
+                    warning
+                </mat-icon>
+                <i class="foreground-warn">
+                    {{ timeWarning | translate }}
+                </i>
+            </ng-container>
+        </div>
 
         <mat-form-field>
             <mat-label>{{ 'Participants' | translate }}</mat-label>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
@@ -46,25 +46,17 @@
 
         <mat-form-field>
             <mat-label>{{ 'Start date' | translate }}</mat-label>
-            <input matInput [matDatepicker]="startDatePicker" formControlName="start_time" />
+            <input matInput [matDatepicker]="startDatePicker" formControlName="start_time" (click)="startDatePicker.open()" readonly />
             <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
             <mat-datepicker #startDatePicker></mat-datepicker>
         </mat-form-field>
 
         <mat-form-field>
             <mat-label>{{ 'End date' | translate }}</mat-label>
-            <input matInput [matDatepicker]="endDatePicker" formControlName="end_time" />
+            <input matInput [matDatepicker]="endDatePicker" formControlName="end_time" (click)="endDatePicker.open()" readonly />
             <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
             <mat-datepicker #endDatePicker></mat-datepicker>
         </mat-form-field>
-
-        <div class="potential-warning">
-            <ng-container *ngIf="!isTimeValid">
-                <i>
-                    {{ timeMessage | translate }}
-                </i>
-            </ng-container>
-        </div>
 
         <mat-form-field>
             <mat-label>{{ 'Participants' | translate }}</mat-label>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
@@ -60,11 +60,8 @@
 
         <div class="potential-warning">
             <ng-container *ngIf="!isTimeValid">
-                <mat-icon inline color="warn">
-                    warning
-                </mat-icon>
-                <i class="foreground-warn">
-                    {{ timeWarning | translate }}
+                <i>
+                    {{ timeMessage | translate }}
                 </i>
             </ng-container>
         </div>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.scss
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.scss
@@ -12,7 +12,3 @@
         display: block;
     }
 }
-
-.potential-warning {
-    height: 25px;
-}

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.scss
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.scss
@@ -12,3 +12,7 @@
         display: block;
     }
 }
+
+.potential-warning {
+    height: 25px;
+}

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
@@ -60,15 +60,6 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
 
     public availableMeetingsObservable: Observable<Selectable[]> | null = null;
 
-    public get timeMessage(): string {
-        if (this._lastDateSet === `start`) {
-            return _(`Due to inverted date settings, the start date's value will be used for both dates.`);
-        } else if (this._lastDateSet === `end`) {
-            return _(`Due to inverted date settings, the end date's value will be used for both dates.`);
-        }
-        return _(`The end date needs to be later than the start date.`);
-    }
-
     public get isValid(): boolean {
         return this.meetingForm?.valid;
     }
@@ -116,10 +107,6 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
      */
     private operatingUser: ViewUser | null = null;
 
-    // private _timeEditingTimeoutId: NodeJS.Timeout;
-
-    private _lastDateSet: `start` | `end`;
-
     public constructor(
         componentServiceCollector: ComponentServiceCollectorService,
         protected override translate: TranslateService,
@@ -154,8 +141,8 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
                 this.operatingUser = user;
                 this.onAfterCreateForm();
             }),
-            this.meetingForm.controls[`start_time`].valueChanges.subscribe(start_time => (this._lastDateSet = `start`)),
-            this.meetingForm.controls[`end_time`].valueChanges.subscribe(end_time => (this._lastDateSet = `end`))
+            this.meetingForm.controls[`start_time`].valueChanges.subscribe(start_time => this.makeDatesValid(false)),
+            this.meetingForm.controls[`end_time`].valueChanges.subscribe(end_time => this.makeDatesValid(true))
         );
 
         this.availableMeetingsObservable = this.orga.organizationObservable.pipe(
@@ -177,7 +164,6 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
     }
 
     public async onSubmit(): Promise<void> {
-        this.makeDatesValid();
         if (this.isCreateView) {
             await this.doCreateMeeting();
         } else {
@@ -369,14 +355,13 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
         this.router.navigate([`committees`, this.committeeId]);
     }
 
-    private makeDatesValid(): void {
+    private makeDatesValid(endDateChanged: boolean): void {
         if (!this.isTimeValid) {
-            if (this._lastDateSet === `end`) {
+            if (endDateChanged) {
                 this.meetingForm.controls[`start_time`].setValue(this.meetingForm.get(`end_time`).value);
             } else {
                 this.meetingForm.controls[`end_time`].setValue(this.meetingForm.get(`start_time`).value);
             }
         }
-        this._lastDateSet = null;
     }
 }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
@@ -60,6 +60,21 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
 
     public availableMeetingsObservable: Observable<Selectable[]> | null = null;
 
+    public readonly timeWarning: string = _(`The end date needs to be later than the start date.`);
+
+    public get isValid(): boolean {
+        return this.meetingForm?.valid && this.isTimeValid;
+    }
+
+    public get isTimeValid(): boolean {
+        const start = this.meetingForm?.get(`start_time`).value;
+        const end = this.meetingForm?.get(`end_time`).value;
+        if (!!start && (!!end || end === 0)) {
+            return start < end;
+        }
+        return true;
+    }
+
     private get isJitsiManipulationAllowed(): boolean {
         return !this.isCreateView && this.operator.isSuperAdmin;
     }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
@@ -70,7 +70,7 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
         const start = this.meetingForm?.get(`start_time`).value;
         const end = this.meetingForm?.get(`end_time`).value;
         if (!!start && (!!end || end === 0)) {
-            return start < end;
+            return start <= end;
         }
         return true;
     }


### PR DESCRIPTION
Closes #1368 

It should now be impossible to create a meeting with an end-time that is earlier than the start time.
This should be the same for editing meetings