### PR TITLE
check cdk viewport size on scrolling table refresh

### DIFF
--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -277,5 +277,6 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     private refresh(): void {
         this._dataSource.next(this._source);
         this.cd.markForCheck();
+        this.scrollViewport.checkViewportSize();
     }
 }

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -277,6 +277,6 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     private refresh(): void {
         this._dataSource.next(this._source);
         this.cd.markForCheck();
-        this.scrollViewport.checkViewportSize();
+        this.scrollViewport?.checkViewportSize();
     }
 }


### PR DESCRIPTION
resolves #1816 

With #1816 you can also resize your window to get all elements displayed. Therefore it seems like the cdk viewport size needs to be rechecked manually sometimes if new items were added to a scrolling table. 