### PR TITLE
prevent opening http streams while cypress is running

### DIFF
--- a/client/src/app/gateways/http-stream/http-stream.service.ts
+++ b/client/src/app/gateways/http-stream/http-stream.service.ts
@@ -51,6 +51,11 @@ export class HttpStreamService {
         }: HttpStreamOptions<T> = {},
         { bodyFn = () => {}, paramsFn = () => null }: RequestOptions = {}
     ): HttpStream<T> {
+        // TODO: remove if https://github.com/cypress-io/cypress/issues/3708 fixed
+        if ((<any>window).isCypressTest) {
+            return new HttpStream(() => null, {});
+        }
+
         const endpoint = this.getEndpointConfiguration(endpointConfiguration);
         const requestOptions = this.getOptions(bodyFn, paramsFn);
         const httpContext = { method: endpoint.method, url: endpoint.url, options: requestOptions };

--- a/client/src/app/gateways/http-stream/http-stream.ts
+++ b/client/src/app/gateways/http-stream/http-stream.ts
@@ -260,6 +260,11 @@ export class HttpStream<T> {
      * Incoming messages and errors are treated by the optional passed `onMessage`- and `onError`-handlers.
      */
     public open(): void {
+        // TODO: remove if https://github.com/cypress-io/cypress/issues/3708 fixed
+        if ((<any>window).isCypressTest) {
+            return;
+        }
+
         this._isClosed = false;
         this.subscribe();
     }

--- a/client/tests/integration/cypress/support/setup.ts
+++ b/client/tests/integration/cypress/support/setup.ts
@@ -1,6 +1,7 @@
 Cypress.on('uncaught:exception', err => !err.message.match(/^[^(ResizeObserver loop limit exceeded)]/));
 
 Cypress.on('window:before:load', window => {
+    Object.defineProperty(window, 'isCypressTest', { value: true });
     Object.defineProperty(window.navigator, 'language', { value: 'en-GB' });
     Object.defineProperty(window.navigator, 'languages', { value: ['en'] });
     Object.defineProperty(window.navigator, 'accept_languages', { value: ['en'] });


### PR DESCRIPTION
Cypress tests are failing again after an issue with opening icc connections was resolved. 

For that reason I have added a check that prevents opening http streams when the client is used by cypress. 