### PR TITLE
Add parameter to exclude ids from search in base search selector.

### DIFF
--- a/client/src/app/site/pages/meetings/modules/participant-search-selector/components/participant-search-selector/participant-search-selector.component.html
+++ b/client/src/app/site/pages/meetings/modules/participant-search-selector/components/participant-search-selector/participant-search-selector.component.html
@@ -3,6 +3,7 @@
         <os-list-search-selector
             class="search-users"
             formControlName="userId"
+            [excludeIds]="true"
             [multiple]="false"
             placeholder="{{ placeholder | translate }}"
             [inputListValues]="filteredUsersSubject"

--- a/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
+++ b/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
@@ -120,6 +120,9 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
     @Input()
     public showEntriesNumber: number = 4;
 
+    @Input()
+    public excludeIds: boolean = false;
+
     public itemSizeInPx = 50;
 
     public get panelHeight(): number {
@@ -353,11 +356,13 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
             return this.selectableItems;
         }
         const filteredItems = this.selectableItems.filter(item => {
-            const idString = `` + item.id;
-            const foundId = idString.trim().toLowerCase().indexOf(searchValue) !== -1;
+            if (!this.excludeIds) {
+                const idString = `` + item.id;
+                const foundId = idString.trim().toLowerCase().indexOf(searchValue) !== -1;
 
-            if (foundId) {
-                return true;
+                if (foundId) {
+                    return true;
+                }
             }
 
             return this.getAdditionalySearchedValuesFn(item)


### PR DESCRIPTION
resolves #1802

Introduces a parameter to exclude IDs from search.
Maybe we should have a look at other search fields that can make usage of this parameter.

Changes base class! Please test other search components that use this base component.