### PR TITLE
Motion exports should now be using sequential numbers

### DIFF
--- a/client/src/app/gateways/export/csv-export.service/csv-export.service.ts
+++ b/client/src/app/gateways/export/csv-export.service/csv-export.service.ts
@@ -152,7 +152,7 @@ export class CsvExportService {
      * @returns capitalized string
      */
     private capitalizeTranslate(input: string): string {
-        const temp = input.charAt(0).toUpperCase() + input.slice(1);
+        const temp = input.charAt(0).toUpperCase() + input.slice(1).replace(`_`, ` `);
         return this.translate.instant(temp);
     }
 

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
@@ -308,7 +308,7 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
                 return `Motion block`;
             }
             default: {
-                return metaDataName.charAt(0).toUpperCase() + metaDataName.slice(1);
+                return metaDataName.charAt(0).toUpperCase() + metaDataName.slice(1).replace(`_`, ` `);
             }
         }
     }

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/definitions.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/definitions.ts
@@ -13,6 +13,7 @@ export type InfoToExport =
     | 'polls'
     | 'speakers'
     | 'id'
+    | 'sequential_number'
     | 'allcomments';
 
 /**
@@ -39,7 +40,7 @@ const motionHeadersAndVerboseNames: { [key in keyof ViewMotion]?: any } = {
     block: `Motion block`,
     recommendation: `Recommendation`,
     state: `State`,
-    id: `Sequential number`
+    sequential_number: `Sequential number`
 };
 
 /**
@@ -57,7 +58,7 @@ export const noMetaData: (keyof ViewMotion)[] = [`number`, `title`, `text`, `rea
  * Subset of {@link motionImportExportHeaderOrder} properties that are
  * restricted to export only due to database or workflow limitations
  */
-const motionExportOnly: (keyof ViewMotion)[] = [`id`, `recommendation`, `state`];
+const motionExportOnly: (keyof ViewMotion)[] = [`id`, `sequential_number`, `recommendation`, `state`];
 
 export const motionExpectedHeaders: (keyof ViewMotion)[] = motionImportExportHeaderOrder.filter(
     header => !motionExportOnly.includes(header)

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
@@ -131,7 +131,7 @@ export class MotionPdfService {
         if (!continuousText) {
             const title = this.createTitle(motion, crMode, lineLength);
             const sequential =
-                infoToExport?.includes(`id`) ??
+                infoToExport?.includes(`sequential_number`) ??
                 (this.meetingSettingsService.instant(`motions_show_sequential_number`) as boolean);
             const subtitle = this.createSubtitle(motion, sequential);
 

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-xlsx-export.service/motion-xlsx-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-xlsx-export.service/motion-xlsx-export.service.ts
@@ -114,7 +114,7 @@ export class MotionXlsxExportService {
                         propertyHeader = `Open requests to speak`;
                         break;
                     default:
-                        propertyHeader = property.charAt(0).toUpperCase() + property.slice(1);
+                        propertyHeader = property.charAt(0).toUpperCase() + property.slice(1).replace(`_`, ` `);
                 }
                 return {
                     header: this.translate.instant(propertyHeader)


### PR DESCRIPTION
Closes #1905 

@emanuelschuetze please test thoroughly whether the different exports now function correctly in relation to ids and sequential numbers