### PR TITLE
dont't reopen autoupdate streams after resolved

### DIFF
--- a/client/src/app/worker/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate-stream-pool.ts
@@ -221,8 +221,6 @@ export class AutoupdateStreamPool {
             this.removeStream(stream);
         } else if (stopReason === `error`) {
             await this.handleError(stream, error);
-        } else if (stopReason === `resolved`) {
-            await this.handleError(stream, undefined);
         }
     }
 


### PR DESCRIPTION
Currently the worker tries to reopen connections when in history mode. This is fixed by this PR. 