### PR TITLE
Greyed out checkboxes for motions that were already forwarded to

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -9,7 +9,7 @@
                 <h4>{{ committee.name }}</h4>
                 <div *ngFor="let meeting of committee.meetings">
                     <mat-checkbox
-                        [disabled]="isActiveMeeting(meeting)"
+                        [disabled]="isActiveMeeting(meeting) || hasAlreadyBeenForwardedTo(meeting)"
                         [value]="meeting.id"
                         [(ngModel)]="checkboxStateMap[meeting.id]"
                         (change)="onChangeCheckbox($event)">

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -1,4 +1,4 @@
-<div mat-dialog-title>{{ 'Forward motions' | translate }}</div>
+<div mat-dialog-title>{{ data.motion.length > 1 ? 'Forward motions' : 'Forward motion' | translate }}{{ ': ' + data.motion[0].number }}</div>
 <div mat-dialog-content>
     <span *ngIf="data.motion.length === 1">{{ 'State' | translate }}: <b>{{ data.motion[0].state.name | translate }} {{data.motion[0].state_extension}}</b></span>
     <br *ngIf="data.motion.length === 1 && activeMeetingCommitteeName">

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.html
@@ -1,4 +1,7 @@
-<div mat-dialog-title>{{ data.motion.length > 1 ? 'Forward motions' : 'Forward motion' | translate }}{{ ': ' + data.motion[0].number }}</div>
+<div mat-dialog-title>
+    {{ data.motion.length > 1 ? 'Forward motions' : 'Forwarding of motion' | translate }}
+    <span *ngIf="data.motion.length === 1">{{ data.motion[0].number }}</span>
+</div>
 <div mat-dialog-content>
     <span *ngIf="data.motion.length === 1">{{ 'State' | translate }}: <b>{{ data.motion[0].state.name | translate }} {{data.motion[0].state_extension}}</b></span>
     <br *ngIf="data.motion.length === 1 && activeMeetingCommitteeName">

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/components/motion-forward-dialog/motion-forward-dialog.component.ts
@@ -53,6 +53,13 @@ export class MotionForwardDialogComponent implements OnInit {
         return +meeting.id === this.activeMeeting.meetingId;
     }
 
+    public hasAlreadyBeenForwardedTo(meeting: GetForwardingMeetingsPresenterMeeting): boolean {
+        if (this.data.motion.length === 1) {
+            return this.data.motion[0].derived_motions?.map(motion => motion.meeting_id).includes(+meeting.id) ?? false;
+        }
+        return false;
+    }
+
     private initStateMap(): void {
         const meetings = this.committeesSubject.value.flatMap(committee => committee.meetings)!;
         for (const meeting of meetings) {


### PR DESCRIPTION
Closes #1661 

Also made the title include the motion number.

All of these changes only apply to single motion forwardings (including multiselects with only one motion)