### PR TITLE
Made meeting-internal delete use handle separately route

### DIFF
--- a/client/src/app/gateways/repositories/base-repository.ts
+++ b/client/src/app/gateways/repositories/base-repository.ts
@@ -441,9 +441,9 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
      * @param actions
      * @returns
      */
-    protected async sendActionsToBackend(actions: ActionRequest[]): Promise<any> {
+    protected async sendActionsToBackend(actions: ActionRequest[], handle_separately = false): Promise<any> {
         try {
-            return await this.actions.sendRequests(actions);
+            return await this.actions.sendRequests(actions, handle_separately);
         } catch (e) {
             throw e;
         }

--- a/client/src/app/gateways/repositories/users/user-repository.service.ts
+++ b/client/src/app/gateways/repositories/users/user-repository.service.ts
@@ -160,10 +160,10 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
         return this.sendActionToBackend(UserAction.UPDATE_SELF, payload);
     }
 
-    public delete(...users: Identifiable[]): Action<void> {
+    public delete(users: Identifiable[], handle_separately = false): Action<void> {
         this.preventInDemo();
         const data: any[] = users.map(user => ({ id: user.id }));
-        return this.actions.create({ action: UserAction.DELETE, data });
+        return this.actions.createFromArray([{ action: UserAction.DELETE, data }], handle_separately);
     }
 
     public assignMeetings(user: Identifiable, data: AssignMeetingsPayload): Action<AssignMeetingsResult> {

--- a/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
@@ -84,8 +84,8 @@ export class ParticipantControllerService extends BaseMeetingControllerService<V
         return this.repo.updateSelf(patch, participant);
     }
 
-    public delete(...participants: Identifiable[]): Action<void> {
-        return this.repo.delete(...participants) as Action<void>;
+    public delete(participants: Identifiable[], handle_separately = false): Action<void> {
+        return this.repo.delete(participants, handle_separately) as Action<void>;
     }
 
     public bulkGenerateNewPasswords(...users: ViewUser[]): Promise<void> {
@@ -162,7 +162,7 @@ export class ParticipantControllerService extends BaseMeetingControllerService<V
         const answer = await firstValueFrom(prompt.afterClosed());
         if (answer) {
             const patch = { group_$_ids: { [this.activeMeetingId!]: [] } };
-            await this.delete(...toDeleteUsers)
+            await this.delete(toDeleteUsers, true)
                 .concat(this.update(patch, ...toRemoveUsers))
                 .resolve();
         }

--- a/client/src/app/site/pages/organization/pages/accounts/services/common/account-controller.service.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/services/common/account-controller.service.ts
@@ -48,7 +48,7 @@ export class AccountControllerService extends BaseController<ViewUser, User> {
         const prompt = await this.userDeleteDialog.open({ toDelete, toRemove: [] });
         const answer = await firstValueFrom(prompt.afterClosed());
         if (answer) {
-            await this.repo.delete(...toDelete).resolve();
+            await this.repo.delete(toDelete).resolve();
         }
         return answer as boolean;
     }

--- a/client/src/app/site/services/user-controller.service.ts
+++ b/client/src/app/site/services/user-controller.service.ts
@@ -56,7 +56,7 @@ export class UserControllerService extends BaseController<ViewUser, User> {
     }
 
     public async delete(...userIds: Identifiable[]): Promise<void> {
-        await this.repo.delete(...userIds).resolve();
+        await this.repo.delete(userIds).resolve();
     }
 
     public setPassword(user: Identifiable, password: string, setAsDefault?: boolean): Promise<void> {


### PR DESCRIPTION
Closes #1523 

This solves the problem described in OpenSlides/openslides-backend#1426 where trying to remove multiple participants from a meeting using multiselection would cause datastore broken lock errors when among the selected users the following was true:
There is at least one group that has:
1. At least two selected users
2. Among the selected users of that group there is at least one who is in another meeting, and at least one who is in no other meeting.