### PR TITLE
fix broken meeting after resignin with different permissions

### DIFF
--- a/client/src/app/worker/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate-stream-pool.ts
@@ -212,6 +212,7 @@ export class AutoupdateStreamPool {
             } as AutoupdateNewUserContent);
 
             for (let stream of this.streams) {
+                stream.clearSubscriptions();
                 stream.restart();
             }
         }

--- a/client/src/app/worker/autoupdate-stream.ts
+++ b/client/src/app/worker/autoupdate-stream.ts
@@ -138,6 +138,12 @@ export class AutoupdateStream {
         this.abort();
     }
 
+    public clearSubscriptions(): void {
+        for (let subscription of this.subscriptions) {
+            subscription.currentData = null;
+        }
+    }
+
     public setAuthToken(token: string): void {
         this.authToken = token;
     }


### PR DESCRIPTION
resolves #1789

Data received by autoupdate subscriptions will now be cleared after user changed. 