### PR TITLE
Built projection hint into detail views

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
@@ -1,5 +1,8 @@
 <mat-card class="os-card speaker-card">
     <!-- Title -->
+    <os-projectable-title class="los-title" *ngIf="!explicitTitleContent" [model]="listOfSpeakers">
+        <mat-icon append *ngIf="closed" style="margin-top: 8px" class="primary-accent-by-theme" matTooltip="{{ 'The list of speakers is closed.' | translate }}">lock</mat-icon>
+    </os-projectable-title>
     <h1 class="los-title" *ngIf="!explicitTitleContent">
         <span>
             {{ title }}

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
@@ -3,12 +3,6 @@
     <os-projectable-title class="los-title" *ngIf="!explicitTitleContent" [model]="listOfSpeakers">
         <mat-icon append *ngIf="closed" style="margin-top: 8px" class="primary-accent-by-theme" matTooltip="{{ 'The list of speakers is closed.' | translate }}">lock</mat-icon>
     </os-projectable-title>
-    <h1 class="los-title" *ngIf="!explicitTitleContent">
-        <span>
-            {{ title }}
-        </span>
-        <mat-icon *ngIf="closed" matTooltip="{{ 'The list of speakers is closed.' | translate }}">lock</mat-icon>
-    </h1>
     <span *ngIf="explicitTitleContent">
         <ng-container *ngTemplateOutlet="explicitTitleContent"></ng-container>
     </span>

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.scss
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.scss
@@ -2,6 +2,7 @@
 
 .los-title {
     margin-left: 25px;
+    display: block;
 }
 
 .finished-list {

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/list-of-speakers-content.module.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/list-of-speakers-content.module.ts
@@ -14,6 +14,7 @@ import { DirectivesModule } from 'src/app/ui/directives';
 import { SortingListModule } from 'src/app/ui/modules/sorting/modules/sorting-list/sorting-list.module';
 
 import { ParticipantCommonServiceModule } from '../../pages/participants/services/common/participant-common-service.module';
+import { DetailViewModule } from '../meetings-component-collector/detail-view/detail-view.module';
 import { ParticipantSearchSelectorModule } from '../participant-search-selector';
 import { ListOfSpeakersContentComponent } from './components/list-of-speakers-content/list-of-speakers-content.component';
 import { ListOfSpeakersContentTitleDirective } from './directives/list-of-speakers-content-title.directive';
@@ -26,6 +27,7 @@ const DECLARATIONS = [ListOfSpeakersContentComponent, ListOfSpeakersContentTitle
     declarations: DECLARATIONS,
     imports: [
         CommonModule,
+        DetailViewModule,
         MatIconModule,
         MatExpansionModule,
         MatListModule,

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.html
@@ -2,7 +2,7 @@
     <h1 class="model-title" *ngIf="titleStyle === 'h1' && model"><ng-container [ngTemplateOutlet]="titleline"></ng-container></h1>
     <h2 class="model-title" *ngIf="titleStyle === 'h2' && model"><ng-container [ngTemplateOutlet]="titleline"></ng-container></h2>
     &nbsp;
-    <mat-icon style="margin-top: 8px" [ngClass]="{'primary-accent-by-theme': titleStyle === 'h1'}" *ngIf="isBeingProjected()" matTooltip="{{ 'Is being projected' | translate }}">videocam</mat-icon>
+    <mat-icon style="margin-top: 8px" [ngClass]="{'primary-accent-by-theme': titleStyle === 'h1'}" *ngIf="isProjectedObservable | async" matTooltip="{{ 'Is being projected' | translate }}">videocam</mat-icon>
     <ng-content select="[append]"></ng-content>
 </div>
 

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.html
@@ -1,0 +1,13 @@
+<div class="title-line">
+    <h1 class="model-title" *ngIf="titleStyle === 'h1' && model"><ng-container [ngTemplateOutlet]="titleline"></ng-container></h1>
+    <h2 class="model-title" *ngIf="titleStyle === 'h2' && model"><ng-container [ngTemplateOutlet]="titleline"></ng-container></h2>
+    &nbsp;
+    <mat-icon style="margin-top: 8px" [ngClass]="{'primary-accent-by-theme': titleStyle === 'h1'}" *ngIf="isBeingProjected()" matTooltip="{{ 'Is being projected' | translate }}">videocam</mat-icon>
+    <ng-content select="[append]"></ng-content>
+</div>
+
+<ng-template #titleline>
+    <ng-content select="[prepend]"></ng-content>
+
+    {{ getTitleFn(model) }}
+</ng-template>

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.scss
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.scss
@@ -1,0 +1,42 @@
+.title-line {
+    display: flex;
+
+    .model-title {
+        // Grab the left padding of the parent element to catch hover-events for the :before element
+        margin-left: -20px;
+        padding-left: 20px;
+
+        .change-title {
+            position: relative;
+            width: 0;
+            height: 0;
+        }
+
+        .change-title:before {
+            position: absolute;
+            top: 18px;
+            left: -17px;
+            display: none;
+            cursor: pointer;
+            content: '';
+            width: 16px;
+            height: 16px;
+            background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" fill="%23337ab7"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+            background-size: 16px 16px;
+        }
+
+        &:hover .change-title:before {
+            display: block;
+        }
+
+        .title-change-indicator {
+            background-color: #0333ff;
+            position: absolute;
+            width: 4px;
+            height: 32px;
+            left: 10px;
+            top: 5px;
+            cursor: pointer;
+        }
+    }
+}

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.spec.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectableTitleComponent } from './projectable-title.component';
+
+xdescribe('ProjectableTitleComponent', () => {
+  let component: ProjectableTitleComponent;
+  let fixture: ComponentFixture<ProjectableTitleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ProjectableTitleComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProjectableTitleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.spec.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.spec.ts
@@ -2,22 +2,21 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProjectableTitleComponent } from './projectable-title.component';
 
-xdescribe('ProjectableTitleComponent', () => {
-  let component: ProjectableTitleComponent;
-  let fixture: ComponentFixture<ProjectableTitleComponent>;
+xdescribe(`ProjectableTitleComponent`, () => {
+    let component: ProjectableTitleComponent;
+    let fixture: ComponentFixture<ProjectableTitleComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ ProjectableTitleComponent ]
-    })
-    .compileComponents();
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ProjectableTitleComponent]
+        }).compileComponents();
 
-    fixture = TestBed.createComponent(ProjectableTitleComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+        fixture = TestBed.createComponent(ProjectableTitleComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it(`should create`, () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
@@ -1,0 +1,33 @@
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { ProjectorControllerService } from 'src/app/site/pages/meetings/pages/projectors/services/projector-controller.service';
+import { BaseProjectableViewModel } from 'src/app/site/pages/meetings/view-models';
+
+@Component({
+    selector: `os-projectable-title`,
+    templateUrl: `./projectable-title.component.html`,
+    styleUrls: [`./projectable-title.component.scss`],
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ProjectableTitleComponent {
+
+    @Input()
+    public model: BaseProjectableViewModel;
+
+    @Input()
+    public getTitleFn: (model: BaseProjectableViewModel) => string = (model) => model.getTitle();
+
+    @Input()
+    public titleStyle: `h1` | `h2` = `h1`;
+
+    constructor(private projectorService: ProjectorControllerService) {}
+
+    public isBeingProjected(): boolean {
+        if (!this.model) {
+            return false;
+        }
+
+        return this.projectorService.isProjected(this.model);
+    }
+
+}

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { distinctUntilChanged, map } from 'rxjs';
 import { ProjectorControllerService } from 'src/app/site/pages/meetings/pages/projectors/services/projector-controller.service';
 import { BaseProjectableViewModel } from 'src/app/site/pages/meetings/view-models';
 
@@ -18,6 +19,11 @@ export class ProjectableTitleComponent {
 
     @Input()
     public titleStyle: `h1` | `h2` = `h1`;
+
+    public isProjectedObservable = this.projectorService.getViewModelListObservable().pipe(
+        distinctUntilChanged(),
+        map(_ => this.isBeingProjected())
+    );
 
     constructor(private projectorService: ProjectorControllerService) {}
 

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
@@ -10,12 +10,11 @@ import { BaseProjectableViewModel } from 'src/app/site/pages/meetings/view-model
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ProjectableTitleComponent {
-
     @Input()
     public model: BaseProjectableViewModel;
 
     @Input()
-    public getTitleFn: (model: BaseProjectableViewModel) => string = (model) => model.getTitle();
+    public getTitleFn: (model: BaseProjectableViewModel) => string = model => model.getTitle();
 
     @Input()
     public titleStyle: `h1` | `h2` = `h1`;
@@ -29,5 +28,4 @@ export class ProjectableTitleComponent {
 
         return this.projectorService.isProjected(this.model);
     }
-
 }

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/detail-view.module.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/detail-view.module.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
@@ -10,11 +12,13 @@ import { DetailViewComponent } from './components/detail-view/detail-view.compon
 import { DetailViewNavigatorComponent } from './components/detail-view-navigator/detail-view-navigator.component';
 import { DetailViewNotFoundComponent } from './components/detail-view-not-found/detail-view-not-found.component';
 import { EasterEggComponent } from './components/easter-egg/easter-egg.component';
+import { ProjectableTitleComponent } from './components/projectable-title/projectable-title.component';
 
 const DECLARATIONS = [
     DetailViewComponent,
     DetailViewNavigatorComponent,
     DetailViewNotFoundComponent,
+    ProjectableTitleComponent,
     EasterEggComponent
 ];
 
@@ -27,6 +31,8 @@ const DECLARATIONS = [
         HeadBarModule,
         OpenSlidesTranslationModule.forChild(),
         MatCardModule,
+        MatIconModule,
+        MatTooltipModule,
         MatProgressSpinnerModule
     ]
 })

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.html
@@ -31,9 +31,7 @@
         [ngClass]="editTopic ? 'os-form-card' : 'os-card'"
     >
         <ng-container *ngIf="!editTopic && topic">
-            <div>
-                <h1>{{ topic.getListTitle() }}</h1>
-            </div>
+            <os-projectable-title [model]="topic"></os-projectable-title>
             <div>
                 <span *ngIf="topic.text">
                     <!-- Render topic text as HTML -->

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.html
@@ -105,9 +105,7 @@
 
 <ng-template #metaInfoTemplate>
     <mat-card class="os-card spacer-bottom-60" *ngIf="assignment">
-        <div *ngIf="!isEditing && assignment.getTitle">
-            <h1>{{ assignment.getTitle() }}</h1>
-        </div>
+        <os-projectable-title *ngIf="!isEditing && assignment.getTitle" [model]="assignment"></os-projectable-title>
         <div *ngIf="assignment">
             <div
                 *ngIf="assignment.assignment.description"

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
@@ -17,7 +17,8 @@
                     [showIcon]="block.internal"
                     [iconTooltip]="'Internal' | translate"
                 >
-                    <h2>{{ block.title }}</h2>
+                    <os-projectable-title [model]="block" titleStyle="h2"></os-projectable-title>
+                    <!-- <h2>{{ block.title }}</h2> -->
                 </os-icon-container>
             </os-icon-container>
         </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
@@ -18,7 +18,6 @@
                     [iconTooltip]="'Internal' | translate"
                 >
                     <os-projectable-title [model]="block" titleStyle="h2"></os-projectable-title>
-                    <!-- <h2>{{ block.title }}</h2> -->
                 </os-icon-container>
             </os-icon-container>
         </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-title/motion-manage-title.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-title/motion-manage-title.component.html
@@ -1,22 +1,19 @@
 <div class="title" *ngIf="motion">
-    <div class="title-line">
-        <h1 class="motion-title">
-            <span *ngIf="titleCanBeChanged()">
-                <span
-                    class="title-change-indicator"
-                    *ngIf="titleChangeRecommendation"
-                    (click)="gotoChangeRecommendation(titleChangeRecommendation)"
-                ></span>
-                <span
-                    class="change-title"
-                    *osPerms="permission.motionCanManage; and: !titleChangeRecommendation"
-                    (click)="createTitleChangeRecommendation()"
-                ></span>
-            </span>
-
-            {{ getTitleWithChanges() }}
-        </h1>
+    <os-projectable-title [model]="motion" [getTitleFn]="getTitleFn">
+        <span class="motion-title" prepend *ngIf="titleCanBeChanged()">
+            <span
+                class="title-change-indicator"
+                *ngIf="titleChangeRecommendation"
+                (click)="gotoChangeRecommendation(titleChangeRecommendation)"
+            ></span>
+            <span
+                class="change-title"
+                *osPerms="permission.motionCanManage; and: !titleChangeRecommendation"
+                (click)="createTitleChangeRecommendation()"
+            ></span>
+        </span>
         <button
+            append
             class="primary-accent-by-theme"
             mat-icon-button
             (click)="toggleFavorite()"
@@ -24,7 +21,7 @@
         >
             <mat-icon>{{ isFavorite() ? 'star' : 'star_border' }}</mat-icon>
         </button>
-    </div>
+    </os-projectable-title>
 
     <!-- Sequential number -->
     <span class="main-nav-color title-font">

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-title/motion-manage-title.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-title/motion-manage-title.component.ts
@@ -23,6 +23,8 @@ export class MotionManageTitleComponent extends BaseMotionDetailChildComponent {
         return this.motion.lead_motion!;
     }
 
+    public getTitleFn = () => this.getTitleWithChanges();
+
     private get personalNote(): PersonalNote | null {
         return this.motion.getPersonalNote();
     }


### PR DESCRIPTION
Closes #574 

Created own title component for meeting-side detail views that shows a camera icon when the model is projected.
Built it into topic, motion, assignment and list of speakers detail views, as well as into the motion-block-detail headbar.

For now I believe that the hint only shows for models that are projected on the standard projector, is this fine or should there also be a notification for the other projectors @emanuelschuetze ?