### PR TITLE
Fix participant creation wizard

### DIFF
--- a/client/src/app/gateways/repositories/users/user-repository.service.ts
+++ b/client/src/app/gateways/repositories/users/user-repository.service.ts
@@ -191,7 +191,7 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
             email: partialUser.email,
             default_structure_level: partialUser.default_structure_level,
             default_number: partialUser.default_number,
-            default_vote_weight: toDecimal(partialUser.default_vote_weight) as any,
+            default_vote_weight: toDecimal(partialUser.default_vote_weight, false) as any,
             organization_management_level: partialUser.organization_management_level,
             committee_$_management_level: partialUser.committee_$_management_level,
             group_$_ids: partialUser.group_$_ids,

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
@@ -178,7 +178,7 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
                 searchCriteria: [{ username: _username, email }],
                 permissionRelatedId: this.activeMeetingId!
             });
-            this._suitableAccountList = Object.keys(result).flatMap(key => result[key]);
+            this._suitableAccountList = Object.values(result).flat();
             if (this._suitableAccountList.length === 0) {
                 this.goToStep(this.CREATE_PARTICIPANT_STEP);
             } else {

--- a/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
@@ -251,7 +251,7 @@ export class ParticipantControllerService extends BaseMeetingControllerService<V
             },
             number_$: participant.number_$ || { [this.activeMeetingId!]: participant.number },
             vote_weight_$: participant.vote_weight_$ || {
-                [this.activeMeetingId!]: toDecimal(participant.vote_weight as any)
+                [this.activeMeetingId!]: toDecimal(participant.vote_weight as any, false)
             },
             vote_delegated_$_to_id: participant.vote_delegated_$_to_id || {
                 [this.activeMeetingId!]: participant.vote_delegated_to_id


### PR DESCRIPTION
The `default_vote_weight` was mistakenly sent together with the user, which resulted in an error if the requets user did not have sufficient permissions.

@emanuelschuetze I could not reproduce the error of being able to change the account data.