### PR TITLE
Hid menu motion forward button for un-forwardable motions

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.html
@@ -95,7 +95,7 @@
                     </button>
                 </div>
                 <!-- Forward motion -->
-                <div *osPerms="permission.motionCanForward">
+                <div *osPerms="permission.motionCanForward; and: motion.state?.allow_motion_forwarding">
                     <button mat-menu-item (click)="forwardMotionToMeetings()">
                         <mat-icon>forward</mat-icon>
                         <span>{{ 'Forward' | translate }}</span>


### PR DESCRIPTION
Closes #1900 

Don't know if this was the actual problem that this issue is meant to address, but I found out that the forward button in the menu isn't hidden for motions that are in a state from which forwardings can't happen.

I.e. if a motion is in a state that cant forward, one could still find a forward button in the detail view menu. If you then clicked on that button the client would send an empty forwarding request and show a snackbar stating "Successfully forwarded 0 motion"