### PR TITLE
Hide decision checkboxes when the motion is in the last state

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
@@ -519,7 +519,7 @@ export class MotionPdfService {
         }
 
         // Checkboxes for resolution
-        if (optionToFollowRecommendation) {
+        if (optionToFollowRecommendation && !motion.state.isFinalState) {
             metaTableBody.push([
                 {
                     text: `${this.translate.instant(`Decision`)}:`,


### PR DESCRIPTION
Fix #1578