### PR TITLE
Fix navbar arrow position on WebKit

### DIFF
--- a/client/src/app/ui/modules/sidenav/components/sidenav/sidenav.component.scss
+++ b/client/src/app/ui/modules/sidenav/components/sidenav/sidenav.component.scss
@@ -63,7 +63,7 @@ mat-sidenav-container {
 
 // CSS for the toggle button
 .nav-toggle-button-container {
-    position: fixed;
+    position: absolute;
     z-index: 99;
     bottom: 24px;
     & > div {
@@ -72,9 +72,7 @@ mat-sidenav-container {
 
     .nav-toggle-button {
         bottom: 0;
-
         position: absolute;
-        visibility: visible;
         transform: none;
         width: 24px;
         min-width: 24px;


### PR DESCRIPTION
Fixes a bug where the "close" arrow was not repositioned on WebKit browsers Closes #1281