### PR TITLE
Grey out motion detail nav buttons

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
@@ -25,12 +25,12 @@
 
             <!-- Back and forth buttons -->
             <div *ngIf="!editMotion && !vp.isMobile && showNavigateButtons" class="extra-controls-slot prev-next-motion-controls">
-                <button mat-button (click)="navigateToMotion(previousMotion)" [disabled]="!previousMotion">
+                <button mat-button (click)="navigateToMotion(previousMotion)" [disabled]="!previousMotion" class="motion-detail-nav-button">
                     <os-icon-container icon="chevron_left">
                         {{ previousMotion ? previousMotion.number : '' }}
                     </os-icon-container>
                 </button>
-                <button mat-button (click)="navigateToMotion(nextMotion)" [disabled]="!nextMotion">
+                <button mat-button (click)="navigateToMotion(nextMotion)" [disabled]="!nextMotion" class="motion-detail-nav-button">
                     <os-icon-container icon="chevron_right" [swap]="true">
                         {{ nextMotion ? nextMotion.number : '' }}
                     </os-icon-container>
@@ -46,11 +46,11 @@
 
             <mat-menu #motionExtraMenu="matMenu">
                 <div *ngIf="vp.isMobile && showNavigateButtons">
-                    <button mat-menu-item (click)="navigateToMotion(previousMotion)" [disabled]="!previousMotion">
+                    <button mat-menu-item (click)="navigateToMotion(previousMotion)" [disabled]="!previousMotion" class="motion-detail-nav-button">
                         <mat-icon>chevron_left</mat-icon>
                         <span *ngIf="previousMotion">{{ 'Motion' | translate }} {{ previousMotion.number }}</span>
                     </button>
-                    <button mat-menu-item (click)="navigateToMotion(nextMotion)" [disabled]="!nextMotion">
+                    <button mat-menu-item (click)="navigateToMotion(nextMotion)" [disabled]="!nextMotion" class="motion-detail-nav-button">
                         <mat-icon>chevron_right</mat-icon>
                         <span *ngIf="nextMotion">{{ 'Motion' | translate }} {{ nextMotion.number }}</span>
                     </button>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
@@ -24,21 +24,17 @@
             </div>
 
             <!-- Back and forth buttons -->
-            <div *ngIf="!editMotion && !vp.isMobile" class="extra-controls-slot prev-next-motion-controls">
-                <div *ngIf="previousMotion">
-                    <button mat-button (click)="navigateToMotion(previousMotion)">
-                        <os-icon-container icon="chevron_left">
-                            {{ previousMotion.number }}
-                        </os-icon-container>
-                    </button>
-                </div>
-                <div *ngIf="nextMotion">
-                    <button mat-button (click)="navigateToMotion(nextMotion)">
-                        <os-icon-container icon="chevron_right" [swap]="true">
-                            {{ nextMotion.number }}
-                        </os-icon-container>
-                    </button>
-                </div>
+            <div *ngIf="!editMotion && !vp.isMobile && showNavigateButtons" class="extra-controls-slot prev-next-motion-controls">
+                <button mat-button (click)="navigateToMotion(previousMotion)" [disabled]="!previousMotion">
+                    <os-icon-container icon="chevron_left">
+                        {{ previousMotion ? previousMotion.number : '' }}
+                    </os-icon-container>
+                </button>
+                <button mat-button (click)="navigateToMotion(nextMotion)" [disabled]="!nextMotion">
+                    <os-icon-container icon="chevron_right" [swap]="true">
+                        {{ nextMotion ? nextMotion.number : '' }}
+                    </os-icon-container>
+                </button>
             </div>
 
             <!-- Menu -->
@@ -49,14 +45,14 @@
             </div>
 
             <mat-menu #motionExtraMenu="matMenu">
-                <div *ngIf="vp.isMobile">
-                    <button mat-menu-item (click)="navigateToMotion(previousMotion)" *ngIf="previousMotion">
+                <div *ngIf="vp.isMobile && showNavigateButtons">
+                    <button mat-menu-item (click)="navigateToMotion(previousMotion)" [disabled]="!previousMotion">
                         <mat-icon>chevron_left</mat-icon>
-                        <span>{{ 'Motion' | translate }} {{ previousMotion.number }}</span>
+                        <span *ngIf="previousMotion">{{ 'Motion' | translate }} {{ previousMotion.number }}</span>
                     </button>
-                    <button mat-menu-item (click)="navigateToMotion(nextMotion)" *ngIf="nextMotion">
+                    <button mat-menu-item (click)="navigateToMotion(nextMotion)" [disabled]="!nextMotion">
                         <mat-icon>chevron_right</mat-icon>
-                        <span>{{ 'Motion' | translate }} {{ nextMotion.number }}</span>
+                        <span *ngIf="nextMotion">{{ 'Motion' | translate }} {{ nextMotion.number }}</span>
                     </button>
                     <mat-divider *ngIf="previousMotion || nextMotion"></mat-divider>
                 </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
@@ -161,3 +161,7 @@ span {
     font-size: 70%;
     float: right;
 }
+
+.motion-detail-nav-button {
+    min-width: 110px;
+}

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.ts
@@ -83,12 +83,34 @@ export class MotionDetailViewComponent extends BaseMeetingComponent implements O
     /**
      * preload the next motion for direct navigation
      */
-    public nextMotion: ViewMotion | null = null;
+    public set nextMotion(motion: ViewMotion | null) {
+        this._nextMotion = motion;
+        this.cd.markForCheck();
+    }
 
     /**
      * preload the previous motion for direct navigation
      */
-    public previousMotion: ViewMotion | null = null;
+    public set previousMotion(motion: ViewMotion | null) {
+        this._previousMotion = motion;
+        this.cd.markForCheck();
+    }
+
+    public get nextMotion(): ViewMotion | null {
+        return this._nextMotion;
+    }
+
+    public get previousMotion(): ViewMotion | null {
+        return this._previousMotion;
+    }
+
+    private _nextMotion: ViewMotion | null = null;
+
+    private _previousMotion: ViewMotion | null = null;
+
+    public get showNavigateButtons(): boolean {
+        return !!this.previousMotion || !!this.nextMotion;
+    }
 
     public hasLoaded = new BehaviorSubject(false);
 
@@ -266,7 +288,6 @@ export class MotionDetailViewComponent extends BaseMeetingComponent implements O
         } else {
             this.nextMotion = null;
         }
-        this.cd.markForCheck();
     }
 
     /**


### PR DESCRIPTION
Closes #1698 

TODO: Find out what shall be done with the amendment navigation (when on a motion that has amendments, the next-motion-button will lead to the first of those amendments. There is no way to reach the next non-amendment motion, aside from navigating to the motion-list and manually selecting it)

What do you think @emanuelschuetze ?