### PR TITLE
Fix line number collision detection, missing annotations

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
@@ -1703,6 +1703,7 @@ export class MotionDiffService {
      * @param {ViewUnifiedChange[]} changes
      * @param {number} lineLength
      * @param {number} highlightLine
+     * @param {number} firstLine
      */
     public getTextWithChanges(
         motionHtml: string,
@@ -1743,6 +1744,7 @@ export class MotionDiffService {
      * @param {string} origText The original text - needs to be line-numbered
      * @param {string} newText The changed text
      * @param {number} lineLength the line length
+     * @param {ViewUnifiedChange[]} changeRecos
      * @return {DiffLinesInParagraph|null}
      */
     public getAmendmentParagraphsLines(

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/amendment-create-wizard/amendment-create-wizard.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/amendment-create-wizard/amendment-create-wizard.component.html
@@ -61,11 +61,11 @@
                             ></mat-radio-button>
                             <div class="paragraph-text motion-text">
                                 <div>
-                                    <i *ngIf="paragraph.lineFrom >= paragraph.lineTo - 1" class="line-number">
+                                    <i *ngIf="paragraph.lineFrom >= paragraph.lineTo" class="line-number">
                                         {{ 'Line' | translate }} {{ paragraph.lineFrom }}:
                                     </i>
-                                    <i *ngIf="paragraph.lineFrom < paragraph.lineTo - 1" class="line-number">
-                                        {{ 'Line' | translate }} {{ paragraph.lineFrom }} - {{ paragraph.lineTo - 1 }}:
+                                    <i *ngIf="paragraph.lineFrom < paragraph.lineTo" class="line-number">
+                                        {{ 'Line' | translate }} {{ paragraph.lineFrom }} - {{ paragraph.lineTo }}:
                                     </i>
                                 </div>
                                 <div [innerHTML]="getParagraphPreview(i) | trust: 'html'"></div>
@@ -84,11 +84,11 @@
                 <!-- Text -->
                 <section *ngFor="let paragraph of contentForm.value.selectedParagraphs">
                     <h4>
-                        <span *ngIf="paragraph.lineFrom >= paragraph.lineTo - 1" class="line-number">
+                        <span *ngIf="paragraph.lineFrom >= paragraph.lineTo" class="line-number">
                             {{ 'Line' | translate }} {{ paragraph.lineFrom }}:
                         </span>
-                        <span *ngIf="paragraph.lineFrom < paragraph.lineTo - 1" class="line-number">
-                            {{ 'Line' | translate }} {{ paragraph.lineFrom }} - {{ paragraph.lineTo - 1 }}:
+                        <span *ngIf="paragraph.lineFrom < paragraph.lineTo" class="line-number">
+                            {{ 'Line' | translate }} {{ paragraph.lineFrom }} - {{ paragraph.lineTo }}:
                         </span>
                     </h4>
                     <os-editor [formControlName]="'text_' + paragraph.paragraphNo"></os-editor>

--- a/client/src/app/site/pages/meetings/pages/motions/services/common/motion-line-numbering.service/motion-line-numbering.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/common/motion-line-numbering.service/motion-line-numbering.service.ts
@@ -453,11 +453,11 @@ export class MotionLineNumberingService {
                 (otherChange: ViewUnifiedChange) =>
                     otherChange.getChangeId() !== change.getChangeId() &&
                     ((otherChange.getLineFrom() >= change.getLineFrom() &&
-                        otherChange.getLineFrom() < change.getLineTo()) ||
-                        (otherChange.getLineTo() > change.getLineFrom() &&
+                        otherChange.getLineFrom() <= change.getLineTo()) ||
+                        (otherChange.getLineTo() >= change.getLineFrom() &&
                             otherChange.getLineTo() <= change.getLineTo()) ||
-                        (otherChange.getLineFrom() < change.getLineFrom() &&
-                            otherChange.getLineTo() > change.getLineTo()))
+                        (otherChange.getLineFrom() <= change.getLineFrom() &&
+                            otherChange.getLineTo() >= change.getLineTo()))
             ).length > 0
         );
     }


### PR DESCRIPTION
This fixes the collision detection, which probably broke as part of https://github.com/OpenSlides/openslides-client/pull/1012 . An example where no collision is was discovered anymore:
- Amendment 1 covers line 5 (lineFrom = 5, lineTo = 5)
- Amendment 2 covers line 5 (lineFrom = 5, lineTo = 5) too

(The failing test appears to be a general issue in the pipeline, as it also happens in https://github.com/OpenSlides/openslides-client/actions/runs/3446108245/jobs/5750608572)