### PR TITLE
use projector zoom controls for mediafiles

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/mediafile-slide/components/mediafile-slide.component.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/mediafile-slide/components/mediafile-slide.component.ts
@@ -19,7 +19,7 @@ export class MediafileSlideComponent extends BaseSlideComponent<MediafileSlideDa
     }
 
     public get zoom(): number {
-        return Math.pow(1.1, this.data.options[`zoom`] || 0);
+        return Math.pow(1.1, this.projector?.scale || 0);
     }
 
     public get page(): number {

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/presentation-controls/presentation-controls.component.html
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/presentation-controls/presentation-controls.component.html
@@ -39,16 +39,6 @@
                 <!-- TODO: Use form for page number; use pdfSetPage then. Do not forget to include a range check in pdfSetPage. -->
                 <span>{{ 'Page' | translate }}</span>
                 {{ getPage(projection) }}/{{ getPagesAmountFor(projection) }}
-                <br />
-                <button type="button" mat-icon-button (click)="zoom(projection, 'out')">
-                    <mat-icon>zoom_out</mat-icon>
-                </button>
-                <button type="button" mat-icon-button (click)="zoom(projection, 'reset')">
-                    <mat-icon>replay</mat-icon>
-                </button>
-                <button type="button" mat-icon-button (click)="zoom(projection, 'in')">
-                    <mat-icon>zoom_in</mat-icon>
-                </button>
             </div>
         </div>
     </mat-expansion-panel>

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/presentation-controls/presentation-controls.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/presentation-controls/presentation-controls.component.ts
@@ -79,17 +79,6 @@ export class PresentationControlsComponent {
         this.updateProjectionOptions(projection);
     }
 
-    public zoom(projection: ViewProjection, direction: 'in' | 'out' | 'reset'): void {
-        if (direction === `reset`) {
-            projection.options[`zoom`] = 0;
-        } else if (direction === `in`) {
-            projection.options[`zoom`] = (projection.options[`zoom`] || 0) + 1;
-        } else if (direction === `out`) {
-            projection.options[`zoom`] = (projection.options[`zoom`] || 0) - 1;
-        }
-        this.updateProjectionOptions(projection);
-    }
-
     public fullscreen(projection: ViewProjection): void {
         projection.options[`fullscreen`] = !projection.options[`fullscreen`];
         this.updateProjectionOptions(projection);


### PR DESCRIPTION
resolves #1850 

Removes the special media files zoom controls and uses the projector zoom instead. 