### PR TITLE
participant import - use only username for duplicate check if given

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
@@ -186,9 +186,13 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
     public async onChooseAccount(): Promise<void> {
         if (this._hasFormChanged) {
             const { username, first_name, last_name, email } = this.createUserForm.value;
-            const _username = username ? username : `${first_name}${last_name}`;
+            let searchCriteria: any = [{ username: `${first_name}${last_name}`, email: email }];
+            if (username) {
+                searchCriteria = [{ username: username }];
+            }
+
             const result = await this.presenter.call({
-                searchCriteria: [{ username: _username, email }],
+                searchCriteria,
                 permissionRelatedId: this.activeMeetingId!
             });
             this._suitableAccountList = Object.values(result).flat();

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -127,7 +127,8 @@ export class ParticipantImportService extends BaseUserImportService {
     }): Promise<ImportModel<User>> {
         const username = input.username ? input.username : `${input.first_name} ${input.last_name}`;
         const userEmailUsername = `${username}/${input.email}`;
-        const duplicates = this._existingUserMap[userEmailUsername] ?? [];
+        const userUsername = `${username}/`;
+        const duplicates = this._existingUserMap[userUsername] ?? this._existingUserMap[userEmailUsername] ?? [];
         const newEntry = duplicates.length === 1 ? { ...duplicates[0], ...input } : input;
         const hasDuplicates =
             duplicates.length > 1 ||

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -144,8 +144,7 @@ export class ParticipantImportService extends BaseUserImportService {
                     return { username: entry.username };
                 }
 
-                const username = !!entry.username ? entry.username : `${entry.first_name} ${entry.last_name}`;
-                return { username, email: entry.email };
+                return { username: `${entry.first_name} ${entry.last_name}`, email: entry.email };
             })
         });
         return result;

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -144,7 +144,7 @@ export class ParticipantImportService extends BaseUserImportService {
                     return { username: entry.username };
                 }
 
-                return { username: `${entry.first_name} ${entry.last_name}`, email: entry.email };
+                return { username: `${entry.first_name}${entry.last_name}`, email: entry.email };
             })
         });
         return result;

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -140,6 +140,10 @@ export class ParticipantImportService extends BaseUserImportService {
         const result = await this.presenter.call({
             permissionRelatedId: this.activeMeetingId,
             searchCriteria: entries.map(entry => {
+                if (entry.username) {
+                    return { username: entry.username };
+                }
+
                 const username = !!entry.username ? entry.username : `${entry.first_name} ${entry.last_name}`;
                 return { username, email: entry.email };
             })


### PR DESCRIPTION
resolves #1896 

If a username is given on participant import the email will now be excluded from the search for duplicates. 