### PR TITLE
Fix PDF export

### DIFF
--- a/client/src/app/gateways/http.service.ts
+++ b/client/src/app/gateways/http.service.ts
@@ -182,6 +182,10 @@ export class HttpService {
      * @returns the modified headers
      */
     private injectBypassHeader(headers: HttpHeadersObj): HttpHeadersObj {
-        return { 'ngsw-bypass': `true`, ...headers };
+        if (headers instanceof HttpHeaders) {
+            return headers.set(`ngsw-bypass`, `true`);
+        } else {
+            return { 'ngsw-bypass': `true`, ...headers };
+        }
     }
 }


### PR DESCRIPTION
The change in https://github.com/OpenSlides/openslides-client/pull/1544/files was not correctly implemented for the `HttpHeaders` class, which lead to errors in the pdf export.