### PR TITLE
Implement: Disabling voteweight hides corresponding filter and sort options

### DIFF
--- a/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
+++ b/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
@@ -32,9 +32,12 @@ interface RepositoryFilterConfig<OV extends BaseViewModel, V> {
 @Directive()
 export abstract class BaseFilterListService<V extends BaseViewModel> implements FilterListService<V> {
     public get filterDefinitionsObservable(): Observable<OsFilter<V>[]> {
-        return this._filterDefinitionsSubject.pipe(distinctUntilChanged(), map(definitions => {
-            return definitions.filter(definition => !this.shouldHideOption(definition))
-        }));
+        return this._filterDefinitionsSubject.pipe(
+            distinctUntilChanged(),
+            map(definitions => {
+                return definitions.filter(definition => !this.shouldHideOption(definition));
+            })
+        );
     }
 
     /**
@@ -391,9 +394,14 @@ export abstract class BaseFilterListService<V extends BaseViewModel> implements 
         return [];
     }
 
-    private shouldHideOption(option: OsFilter<V> | OsFilterIndicator<V>): boolean {
+    private shouldHideOption(option: OsFilter<V> | OsFilterIndicator<V>, update = true): boolean {
         const setting = this.getHideFilterSettings().find(setting => setting.property === option.property);
-        return setting ? setting.shouldHideFn() : false;
+        const settingHidden = setting ? setting.shouldHideFn() : false;
+        if (setting && settingHidden !== setting.currentlyHidden && update) {
+            setting.currentlyHidden = settingHidden;
+            this.updateFilteredData();
+        }
+        return settingHidden;
     }
 
     private async loadFilters(): Promise<OsFilter<V>[] | null> {
@@ -562,7 +570,9 @@ export abstract class BaseFilterListService<V extends BaseViewModel> implements 
             } else {
                 const activeFilters = this.filterDefinitions.filter(filter => !!filter.count);
                 filteredData = this._inputData.filter(item =>
-                    activeFilters.every(filter => this.isPassingFilter(item, filter) && !this.shouldHideOption(filter))
+                    activeFilters.every(
+                        filter => this.isPassingFilter(item, filter) && !this.shouldHideOption(filter, false)
+                    )
                 );
             }
         }

--- a/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
+++ b/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
@@ -4,7 +4,7 @@ import { ViewModelListProvider } from 'src/app/ui/base/view-model-list-provider'
 import { ActiveFiltersStoreService, FilterListService } from 'src/app/ui/modules/list/definitions/filter-service';
 
 import { BaseViewModel } from '../base-view-model';
-import { OsFilter, OsFilterIndicator, OsFilterOption, OsFilterOptionCondition } from './os-filter';
+import { OsFilter, OsFilterIndicator, OsFilterOption, OsFilterOptionCondition, OsHideFilterSetting } from './os-filter';
 
 interface RepositoryFilterConfig<OV extends BaseViewModel, V> {
     /**
@@ -32,7 +32,9 @@ interface RepositoryFilterConfig<OV extends BaseViewModel, V> {
 @Directive()
 export abstract class BaseFilterListService<V extends BaseViewModel> implements FilterListService<V> {
     public get filterDefinitionsObservable(): Observable<OsFilter<V>[]> {
-        return this._filterDefinitionsSubject.pipe(distinctUntilChanged());
+        return this._filterDefinitionsSubject.pipe(distinctUntilChanged(), map(definitions => {
+            return definitions.filter(definition => !this.shouldHideOption(definition))
+        }));
     }
 
     /**
@@ -68,7 +70,7 @@ export abstract class BaseFilterListService<V extends BaseViewModel> implements 
      * get stacked filters
      */
     public get filterStack(): OsFilterIndicator<V>[] {
-        return this._filterStack;
+        return this._filterStack.filter(definition => !this.shouldHideOption(definition));
     }
 
     public get unfilteredCountObservable(): Observable<number> {
@@ -382,6 +384,18 @@ export abstract class BaseFilterListService<V extends BaseViewModel> implements 
      */
     protected abstract getFilterDefinitions(): OsFilter<V>[];
 
+    /**
+     * Overriding this method allows a subclass to provide functions which define when a filter should neither be shown nor applied.
+     */
+    protected getHideFilterSettings(): OsHideFilterSetting<V>[] {
+        return [];
+    }
+
+    private shouldHideOption(option: OsFilter<V> | OsFilterIndicator<V>): boolean {
+        const setting = this.getHideFilterSettings().find(setting => setting.property === option.property);
+        return setting ? setting.shouldHideFn() : false;
+    }
+
     private async loadFilters(): Promise<OsFilter<V>[] | null> {
         return this.parseFilters(await this.activeFiltersStore.load<V>(this.storageKey));
     }
@@ -548,7 +562,7 @@ export abstract class BaseFilterListService<V extends BaseViewModel> implements 
             } else {
                 const activeFilters = this.filterDefinitions.filter(filter => !!filter.count);
                 filteredData = this._inputData.filter(item =>
-                    activeFilters.every(filter => this.isPassingFilter(item, filter))
+                    activeFilters.every(filter => this.isPassingFilter(item, filter) && !this.shouldHideOption(filter))
                 );
             }
         }

--- a/client/src/app/site/base/base-filter.service/os-filter.ts
+++ b/client/src/app/site/base/base-filter.service/os-filter.ts
@@ -45,6 +45,7 @@ export interface OsFilterIndicator<V> {
 export interface OsHideFilterSetting<V> {
     property: keyof V;
     shouldHideFn: () => boolean;
+    currentlyHidden?: boolean;
 }
 
 /**

--- a/client/src/app/site/base/base-filter.service/os-filter.ts
+++ b/client/src/app/site/base/base-filter.service/os-filter.ts
@@ -42,6 +42,11 @@ export interface OsFilterIndicator<V> {
     option: OsFilterOption;
 }
 
+export interface OsHideFilterSetting<V> {
+    property: keyof V;
+    shouldHideFn: () => boolean;
+}
+
 /**
  * Define the type of a filter condition
  */

--- a/client/src/app/site/base/base-sort.service/os-sort.ts
+++ b/client/src/app/site/base/base-sort.service/os-sort.ts
@@ -18,6 +18,12 @@ export interface OsSortingOption<T> {
     sortFn?: (itemA: T, itemB: T, ascending: boolean, intl?: Intl.Collator) => number;
 }
 
+export interface OsHideSortingOptionSetting<T> {
+    property: keyof T;
+    shouldHideFn: () => boolean;
+    currentlyHidden?: boolean;
+}
+
 /**
  * An array of properties may be given to define secondary options
  *

--- a/client/src/app/site/guards/permission.guard.ts
+++ b/client/src/app/site/guards/permission.guard.ts
@@ -31,7 +31,6 @@ export class PermissionGuard implements CanLoad {
             return false;
         }
         if (route.data && !(await this.authCheck.isAuthorized(route.data))) {
-            console.log(`LOG: 5`);
             this.reroute.handleForbiddenRoute(route.data, segments, url);
             return false;
         }

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/services/participant-list-filter.service/participant-list-filter.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/services/participant-list-filter.service/participant-list-filter.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { OsFilter } from 'src/app/site/base/base-filter.service';
+import { OsFilter, OsHideFilterSetting } from 'src/app/site/base/base-filter.service';
 import { BaseMeetingFilterListService } from 'src/app/site/pages/meetings/base/base-meeting-filter-list.service';
 import { MeetingActiveFiltersService } from 'src/app/site/pages/meetings/services/meeting-active-filters.service';
+import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { DelegationType } from 'src/app/site/pages/meetings/view-models/delegation-type';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 
@@ -24,16 +25,20 @@ export class ParticipantListFilterService extends BaseMeetingFilterListService<V
         options: []
     };
 
+    private _voteWeightEnabled: boolean;
+
     public constructor(
         store: MeetingActiveFiltersService,
         groupRepo: GroupControllerService,
-        private translate: TranslateService
+        private translate: TranslateService,
+        private meetingSettings: MeetingSettingsService
     ) {
         super(store);
         this.updateFilterForRepo({
             repo: groupRepo,
             filter: this.userGroupFilterOptions
         });
+        this.meetingSettings.get(`users_enable_vote_weight`).subscribe(value => this._voteWeightEnabled = value);;
     }
 
     /**
@@ -101,5 +106,17 @@ export class ParticipantListFilterService extends BaseMeetingFilterListService<V
             }
         ];
         return staticFilterOptions.concat(this.userGroupFilterOptions);
+    }
+
+    protected override getHideFilterSettings(): OsHideFilterSetting<ViewUser>[] {
+        return [
+            {
+                property: `isVoteWeightOne`,
+                shouldHideFn: () => {
+                    console.log(`LOG: `, this._voteWeightEnabled)
+                    return !this._voteWeightEnabled
+                }
+            }
+        ]
     }
 }

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/services/participant-list-filter.service/participant-list-filter.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/services/participant-list-filter.service/participant-list-filter.service.ts
@@ -38,7 +38,7 @@ export class ParticipantListFilterService extends BaseMeetingFilterListService<V
             repo: groupRepo,
             filter: this.userGroupFilterOptions
         });
-        this.meetingSettings.get(`users_enable_vote_weight`).subscribe(value => this._voteWeightEnabled = value);;
+        this.meetingSettings.get(`users_enable_vote_weight`).subscribe(value => (this._voteWeightEnabled = value));
     }
 
     /**
@@ -113,10 +113,9 @@ export class ParticipantListFilterService extends BaseMeetingFilterListService<V
             {
                 property: `isVoteWeightOne`,
                 shouldHideFn: () => {
-                    console.log(`LOG: `, this._voteWeightEnabled)
-                    return !this._voteWeightEnabled
+                    return !this._voteWeightEnabled;
                 }
             }
-        ]
+        ];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/services/participant-list-sort.service/participant-list-sort.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/services/participant-list-sort.service/participant-list-sort.service.ts
@@ -1,7 +1,13 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { StorageService } from 'src/app/gateways/storage.service';
-import { BaseSortListService, OsSortingDefinition, OsSortingOption } from 'src/app/site/base/base-sort.service';
+import {
+    BaseSortListService,
+    OsHideSortingOptionSetting,
+    OsSortingDefinition,
+    OsSortingOption
+} from 'src/app/site/base/base-sort.service';
+import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 
 import { ParticipantListServiceModule } from '../participant-list-service.module';
@@ -32,8 +38,15 @@ export class ParticipantListSortService extends BaseSortListService<ViewUser> {
         // TODO email send?
     ];
 
-    public constructor(translate: TranslateService, store: StorageService) {
+    private _voteWeightEnabled: boolean;
+
+    public constructor(
+        translate: TranslateService,
+        store: StorageService,
+        private meetingSettings: MeetingSettingsService
+    ) {
         super(translate, store);
+        this.meetingSettings.get(`users_enable_vote_weight`).subscribe(value => (this._voteWeightEnabled = value));
     }
 
     /**
@@ -53,5 +66,14 @@ export class ParticipantListSortService extends BaseSortListService<ViewUser> {
             sortProperty: [`first_name`, `last_name`],
             sortAscending: true
         };
+    }
+
+    protected override getHideSortingOptionSettings(): OsHideSortingOptionSetting<ViewUser>[] {
+        return [
+            {
+                property: `vote_weight`,
+                shouldHideFn: () => !this._voteWeightEnabled
+            }
+        ];
     }
 }


### PR DESCRIPTION
Closes #848 

Somewhat got it to work for filters

TODO:

- [x] 1. Open listview with voteweights enabled, select a voteweight filter
      2. Go to settings and disable
      3. Gpen listview
      4. Enable
      5. Open listview, filter will start being loaded, then it will show the list as if the filter was still hidden
      6. Reloading makes filter work
- [x] Implement the same thing for the sorting service