### PR TITLE
add missing try catch block to autoupdate health check

### DIFF
--- a/client/src/app/worker/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate-stream-pool.ts
@@ -225,15 +225,19 @@ export class AutoupdateStreamPool {
     }
 
     private async isEndpointHealthy(): Promise<boolean> {
-        const data = await fetch(this.endpoint.healthUrl).then(response => {
-            if (response.ok) {
-                return response.json();
-            }
+        try {
+            const data = await fetch(this.endpoint.healthUrl).then(response => {
+                if (response.ok) {
+                    return response.json();
+                }
 
-            return { healthy: false };
-        });
+                return { healthy: false };
+            });
 
-        return !!data?.healthy;
+            return !!data?.healthy;
+        } catch (e) {
+            return false;
+        }
     }
 
     private updateMessagePorts(): void {


### PR DESCRIPTION
Currently the shared worker crashes when a user loses network connection. This should be fixed by this PR. 