### PR TITLE
Fix ICC by bypassing the ngsw

### DIFF
--- a/client/ngsw-config.json
+++ b/client/ngsw-config.json
@@ -25,16 +25,5 @@
                 "files": ["/assets/**", "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"]
             }
         }
-    ],
-    "dataGroups": [
-        {
-            "name": "api",
-            "urls": ["/rest/*", "/apps/*", "/system/*", "/stats"],
-            "cacheConfig": {
-                "maxSize": 0,
-                "maxAge": "0u",
-                "strategy": "freshness"
-            }
-        }
     ]
 }

--- a/client/src/app/gateways/http-stream/http-stream-endpoint.service.ts
+++ b/client/src/app/gateways/http-stream/http-stream-endpoint.service.ts
@@ -38,7 +38,6 @@ export class HttpStreamEndpointService {
     }
 
     public async isEndpointHealthy(endpoint: EndpointConfiguration): Promise<boolean> {
-        // TODO: Add ngsw-bypass header
         try {
             const response = await this.http.get<{ healthy: boolean }>(endpoint.healthUrl);
             return !!response.healthy;

--- a/client/src/app/gateways/http.service.ts
+++ b/client/src/app/gateways/http.service.ts
@@ -51,7 +51,10 @@ export class HttpService {
         const options: HttpOptions = {
             observe: `response`,
             body: data,
-            headers: customHeader,
+            // ngsw-bypass tells the angular service worker to ignore this request.
+            // Since any call made from inside the angular code should never be cached anyway, we
+            // set it here as the default.
+            headers: { 'ngsw-bypass': `true`, ...customHeader },
             responseType
         };
 

--- a/client/src/app/gateways/http.service.ts
+++ b/client/src/app/gateways/http.service.ts
@@ -11,16 +11,18 @@ import {
     ResponseType
 } from '../infrastructure/definitions/http';
 import { ProcessError } from '../infrastructure/errors';
-import { OpenSlidesInjector } from '../infrastructure/utils/di/openslides-injector';
 import { toBase64 } from '../infrastructure/utils/functions';
 import { ErrorMapService } from './error-map.service';
 
-const defaultHeaders = { [`Content-Type`]: `application/json` };
+type HttpHeadersObj = HttpHeaders | { [header: string]: string | string[] };
+
+const defaultHeaders: HttpHeadersObj = { [`Content-Type`]: `application/json` };
+
 @Injectable({
     providedIn: `root`
 })
 export class HttpService {
-    public constructor(private http: HttpClient, private errorMapper: ErrorMapService) {}
+    public constructor(private http: HttpClient, private errorMapper: ErrorMapService, private snackBar: MatSnackBar) {}
 
     /**
      * Send the a http request the the given path.
@@ -54,7 +56,7 @@ export class HttpService {
             // ngsw-bypass tells the angular service worker to ignore this request.
             // Since any call made from inside the angular code should never be cached anyway, we
             // set it here as the default.
-            headers: { 'ngsw-bypass': `true`, ...customHeader },
+            headers: this.injectBypassHeader(customHeader),
             responseType
         };
 
@@ -64,12 +66,11 @@ export class HttpService {
         } catch (error) {
             if (error instanceof HttpErrorResponse) {
                 if (!!error.error.message) {
-                    const snackBar = OpenSlidesInjector.get(MatSnackBar);
                     const cleanError = this.errorMapper.getCleanErrorMessage(error.error.message, error.url);
                     if (typeof cleanError !== `string`) {
                         throw cleanError;
                     }
-                    snackBar.open(cleanError, `Ok`);
+                    this.snackBar.open(cleanError, `Ok`);
                 }
                 return null;
             } else {
@@ -90,7 +91,7 @@ export class HttpService {
         return this.http.request<T>(method, url, {
             observe: options.observe ?? (`body` as any),
             responseType: options?.responseType ?? (`json` as any),
-            headers: options?.headers ?? defaultHeaders,
+            headers: this.injectBypassHeader(options?.headers ?? defaultHeaders),
             ...options
         }) as any;
     }
@@ -172,5 +173,15 @@ export class HttpService {
         const headers = new HttpHeaders();
         const file = await this.get<Blob>(url, {}, {}, headers, `blob`);
         return await toBase64(file);
+    }
+
+    /**
+     * Injects the bypass header into the given headers.
+     *
+     * @param headers the headers
+     * @returns the modified headers
+     */
+    private injectBypassHeader(headers: HttpHeadersObj): HttpHeadersObj {
+        return { 'ngsw-bypass': `true`, ...headers };
     }
 }


### PR DESCRIPTION
The previous method of telling the service worker to ignore certain paths and not cache them did not work reliably anymore (for unknown reasons). This lead to ALL http calls being intercepted by the service worker, which was annoying for "normal" calls, but fatal for blocking calls, since the service worker did not seem to be able to handle these, which lead in turn to the ICC service not working correctly because even the first message, the channel id, did not get through. 

This PR introduces an alternative solution using the `ngsw-bypass` header to explicitly bypass the service worker for all http calls. These are currently calls to the AU, backend, auth, vote and notify service, which should all never be cached, so I inserted the parameter at the lowest level in the http service since I assume that all requests from inside the client will be of such nature, even in the future.