### PR TITLE
fix autoupdate query params overwritten after single request

### DIFF
--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -184,7 +184,7 @@ export class AutoupdateService {
             streamId,
             description,
             request,
-            Object.assign(this._currentQueryParams, customParams || {})
+            Object.assign({}, this._currentQueryParams, customParams || {})
         );
 
         let rejectReceivedData: any;


### PR DESCRIPTION
This fixes an issue where the query params config of autoupdate gets overwritten after a single au request was sent. 