### PR TITLE
fix ammendment text import

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-import/services/motion-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-import/services/motion-import.service.ts
@@ -21,6 +21,7 @@ import { MotionsImportServiceModule } from './motions-import-service.module';
 const CATEGORY_PROPERTY = `category`;
 const MOTION_BLOCK_PROPERTY = `motion_block`;
 const TAG_PROPERTY = `tags`;
+const TEXT_PROPERTY = `text`;
 const SUBMITTER_PROPERTY = `submitters`;
 const SUPPORTER_PROPERTY = `supporters`;
 
@@ -97,5 +98,15 @@ export class MotionImportService extends BaseImportService<Motion> {
                 importedAs: SUPPORTER_PROPERTY
             })
         };
+    }
+
+    protected override pipeParseValue(value: string, header: keyof Motion): any {
+        if (header === TEXT_PROPERTY) {
+            const isSurroundedByHTMLTags = /^<\w+[^>]*>[\w\W]*?<\/\w>$/.test(value);
+
+            if (!isSurroundedByHTMLTags) {
+                return `<p>${value.replace(/\n([ \t]*\n)+/g, `</p><p>`).replace(/\n/g, `<br />`)}</p>`;
+            }
+        }
     }
 }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-import/services/motion-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-import/services/motion-import.service.ts
@@ -101,7 +101,7 @@ export class MotionImportService extends BaseImportService<Motion> {
     }
 
     protected override pipeParseValue(value: string, header: keyof Motion): any {
-        if (header === TEXT_PROPERTY) {
+        if (header === TEXT_PROPERTY && value) {
             const isSurroundedByHTMLTags = /^<\w+[^>]*>[\w\W]*?<\/\w>$/.test(value);
 
             if (!isSurroundedByHTMLTags) {


### PR DESCRIPTION
resolves #1407

For the amendment line selection the text needs to be surrounded by HTML tags. This PR adds surrounding `p` tags to motion text if not existing and tries to divide the text into sections.  