### PR TITLE
Stopped client from completely blocking user deletion for meeting admins

### DIFF
--- a/client/src/app/gateways/presenter/get-user-related-models-presenter.service.ts
+++ b/client/src/app/gateways/presenter/get-user-related-models-presenter.service.ts
@@ -16,6 +16,7 @@ export interface GetUserRelatedModelsUser {
         submitter_ids: Id[];
     }[];
     committees?: GetUserRelatedModelsCommittee[];
+    error?: string; // This is in case the presenter fails in an unpredicted way
 }
 
 export interface GetUserRelatedModelsCommittee {

--- a/client/src/app/site/modules/user-components/components/user-delete-dialog/user-delete-dialog.component.html
+++ b/client/src/app/site/modules/user-components/components/user-delete-dialog/user-delete-dialog.component.html
@@ -67,37 +67,44 @@
 
 <ng-template #userDetailTemplate let-user="user">
     <div class="user-name padding-left-25">{{ user.name }}</div>
-    <ng-container *ngIf="willBeRemoved(user)">
-        <p class="padding-left-25">
-            {{ 'This account will only be removed from this meeting' | translate }}
-        </p>
-    </ng-container>
-    <ng-container *ngIf="!willBeRemoved(user)">
-        <ng-container *ngIf="!hasRelations(user)">
+    <ng-container *ngIf="user.meetings || user.committees">
+        <ng-container *ngIf="willBeRemoved(user)">
             <p class="padding-left-25">
-                {{
-                    'This account is not linked as candidate, submitter or speaker in any meeting and is not manager of any committee'
-                        | translate
-                }}
+                {{ 'This account will only be removed from this meeting' | translate }}
             </p>
         </ng-container>
-        <ng-container *ngIf="hasRelations(user)">
-            <ul *ngFor="let meeting of user.meetings">
-                <p class="meeting-title">{{ meeting.name }}</p>
-                <li *ngIf="meeting.candidate_ids?.length">
-                    {{ 'Is candidate' | translate }}
-                </li>
-                <li *ngIf="meeting.submitter_ids?.length">
-                    {{ 'Is submitter' | translate }}
-                </li>
-                <li *ngIf="meeting.speaker_ids?.length">
-                    {{ 'Is speaker' | translate }}
-                </li>
-            </ul>
-            <ul *ngFor="let committee of getManagedCommittees(user)">
-                <p class="committee-title">{{ committee.name }}</p>
-                <li>{{ 'Is manager' | translate }}</li>
-            </ul>
+        <ng-container *ngIf="!willBeRemoved(user)">
+            <ng-container *ngIf="!hasRelations(user)">
+                <p class="padding-left-25">
+                    {{
+                        'This account is not linked as candidate, submitter or speaker in any meeting and is not manager of any committee'
+                            | translate
+                    }}
+                </p>
+            </ng-container>
+            <ng-container *ngIf="hasRelations(user)">
+                <ul *ngFor="let meeting of user.meetings">
+                    <p class="meeting-title">{{ meeting.name }}</p>
+                    <li *ngIf="meeting.candidate_ids?.length">
+                        {{ 'Is candidate' | translate }}
+                    </li>
+                    <li *ngIf="meeting.submitter_ids?.length">
+                        {{ 'Is submitter' | translate }}
+                    </li>
+                    <li *ngIf="meeting.speaker_ids?.length">
+                        {{ 'Is speaker' | translate }}
+                    </li>
+                </ul>
+                <ul *ngFor="let committee of getManagedCommittees(user)">
+                    <p class="committee-title">{{ committee.name }}</p>
+                    <li>{{ 'Is manager' | translate }}</li>
+                </ul>
+            </ng-container>
         </ng-container>
+    </ng-container>
+    <ng-container *ngIf="!user.meetings && !user.committees">
+        <p class="padding-left-25">
+            {{ 'Relevant information could not be accessed' | translate }}
+        </p>
     </ng-container>
 </ng-template>

--- a/client/src/app/site/modules/user-components/components/user-delete-dialog/user-delete-dialog.component.html
+++ b/client/src/app/site/modules/user-components/components/user-delete-dialog/user-delete-dialog.component.html
@@ -67,13 +67,13 @@
 
 <ng-template #userDetailTemplate let-user="user">
     <div class="user-name padding-left-25">{{ user.name }}</div>
-    <ng-container *ngIf="user.meetings || user.committees">
-        <ng-container *ngIf="willBeRemoved(user)">
-            <p class="padding-left-25">
-                {{ 'This account will only be removed from this meeting' | translate }}
-            </p>
-        </ng-container>
-        <ng-container *ngIf="!willBeRemoved(user)">
+    <ng-container *ngIf="willBeRemoved(user)">
+        <p class="padding-left-25">
+            {{ 'This account will only be removed from this meeting' | translate }}
+        </p>
+    </ng-container>
+    <ng-container *ngIf="!willBeRemoved(user)">
+        <ng-container *ngIf="!user.error">
             <ng-container *ngIf="!hasRelations(user)">
                 <p class="padding-left-25">
                     {{
@@ -101,10 +101,10 @@
                 </ul>
             </ng-container>
         </ng-container>
-    </ng-container>
-    <ng-container *ngIf="!user.meetings && !user.committees">
-        <p class="padding-left-25">
-            {{ 'Relevant information could not be accessed' | translate }}
-        </p>
+        <ng-container *ngIf="user.error">
+            <p class="padding-left-25">
+                {{ user.error | translate }}
+            </p>
+        </ng-container>
     </ng-container>
 </ng-template>

--- a/client/src/app/site/modules/user-components/services/user-delete-dialog.service.ts
+++ b/client/src/app/site/modules/user-components/services/user-delete-dialog.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Selectable } from 'src/app/domain/interfaces';
-import { GetUserRelatedModelsPresenterService } from 'src/app/gateways/presenter/get-user-related-models-presenter.service';
+import {
+    GetUserRelatedModelsPresenterResult,
+    GetUserRelatedModelsPresenterService
+} from 'src/app/gateways/presenter/get-user-related-models-presenter.service';
 import { mediumDialogSettings } from 'src/app/infrastructure/utils/dialog-settings';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 import { BaseDialogService } from 'src/app/ui/base/base-dialog-service';
@@ -27,9 +30,20 @@ export class UserDeleteDialogService extends BaseDialogService<
     }
 
     public async open(data: UserDeleteDialogOpenConfig): Promise<MatDialogRef<UserDeleteDialogComponent, boolean>> {
-        const toDelete = await this.userRelatedModelsPresenter.call({
-            user_ids: data.toDelete.map(user => user.id)
-        });
+        let toDelete: GetUserRelatedModelsPresenterResult;
+        try {
+            toDelete = await this.userRelatedModelsPresenter.call({
+                user_ids: data.toDelete.map(user => user.id)
+            });
+        } catch (e) {
+            toDelete = data.toDelete.mapToObject(user => {
+                return {
+                    [user.id]: {
+                        name: user.getTitle()
+                    }
+                };
+            });
+        }
         for (const user of data.toDelete) {
             toDelete[user.id].name = user.getTitle();
         }

--- a/client/src/app/site/modules/user-components/services/user-delete-dialog.service.ts
+++ b/client/src/app/site/modules/user-components/services/user-delete-dialog.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { Selectable } from 'src/app/domain/interfaces';
 import {
     GetUserRelatedModelsPresenterResult,
@@ -39,7 +40,8 @@ export class UserDeleteDialogService extends BaseDialogService<
             toDelete = data.toDelete.mapToObject(user => {
                 return {
                     [user.id]: {
-                        name: user.getTitle()
+                        name: user.getTitle(),
+                        error: _(`Relevant information could not be accessed`)
                     }
                 };
             });


### PR DESCRIPTION
Closes #1775 

The Missing OrganizationManagementLevel snackbar message will still appear and the deletion dialog will have no previews for the users that will be deleted (fixing those requires changes in the backend's `get_user_related_models`-presenter -> OpenSlides/openslides-backend#1531 ), but until then it at least allows for the deletion process to function again, even though there will be no preview for the deleted users