### PR TITLE
Fix forwarding filtering in search selector

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/services/motion-forward-dialog.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/services/motion-forward-dialog.service.ts
@@ -96,7 +96,8 @@ export class MotionForwardDialogService extends BaseDialogService<MotionForwardD
                         id: committee.id,
                         name: committee.name,
                         getTitle: () => committee.name,
-                        getListTitle: () => ``
+                        getListTitle: () => ``,
+                        toString: () => committee.name
                     };
                 })
             );

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-add-to-meetings/account-add-to-meetings.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-add-to-meetings/account-add-to-meetings.component.html
@@ -31,7 +31,7 @@
                             [showChips]="false"
                             [inputListValues]="meetingsObservable"
                             [getItemAdditionalInfoFn]="getMeetingAdditionalInfoFn"
-                            [getAdditionalySearchedValuesFn]="getMeetingAdditionallySearchedFn"
+                            [getAdditionallySearchedValuesFn]="getMeetingAdditionallySearchedFn"
                             [showEntriesNumber]="8"
                         ></os-list-search-selector>
                     </mat-form-field>

--- a/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
+++ b/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
@@ -106,7 +106,7 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
      * Allows for the definition of additional strings that should be checked against the search value for a given item
      */
     @Input()
-    public getAdditionalySearchedValuesFn: (item: Selectable) => string[] = item => [];
+    public getAdditionallySearchedValuesFn: (item: Selectable) => string[] = item => [];
 
     @Input()
     public set sortFn(fn: false | ((valueA: Selectable, valueB: Selectable) => number)) {
@@ -369,7 +369,7 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
                 }
             }
 
-            return this.getAdditionalySearchedValuesFn(item)
+            return this.getAdditionallySearchedValuesFn(item)
                 .concat(item.toString())
                 .some(value => value.toLowerCase().indexOf(searchValue) > -1);
         });


### PR DESCRIPTION
fixes #1888

The `toString()` function was missing on the "artificial models" returned by the forwarding service, so they could not be correctly filtered by the search selector.