### PR TITLE
fix can not save participant about me

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service.ts
@@ -268,6 +268,9 @@ export class ParticipantControllerService extends BaseMeetingControllerService<V
             vote_delegations_$_from_ids: participant.vote_delegations_$_from_ids || {
                 [this.activeMeetingId!]: participant.vote_delegations_from_ids
             },
+            about_me_$: participant.about_me_$ || {
+                [this.activeMeetingId!]: participant.about_me
+            },
             comment_$: participant.comment_$ || {
                 [this.activeMeetingId!]: participant.comment
             }


### PR DESCRIPTION
resolves part of #1801 

Currently the about me field of a meetings participant could not be saved.