### PR TITLE
dont display "no meetings available" before first autoupdate

### DIFF
--- a/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
+++ b/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
@@ -76,23 +76,17 @@ export class BaseModelRequestHandlerComponent extends BaseUiComponent implements
     protected onParamsChanged(params: any, oldParams?: any): void {}
 
     protected async subscribeTo(...configs: ModelRequestConfig[]): Promise<void> {
-        const subscriptions = [];
         for (const { modelRequest, subscriptionName, ...config } of configs) {
             if (!this._openedSubscriptions.includes(subscriptionName)) {
                 this._openedSubscriptions.push(subscriptionName);
                 const observable = this.createHideWhenObservable(config);
-                const subscription = await this.modelRequestService.subscribeTo({
+                await this.modelRequestService.subscribeTo({
                     subscriptionName,
                     modelRequest,
                     hideWhen: observable
                 });
-                if (subscription) {
-                    subscriptions.push(subscription.receivedData);
-                }
             }
         }
-
-        await Promise.all(subscriptions);
     }
 
     protected async updateSubscribeTo(...configs: ModelRequestConfig[]): Promise<void> {

--- a/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
+++ b/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
@@ -80,11 +80,7 @@ export class BaseModelRequestHandlerComponent extends BaseUiComponent implements
             if (!this._openedSubscriptions.includes(subscriptionName)) {
                 this._openedSubscriptions.push(subscriptionName);
                 const observable = this.createHideWhenObservable(config);
-                await this.modelRequestService.subscribeTo({
-                    subscriptionName,
-                    modelRequest,
-                    hideWhen: observable
-                });
+                await this.modelRequestService.subscribeTo({ subscriptionName, modelRequest, hideWhen: observable });
             }
         }
     }

--- a/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
+++ b/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
@@ -76,13 +76,23 @@ export class BaseModelRequestHandlerComponent extends BaseUiComponent implements
     protected onParamsChanged(params: any, oldParams?: any): void {}
 
     protected async subscribeTo(...configs: ModelRequestConfig[]): Promise<void> {
+        const subscriptions = [];
         for (const { modelRequest, subscriptionName, ...config } of configs) {
             if (!this._openedSubscriptions.includes(subscriptionName)) {
                 this._openedSubscriptions.push(subscriptionName);
                 const observable = this.createHideWhenObservable(config);
-                await this.modelRequestService.subscribeTo({ subscriptionName, modelRequest, hideWhen: observable });
+                const subscription = await this.modelRequestService.subscribeTo({
+                    subscriptionName,
+                    modelRequest,
+                    hideWhen: observable
+                });
+                if (subscription) {
+                    subscriptions.push(subscription.receivedData);
+                }
             }
         }
+
+        await Promise.all(subscriptions);
     }
 
     protected async updateSubscribeTo(...configs: ModelRequestConfig[]): Promise<void> {

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
@@ -14,6 +14,10 @@
     <i>{{ 'No meetings available' | translate }}</i>
 </mat-card>
 
+<div *ngIf="noMeetingsToShow && !ready" class="no-content">
+    <mat-spinner class="spinner-center"></mat-spinner>
+</div>
+
 <ng-container *ngIf="!noMeetingsToShow">
     <div class="padding-right-8">
         <!-- active meetings -->

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
@@ -9,7 +9,7 @@
     <div class="meeting-spacer"></div>
 </div>
 
-<mat-card *ngIf="noMeetingsToShow" class="no-content os-card">
+<mat-card *ngIf="noMeetingsToShow && ready" class="no-content os-card">
     <i>{{ 'No meetings available' | translate }}</i>
 </mat-card>
 

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.scss
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.scss
@@ -25,6 +25,10 @@ os-dashboard {
         text-align: center;
     }
 
+    .spinner-center {
+        margin: auto;
+    }
+
     .meeting-spacer {
         height: 1.5em;
         font-size: 1.875rem;

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.ts
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.ts
@@ -3,7 +3,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { BaseComponent } from 'src/app/site/base/base.component';
 import { MeetingControllerService } from 'src/app/site/pages/meetings/services/meeting-controller.service';
-import { ViewMeeting } from 'src/app/site/pages/meetings/view-models/view-meeting';
+import { MEETING_LIST_SUBSCRIPTION, ViewMeeting } from 'src/app/site/pages/meetings/view-models/view-meeting';
 import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 import { ThemeService } from 'src/app/site/services/theme.service';
@@ -28,6 +28,7 @@ export class DashboardComponent extends BaseComponent {
         return this.themeService.isDarkModeObservable;
     }
 
+    public ready: boolean = false;
     public previousMeetings: ViewMeeting[] = [];
     public currentMeetings: ViewMeeting[] = [];
     public futureMeetings: ViewMeeting[] = [];
@@ -43,6 +44,16 @@ export class DashboardComponent extends BaseComponent {
         super(componentServiceCollector, translate);
         super.setTitle(`Calendar`);
         this.loadMeetings();
+
+        const subscriptionInterval = setInterval(() => {
+            const subscription = this.modelRequestService.getSubscription(MEETING_LIST_SUBSCRIPTION);
+            if (subscription) {
+                clearInterval(subscriptionInterval);
+                subscription.receivedData.then(() => {
+                    this.ready = true;
+                });
+            }
+        }, 50);
     }
 
     public getHeightByMeetings(meetings: ViewMeeting[]): string {

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.ts
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.ts
@@ -52,15 +52,15 @@ export class DashboardComponent extends BaseComponent {
         super.setTitle(`Calendar`);
         this.loadMeetings();
 
-        const subscriptionInterval = setInterval(() => {
-            const subscription = this.modelRequestService.getSubscription(MEETING_LIST_SUBSCRIPTION);
-            if (subscription) {
-                clearInterval(subscriptionInterval);
-                subscription.receivedData.then(() => {
-                    this.ready = true;
-                });
-            }
-        }, 50);
+        this.modelRequestService
+            .waitSubscriptionReady(MEETING_LIST_SUBSCRIPTION)
+            .then(() => {
+                this.ready = true;
+            })
+            .catch(e => {
+                console.error(e);
+                this.ready = true;
+            });
     }
 
     public getHeightByMeetings(meetings: ViewMeeting[]): string {

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/dashboard-detail.module.ts
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/dashboard-detail.module.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
@@ -19,6 +20,7 @@ import { DashboardDetailRoutingModule } from './dashboard-detail-routing.module'
         CommonModule,
         DashboardDetailRoutingModule,
         MatCardModule,
+        MatProgressSpinnerModule,
         MatTooltipModule,
         MatDividerModule,
         MatIconModule,

--- a/client/src/app/site/services/model-request.service.ts
+++ b/client/src/app/site/services/model-request.service.ts
@@ -52,14 +52,14 @@ export class ModelRequestService {
                 console.warn(
                     `Either there are no child models for ${modelRequest.viewModelCtor.name}:${modelRequest.lazyLoad.keyOfParent} yet or they weren't requested`
                 );
-                await this.makeSubscription({ modelRequest, subscriptionName, ...config });
+                this.makeSubscription({ modelRequest, subscriptionName, ...config });
             } else if (availableIds.length > 20) {
                 this.lazyLoadSubscription({ modelRequest, subscriptionName, ...config }, availableIds);
             } else {
-                await this.makeSubscription({ modelRequest, subscriptionName, ...config });
+                this.makeSubscription({ modelRequest, subscriptionName, ...config });
             }
         } else {
-            await this.makeSubscription({ modelRequest, subscriptionName, ...config });
+            this.makeSubscription({ modelRequest, subscriptionName, ...config });
         }
     }
 


### PR DESCRIPTION
resolves #1803 

This also adds a method `waitSubscriptionReady` to `ModelRequestService` to check if a subscription got data. Therefore improves #1715 and further resolves #1238.