### PR TITLE
fix mediafile scrolling table after hide

### DIFF
--- a/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.html
+++ b/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.html
@@ -15,7 +15,7 @@
         <!-- Additional content -->
         <ng-container *ngTemplateOutlet="additionalContent"></ng-container>
     </div>
-    <div class="upload-area--bottom-content">
+    <div [hidden]="isEmpty" class="upload-area--bottom-content">
         <ng-container *ngTemplateOutlet="tableTemplate"></ng-container>
     </div>
 </div>
@@ -37,7 +37,6 @@
 
 <ng-template #tableTemplate>
     <os-scrolling-table
-        *ngIf="!isEmpty"
         vScrollFixed="50"
         [showHeader]="true"
         [dataSource]="dataSource"

--- a/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.ts
+++ b/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.ts
@@ -1,4 +1,13 @@
-import { Component, ContentChild, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
+import {
+    Component,
+    ContentChild,
+    ElementRef,
+    EventEmitter,
+    Input,
+    Output,
+    TemplateRef,
+    ViewChild
+} from '@angular/core';
 import { FileSystemFileEntry, NgxFileDropEntry } from 'ngx-file-drop';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
@@ -36,6 +45,8 @@ export class FileUploadComponent {
 
     @ContentChild(TemplateRef, { static: true })
     public additionalContent: TemplateRef<any> | null = null;
+
+    @ViewChild(`fileInput`) fileInput: ElementRef;
 
     /**
      * Determine if uploading should happen parallel or synchronously.
@@ -84,6 +95,8 @@ export class FileUploadComponent {
                 this.addFile(addedFile);
             }
         }
+
+        this.fileInput.nativeElement.value = null;
     }
 
     /**


### PR DESCRIPTION
resolves #1768 

Currently when deleting all files from from file upload list the scrolling table gets destroyed. This also deletes the previously defined columns. With this pr the scrolling table only gets hidden. 