### PR TITLE
resend autoupdate data if subscription existing

### DIFF
--- a/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
@@ -15,6 +15,7 @@ import {
     AutoupdateReceiveData,
     AutoupdateReceiveError,
     AutoupdateReconnectInactive,
+    AutoupdateResendStreamData,
     AutoupdateSetConnectionStatus,
     AutoupdateSetEndpoint,
     AutoupdateSetStreamId,
@@ -139,6 +140,20 @@ export class AutoupdateCommunicationService {
                 }
             } as AutoupdateOpenStream);
         });
+    }
+
+    /**
+     * Tells the worker to resend the current data of the given subscription
+     *
+     * @param streamId Id of the stream
+     */
+    public resend(streamId: Id): void {
+        this.sharedWorker.sendMessage(`autoupdate`, {
+            action: `resend`,
+            params: {
+                streamId
+            }
+        } as AutoupdateResendStreamData);
     }
 
     /**

--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -41,6 +41,7 @@ export interface StructuredFieldDecriptor {
 
 export interface ModelSubscription {
     id: Id;
+    resend: () => void;
     close: () => void;
 }
 
@@ -160,6 +161,9 @@ export class AutoupdateService {
 
         return {
             id,
+            resend: () => {
+                this.communication.resend(id);
+            },
             close: () => {
                 this.communication.close(id);
                 delete this._activeRequestObjects[id];

--- a/client/src/app/site/services/model-request.service.ts
+++ b/client/src/app/site/services/model-request.service.ts
@@ -41,7 +41,8 @@ export class ModelRequestService {
 
     public async subscribeTo({ modelRequest, subscriptionName, ...config }: SubscribeToConfig): Promise<void> {
         if (this._modelSubscriptionMap[subscriptionName]) {
-            console.warn(`A subscription already made for ${subscriptionName}. Aborting.`);
+            console.warn(`A subscription already made for ${subscriptionName}. Resending.`);
+            this._modelSubscriptionMap[subscriptionName].resend();
             return;
         }
         modelRequest.fieldset = modelRequest.fieldset || [];

--- a/client/src/app/worker/interfaces-autoupdate.ts
+++ b/client/src/app/worker/interfaces-autoupdate.ts
@@ -34,6 +34,15 @@ export interface AutoupdateCloseStream extends WorkerMessageContent {
     params: AutoupdateCloseStreamParams;
 }
 
+export interface AutoupdateResendStreamDataParams {
+    streamId: number;
+}
+
+export interface AutoupdateResendStreamData extends WorkerMessageContent {
+    action: 'resend';
+    params: AutoupdateResendStreamDataParams;
+}
+
 export interface AutoupdateSetConnectionStatusParams {
     status: 'online' | 'offline';
 }

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -5,6 +5,7 @@ import { AutoupdateSubscription } from './autoupdate-subscription';
 import {
     AutoupdateCloseStreamParams,
     AutoupdateOpenStreamParams,
+    AutoupdateResendStreamDataParams,
     AutoupdateSetEndpointParams
 } from './interfaces-autoupdate';
 
@@ -81,6 +82,15 @@ function closeConnection(ctx: MessagePort, params: AutoupdateCloseStreamParams):
     subscription.closePort(ctx);
 }
 
+function resendSubscription(ctx: MessagePort, params: AutoupdateResendStreamDataParams): void {
+    const subscription = autoupdatePool.getSubscriptionById(params.streamId);
+    if (!subscription) {
+        return;
+    }
+
+    subscription.resendTo(ctx);
+}
+
 let currentlyOnline = navigator.onLine;
 function updateOnlineStatus(): void {
     if (currentlyOnline === navigator.onLine) {
@@ -107,6 +117,9 @@ export function addAutoupdateListener(context: any): void {
                 break;
             case `close`:
                 closeConnection(context, params);
+                break;
+            case `resend`:
+                resendSubscription(context, params);
                 break;
             case `auth-change`:
                 autoupdatePool.updateAuthentication();


### PR DESCRIPTION
This fixes a issue where visiting a account detail page leads to meetings not displayed on the calendar. 