### PR TITLE
Beautification of the password reset page

### DIFF
--- a/client/src/app/site/pages/login/pages/reset-password-confirm/components/reset-password-confirm/reset-password-confirm.component.scss
+++ b/client/src/app/site/pages/login/pages/reset-password-confirm/components/reset-password-confirm/reset-password-confirm.component.scss
@@ -1,6 +1,9 @@
 h3 {
     margin-top: 0;
     font-weight: normal;
+    width: 100%;
+    margin-bottom: 30px;
+    text-align: center;
 }
 
 mat-form-field {
@@ -9,9 +12,12 @@ mat-form-field {
 
 .submit-button {
     margin-top: 30px;
-    width: 60%;
     margin-left: auto;
     margin-right: auto;
+}
+
+button {
+    width: 100%;
 }
 
 .form-wrapper {

--- a/client/src/app/site/pages/login/pages/reset-password-confirm/components/reset-password-confirm/reset-password-confirm.component.ts
+++ b/client/src/app/site/pages/login/pages/reset-password-confirm/components/reset-password-confirm/reset-password-confirm.component.ts
@@ -93,7 +93,7 @@ export class ResetPasswordConfirmComponent extends BaseComponent implements OnIn
                     duration: 0
                 }
             );
-            this.router.navigate([`..`]);
+            this.router.navigate([`/login`]);
         } catch (e) {
             console.log(`error`, e);
         }

--- a/client/src/app/site/pages/login/pages/reset-password-confirm/reset-password-confirm.module.ts
+++ b/client/src/app/site/pages/login/pages/reset-password-confirm/reset-password-confirm.module.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 
 import { ResetPasswordConfirmComponent } from './components/reset-password-confirm/reset-password-confirm.component';
@@ -14,6 +16,8 @@ import { ResetPasswordConfirmRoutingModule } from './reset-password-confirm-rout
         ResetPasswordConfirmRoutingModule,
         ReactiveFormsModule,
         MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule,
         OpenSlidesTranslationModule.forChild()
     ]
 })

--- a/client/src/app/site/pages/login/pages/reset-password/components/reset-password/reset-password.component.html
+++ b/client/src/app/site/pages/login/pages/reset-password/components/reset-password/reset-password.component.html
@@ -4,6 +4,7 @@
         <mat-form-field>
             <input
                 matInput
+                osAutofocus
                 required
                 placeholder="{{ 'Email' | translate }}"
                 formControlName="email"
@@ -20,7 +21,7 @@
             mat-raised-button
             color="accent"
             class="submit-button"
-            [disabled]="resetPasswordForm.invalid"
+            [disabled]="resetPasswordForm.invalid || isWaiting"
         >
             {{ 'Reset password' | translate }}
         </button>

--- a/client/src/app/site/pages/login/pages/reset-password/components/reset-password/reset-password.component.ts
+++ b/client/src/app/site/pages/login/pages/reset-password/components/reset-password/reset-password.component.ts
@@ -63,7 +63,7 @@ export class ResetPasswordComponent extends BaseComponent implements OnInit {
                     duration: 0
                 }
             );
-            this.router.navigate([`..`]);
+            this.router.navigate([`/login`]);
         } catch (e) {
             this._isWaiting = false;
             this.raiseError(e);

--- a/client/src/app/site/pages/login/pages/reset-password/components/reset-password/reset-password.component.ts
+++ b/client/src/app/site/pages/login/pages/reset-password/components/reset-password/reset-password.component.ts
@@ -16,6 +16,12 @@ export class ResetPasswordComponent extends BaseComponent implements OnInit {
      */
     public resetPasswordForm: UntypedFormGroup;
 
+    public get isWaiting(): boolean {
+        return this._isWaiting;
+    }
+
+    private _isWaiting: boolean = false;
+
     /**
      * Constructur for the reset password view. Initializes the form for the email.
      */
@@ -47,7 +53,9 @@ export class ResetPasswordComponent extends BaseComponent implements OnInit {
         }
 
         try {
+            this._isWaiting = true;
             await this.userRepo.forgetPassword(this.resetPasswordForm.get(`email`)!.value);
+            this._isWaiting = false;
             this.matSnackBar.open(
                 this.translate.instant(`An email with a password reset link was send!`),
                 this.translate.instant(`OK`),
@@ -57,6 +65,7 @@ export class ResetPasswordComponent extends BaseComponent implements OnInit {
             );
             this.router.navigate([`..`]);
         } catch (e) {
+            this._isWaiting = false;
             this.raiseError(e);
         }
     }

--- a/client/src/app/site/pages/login/pages/reset-password/reset-password.module.ts
+++ b/client/src/app/site/pages/login/pages/reset-password/reset-password.module.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
+import { DirectivesModule } from 'src/app/ui/directives';
 
 import { ResetPasswordComponent } from './components/reset-password/reset-password.component';
 import { ResetPasswordRoutingModule } from './reset-password-routing.module';
@@ -17,6 +18,7 @@ import { ResetPasswordRoutingModule } from './reset-password-routing.module';
         MatFormFieldModule,
         MatButtonModule,
         MatInputModule,
+        DirectivesModule,
         ReactiveFormsModule,
         OpenSlidesTranslationModule.forChild()
     ]


### PR DESCRIPTION
Closes #757 

Currently the page will throw an error: `Error when trying to forward to only meeting: Operator has not fully loaded yet.` if one clicks the reset password button.

This is triggered by a navigation command. 
Once I have the information, where that button is supposed to navigate to, I shall fix that and request reviews