### PR TITLE
Made flex-vertical-center style's alignment safe

### DIFF
--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -802,7 +802,6 @@ button.mat-menu-item.selected {
 
 .flex-vertical-center {
     display: flex;
-    // align-items: safe center;
     flex-direction: row;
 
     &.align-left {

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -802,7 +802,7 @@ button.mat-menu-item.selected {
 
 .flex-vertical-center {
     display: flex;
-    align-items: center;
+    align-items: safe center;
     flex-direction: row;
 
     &.align-left {

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -802,11 +802,16 @@ button.mat-menu-item.selected {
 
 .flex-vertical-center {
     display: flex;
-    align-items: safe center;
+    // align-items: safe center;
     flex-direction: row;
 
     &.align-left {
         justify-content: flex-start;
+    }
+
+    & > * {
+        margin-top: auto;
+        margin-bottom: auto;
     }
 }
 


### PR DESCRIPTION
To fix participant import text field (which cut off the top of the content if the content got too long).

Closes #568 

To do this I changed a global style (`flex-vertical-center`) which is used in all kinds of components:
Among others:

- basically all major lists (participant, motions, import lists, file lists, etc.)
- account dialog, user-delete-dialog
- participant detail view
- dashboard
- search selectors

I don't think this will actually break anything (as far as I have seen it doesn't), but it would probably be a good idea to check, if the related views look weird, when testing.