### PR TITLE
Cleanup

### DIFF
--- a/client/src/app/infrastructure/utils/functions.ts
+++ b/client/src/app/infrastructure/utils/functions.ts
@@ -1,5 +1,4 @@
 import { Decimal } from '../../domain/definitions/key-types';
-import { deepCopy } from './transform-functions';
 
 export function toBase64(data: File | Blob): Promise<string> {
     return new Promise<string>(async (resolve, reject) => {
@@ -35,18 +34,6 @@ export function reconvertChars(text: string): string {
         .replace(/&szlig;|&#223;/g, `ß`);
 }
 
-export function shuffle<T>(items: T[], times: number = 1000): T[] {
-    const copy = deepCopy(items);
-    for (let i = 0; i < times; ++i) {
-        const oldItem = Math.floor(Math.random() * items.length);
-        const newItem = Math.floor(Math.random() * items.length);
-        const tmp = copy[oldItem];
-        copy[oldItem] = copy[newItem];
-        copy[newItem] = tmp;
-    }
-    return copy;
-}
-
 /**
  * Helper to remove html tags from a string.
  * CAUTION: It is just a basic "don't show distracting html tags in a
@@ -59,7 +46,7 @@ export function stripHtmlTags(inputString: string): string {
     return inputString.replace(regexp, ``).trim();
 }
 
-const VERBOSE_TRUE_FIELDS = [`1`, `y`, `yes`, `true`, `on`];
+const VERBOSE_TRUE_FIELDS = [`1`, `on`, `true`];
 
 export function toBoolean(value: string): boolean {
     return VERBOSE_TRUE_FIELDS.includes(value.toLowerCase());

--- a/client/src/app/site/modules/user-components/components/password-form/password-form.component.ts
+++ b/client/src/app/site/modules/user-components/components/password-form/password-form.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
-import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
+import { TranslateService } from '@ngx-translate/core';
+import { BaseComponent } from 'src/app/site/base/base.component';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 
 import { PasswordForm } from '../../definitions';
 import { PasswordValidator } from '../../validators';
@@ -24,7 +26,7 @@ const UndesiredPasswordFeedback = `ಠ_ಠ`;
     templateUrl: `./password-form.component.html`,
     styleUrls: [`./password-form.component.scss`]
 })
-export class PasswordFormComponent extends BaseUiComponent implements OnInit {
+export class PasswordFormComponent extends BaseComponent implements OnInit {
     @Output()
     public changeEvent = new EventEmitter<PasswordForm>();
 
@@ -38,8 +40,12 @@ export class PasswordFormComponent extends BaseUiComponent implements OnInit {
     public hideNewPassword = true;
     public hideConfirmPassword = true;
 
-    public constructor(private fb: UntypedFormBuilder) {
-        super();
+    public constructor(
+        private fb: UntypedFormBuilder,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
+    ) {
+        super(componentServiceCollector, translate);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/modules/user-components/components/user-multiselect-actions/user-multiselect-actions.component.ts
+++ b/client/src/app/site/modules/user-components/components/user-multiselect-actions/user-multiselect-actions.component.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, TemplateRef, ViewChild } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
+import { BaseComponent } from 'src/app/site/base/base.component';
 import { ActiveMeetingIdService } from 'src/app/site/pages/meetings/services/active-meeting-id.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 import { UserControllerService } from 'src/app/site/services/user-controller.service';
-import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
 @Component({
@@ -14,7 +15,7 @@ import { PromptService } from 'src/app/ui/modules/prompt-dialog';
     styleUrls: [`./user-multiselect-actions.component.scss`],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class UserMultiselectActionsComponent extends BaseUiComponent {
+export class UserMultiselectActionsComponent extends BaseComponent {
     @ViewChild(TemplateRef, { static: true })
     public implicitContent: TemplateRef<any>;
 
@@ -37,14 +38,15 @@ export class UserMultiselectActionsComponent extends BaseUiComponent {
     public selectedUsersChange = new EventEmitter<ViewUser[]>();
 
     public constructor(
-        private translate: TranslateService,
         private operator: OperatorService,
         private promptService: PromptService,
         private matSnackbar: MatSnackBar,
         private activeMeetingIdService: ActiveMeetingIdService,
-        public repo: UserControllerService
+        public repo: UserControllerService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super();
+        super(componentServiceCollector, translate);
     }
 
     /**
@@ -109,8 +111,4 @@ export class UserMultiselectActionsComponent extends BaseUiComponent {
     public deleteSelected(): void {
         this.deleting.emit();
     }
-
-    protected override raiseError = (message: string): void => {
-        this.matSnackbar.open(message, this.translate.instant(`OK`));
-    };
 }

--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
@@ -1,13 +1,15 @@
 import { ChangeDetectorRef, Directive, Input } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, debounceTime, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { IdentifiedVotingData, PollPropertyVerbose, VoteValue, VotingData } from 'src/app/domain/models/poll';
+import { BaseComponent } from 'src/app/site/base/base.component';
 import { BaseViewModel } from 'src/app/site/base/base-view-model';
 import { PollControllerService } from 'src/app/site/pages/meetings/modules/poll/services/poll-controller.service';
 import { ViewPoll } from 'src/app/site/pages/meetings/pages/polls';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
-import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
 
 import { MeetingSettingsService } from '../../../services/meeting-settings.service';
 import { VotingProhibition, VotingService } from '../services/voting.service';
@@ -20,7 +22,7 @@ export interface VoteOption {
 }
 
 @Directive()
-export abstract class BasePollVoteComponent<C extends BaseViewModel = any> extends BaseUiComponent {
+export abstract class BasePollVoteComponent<C extends BaseViewModel = any> extends BaseComponent {
     @Input()
     public set poll(value: ViewPoll<C>) {
         this._poll = value;
@@ -66,9 +68,11 @@ export abstract class BasePollVoteComponent<C extends BaseViewModel = any> exten
         protected votingService: VotingService,
         protected cd: ChangeDetectorRef,
         private pollRepo: PollControllerService,
-        private meetingSettingsService: MeetingSettingsService
+        private meetingSettingsService: MeetingSettingsService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super();
+        super(componentServiceCollector, translate);
         this.subscriptions.push(
             operator.userObservable.pipe(debounceTime(50)).subscribe(user => {
                 if (user) {

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-vote/topic-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-vote/topic-poll-vote.component.ts
@@ -11,6 +11,7 @@ import { VotingService } from 'src/app/site/pages/meetings/modules/poll/services
 import { ViewOption } from 'src/app/site/pages/meetings/pages/polls';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
@@ -54,15 +55,16 @@ export class TopicPollVoteComponent extends BasePollVoteComponent<ViewTopic> imp
     }
 
     public constructor(
+        private promptService: PromptService,
         operator: OperatorService,
         votingService: VotingService,
-        pollRepo: PollControllerService,
-        private promptService: PromptService,
         cd: ChangeDetectorRef,
-        private translate: TranslateService,
-        meetingSettingsService: MeetingSettingsService
+        pollRepo: PollControllerService,
+        meetingSettingsService: MeetingSettingsService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super(operator, votingService, cd, pollRepo, meetingSettingsService);
+        super(operator, votingService, cd, pollRepo, meetingSettingsService, componentServiceCollector, translate);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.ts
@@ -13,6 +13,7 @@ import { ViewAssignment } from 'src/app/site/pages/meetings/pages/assignments';
 import { ViewOption } from 'src/app/site/pages/meetings/pages/polls';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
@@ -67,15 +68,16 @@ export class AssignmentPollVoteComponent extends BasePollVoteComponent<ViewAssig
     }
 
     public constructor(
+        private promptService: PromptService,
         operator: OperatorService,
         votingService: VotingService,
-        pollRepo: PollControllerService,
         cd: ChangeDetectorRef,
-        private promptService: PromptService,
-        private translate: TranslateService,
-        meetingSettingsService: MeetingSettingsService
+        pollRepo: PollControllerService,
+        meetingSettingsService: MeetingSettingsService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super(operator, votingService, cd, pollRepo, meetingSettingsService);
+        super(operator, votingService, cd, pollRepo, meetingSettingsService, componentServiceCollector, translate);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/pages/meetings/pages/history/components/history-list/history-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/history/components/history-list/history-list.component.html
@@ -56,7 +56,7 @@
         <!-- Timestamp -->
         <ng-container matColumnDef="time">
             <mat-header-cell *matHeaderCellDef>{{ 'Timestamp' | translate }}</mat-header-cell>
-            <mat-cell *matCellDef="let position">{{ getTimestamp(position) }}</mat-cell>
+            <mat-cell *matCellDef="let position">{{ position.timestamp | localizedDate }}</mat-cell>
         </ng-container>
 
         <!-- Info -->

--- a/client/src/app/site/pages/meetings/pages/history/components/history-list/history-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/history/components/history-list/history-list.component.ts
@@ -14,7 +14,6 @@ import { AssignmentRepositoryService } from 'src/app/gateways/repositories/assig
 import { BaseRepository } from 'src/app/gateways/repositories/base-repository';
 import { MotionRepositoryService } from 'src/app/gateways/repositories/motions';
 import { UserRepositoryService } from 'src/app/gateways/repositories/users';
-import { langToLocale } from 'src/app/infrastructure/utils/lang-to-locale';
 import {
     collectionIdFromFqid,
     fqidFromCollectionAndId,
@@ -267,10 +266,6 @@ export class HistoryListComponent extends BaseMeetingComponent implements OnInit
             const message = this.translate.instant(`Cannot navigate to the selected history element.`);
             this.raiseError(message);
         }
-    }
-
-    public getTimestamp(position: Position): string {
-        return position.getLocaleString(langToLocale(this.translate.currentLang));
     }
 
     public refresh(): void {

--- a/client/src/app/site/pages/meetings/pages/history/definitions/position.ts
+++ b/client/src/app/site/pages/meetings/pages/history/definitions/position.ts
@@ -4,23 +4,9 @@ export class Position {
     public information: string[];
     public user: string;
 
-    public get date(): Date {
-        return new Date(this.timestamp * 1000);
-    }
-
     public constructor(input: Position) {
         if (input) {
             Object.assign(this, input);
         }
-    }
-
-    /**
-     * Converts the date (this.now) to a time and date string.
-     *
-     * @param locale locale indicator, i.e 'de-DE'
-     * @returns a human readable kind of time and date representation
-     */
-    public getLocaleString(locale: string): string {
-        return this.date.toLocaleString(locale);
     }
 }

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-vote/motion-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-vote/motion-poll-vote.component.ts
@@ -10,6 +10,7 @@ import { PollControllerService } from 'src/app/site/pages/meetings/modules/poll/
 import { VotingService } from 'src/app/site/pages/meetings/modules/poll/services/voting.service';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
@@ -41,15 +42,16 @@ export class MotionPollVoteComponent extends BasePollVoteComponent implements On
     ];
 
     public constructor(
+        private promptService: PromptService,
         operator: OperatorService,
         votingService: VotingService,
-        pollRepo: PollControllerService,
         cd: ChangeDetectorRef,
-        private translate: TranslateService,
-        private promptService: PromptService,
-        meetingSettingsService: MeetingSettingsService
+        pollRepo: PollControllerService,
+        meetingSettingsService: MeetingSettingsService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super(operator, votingService, cd, pollRepo, meetingSettingsService);
+        super(operator, votingService, cd, pollRepo, meetingSettingsService, componentServiceCollector, translate);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/modules/directives/listen-editing/listen-editing.directive.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/modules/directives/listen-editing/listen-editing.directive.ts
@@ -1,13 +1,12 @@
 import { Directive, Input, OnDestroy } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 import { Fqid } from 'src/app/domain/definitions/key-types';
 import { BaseModel } from 'src/app/domain/models/base/base-model';
 import { NotifyService } from 'src/app/gateways/notify.service';
+import { BaseComponent } from 'src/app/site/base/base.component';
 import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
-import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
 
 /**
  * Enum to define different types of notifications.
@@ -72,7 +71,7 @@ interface EditObject {
 @Directive({
     selector: `[osListenEditing]`
 })
-export class ListenEditingDirective extends BaseUiComponent implements OnDestroy {
+export class ListenEditingDirective extends BaseComponent implements OnDestroy {
     @Input()
     public set osListenEditing(editObject: EditObject) {
         this.isEditing = editObject.editMode;
@@ -107,27 +106,13 @@ export class ListenEditingDirective extends BaseUiComponent implements OnDestroy
 
     private isEditing = false;
 
-    private get matSnackBar(): MatSnackBar {
-        return this.componentServiceCollector.matSnackBar;
-    }
-
     public constructor(
-        private componentServiceCollector: ComponentServiceCollectorService,
-        private translate: TranslateService,
         private notifyService: NotifyService,
-        private operator: OperatorService
+        private operator: OperatorService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super();
-
-        this.raiseWarning = (warn: string) => {
-            this.matSnackBar.open(warn, this.translate.instant(`OK`), {
-                duration: 0
-            });
-        };
-
-        this.closeSnackbar = (): void => {
-            this.matSnackBar.dismiss();
-        };
+        super(componentServiceCollector, translate);
     }
 
     public override ngOnDestroy(): void {
@@ -230,7 +215,7 @@ export class ListenEditingDirective extends BaseUiComponent implements OnDestroy
     private recognizeOtherWorkerOnMotion(senderName: string): void {
         this.otherWorkOnBaseModel = this.otherWorkOnBaseModel.filter(value => value !== senderName);
         if (this.otherWorkOnBaseModel.length === 0) {
-            this.closeSnackbar();
+            this.closeSnackBar();
         }
     }
 
@@ -243,7 +228,7 @@ export class ListenEditingDirective extends BaseUiComponent implements OnDestroy
     private unsubscribeEditNotifications(unsubscriptionReason: EditNotificationType): void {
         if (this.editNotificationSubscription && !this.editNotificationSubscription.closed) {
             this.sendEditNotification(unsubscriptionReason);
-            this.closeSnackbar();
+            this.closeSnackBar();
             this.editNotificationSubscription.unsubscribe();
         }
     }

--- a/client/src/app/site/pages/meetings/pages/motions/services/list/motion-list-sort.service/motion-list-sort.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/list/motion-list-sort.service/motion-list-sort.service.ts
@@ -39,8 +39,8 @@ export class MotionListSortService extends BaseSortListService<ViewMotion> {
         { property: `category`, sortFn: this.categorySortFn },
         { property: `block_id`, label: `Motion block` },
         { property: `state` },
-        { property: `creationDate`, label: _(`Creation date`) },
-        { property: `lastChangeDate`, label: _(`Last modified`) }
+        { property: `created`, label: _(`Creation date`) },
+        { property: `last_modified`, label: _(`Last modified`) }
     ];
 
     /**

--- a/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
@@ -97,26 +97,6 @@ export class ViewMotion extends BaseProjectableViewModel<Motion> {
     }
 
     /**
-     * @returns the creation date as Date object
-     */
-    public get creationDate(): Date | null {
-        if (!this.motion.created) {
-            return null;
-        }
-        return new Date(this.motion.created);
-    }
-
-    /**
-     * @returns the date of the last change as Date object, null if empty
-     */
-    public get lastChangeDate(): Date | null {
-        if (!this.motion.last_modified) {
-            return null;
-        }
-        return new Date(this.motion.last_modified);
-    }
-
-    /**
      * @returns the current state extension if the workwlof allows for extenstion fields
      */
     public get stateExtension(): string | null {

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-multiselect-actions/participant-multiselect-actions.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-multiselect-actions/participant-multiselect-actions.component.ts
@@ -1,9 +1,10 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { BaseComponent } from 'src/app/site/base/base.component';
 import { ParticipantControllerService } from 'src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
-import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
 @Component({
@@ -11,7 +12,7 @@ import { PromptService } from 'src/app/ui/modules/prompt-dialog';
     templateUrl: `./participant-multiselect-actions.component.html`,
     styleUrls: [`./participant-multiselect-actions.component.scss`]
 })
-export class ParticipantMultiselectActionsComponent extends BaseUiComponent {
+export class ParticipantMultiselectActionsComponent extends BaseComponent {
     @Input()
     public selectedUsers: ViewUser[] = [];
 
@@ -25,12 +26,13 @@ export class ParticipantMultiselectActionsComponent extends BaseUiComponent {
     public deselectAll = new EventEmitter<void>();
 
     public constructor(
-        private translate: TranslateService,
         private operator: OperatorService,
         private promptService: PromptService,
-        public repo: ParticipantControllerService
+        public repo: ParticipantControllerService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super();
+        super(componentServiceCollector, translate);
     }
 
     /**

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-password/account-password.component.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-password/account-password.component.ts
@@ -1,20 +1,21 @@
 import { AfterViewInit, Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { OML } from 'src/app/domain/definitions/organization-permission';
+import { BaseComponent } from 'src/app/site/base/base.component';
 import { PasswordForm } from 'src/app/site/modules/user-components';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { OpenSlidesRouterService } from 'src/app/site/services/openslides-router.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 import { UserControllerService } from 'src/app/site/services/user-controller.service';
-import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
 
 @Component({
     selector: `os-account-password`,
     templateUrl: `./account-password.component.html`,
     styleUrls: [`./account-password.component.scss`]
 })
-export class AccountPasswordComponent extends BaseUiComponent implements OnInit, AfterViewInit {
+export class AccountPasswordComponent extends BaseComponent implements OnInit, AfterViewInit {
     public isValid = false;
     public passwordForm: PasswordForm | string = ``;
     public user: ViewUser | null = null;
@@ -26,10 +27,11 @@ export class AccountPasswordComponent extends BaseUiComponent implements OnInit,
     public constructor(
         private operator: OperatorService,
         private userController: UserControllerService,
-        private router: Router,
-        private osRouter: OpenSlidesRouterService
+        private osRouter: OpenSlidesRouterService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super();
+        super(componentServiceCollector, translate);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/pages/organization/pages/organization-info/components/organization-statistics/organization-statistics.component.ts
+++ b/client/src/app/site/pages/organization/pages/organization-info/components/organization-statistics/organization-statistics.component.ts
@@ -1,17 +1,19 @@
 import { Component, OnInit } from '@angular/core';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
+import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
+import { BaseComponent } from 'src/app/site/base/base.component';
 import { OrganizationService } from 'src/app/site/pages/organization/services/organization.service';
 import { OrganizationSettingsService } from 'src/app/site/pages/organization/services/organization-settings.service';
+import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { UserControllerService } from 'src/app/site/services/user-controller.service';
-import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
 
 @Component({
     selector: `os-organization-statistics`,
     templateUrl: `./organization-statistics.component.html`,
     styleUrls: [`./organization-statistics.component.scss`]
 })
-export class OrganizationStatisticsComponent extends BaseUiComponent implements OnInit {
+export class OrganizationStatisticsComponent extends BaseComponent implements OnInit {
     public activeMeetingsText = _(`Active meetings`);
     public activeUsersText = _(`Active accounts`);
 
@@ -24,9 +26,11 @@ export class OrganizationStatisticsComponent extends BaseUiComponent implements 
     public constructor(
         private orgaService: OrganizationService,
         private orgaSettings: OrganizationSettingsService,
-        private userController: UserControllerService
+        private userController: UserControllerService,
+        componentServiceCollector: ComponentServiceCollectorService,
+        translate: TranslateService
     ) {
-        super();
+        super(componentServiceCollector, translate);
     }
 
     public ngOnInit(): void {

--- a/client/src/app/site/pages/organization/services/organization.service.ts
+++ b/client/src/app/site/pages/organization/services/organization.service.ts
@@ -10,11 +10,6 @@ import { getDesignListSubscriptionConfig } from '../pages/designs/config/model-s
 import { ViewOrganization } from '../view-models/view-organization';
 
 /**
- * Token to get a resource dedicated to the `logo_web_header` of an organization.
- */
-export const WEB_HEADER_TOKEN = `web_header`;
-
-/**
  * The organization_id is always the 1.
  */
 export const ORGANIZATION_ID = 1;

--- a/client/src/app/site/pages/organization/view-models/view-organization.ts
+++ b/client/src/app/site/pages/organization/view-models/view-organization.ts
@@ -12,7 +12,6 @@ import { ViewResource } from '../pages/resources';
 
 export class ViewOrganization extends BaseViewModel<Organization> {
     public static COLLECTION = Organization.COLLECTION;
-    protected _collection = Organization.COLLECTION;
 
     public get organization(): Organization {
         return this._model;

--- a/client/src/app/ui/base/base-ui-component.ts
+++ b/client/src/app/ui/base/base-ui-component.ts
@@ -9,10 +9,28 @@ export class BaseUiComponent implements OnDestroy {
     protected subscriptions = new SubscriptionMap();
 
     public updateSubscription(name: string, subscription: Subscription): void {
+        this.clearSubscription(name);
         this.subscriptions.updateSubscription(name, subscription);
     }
 
+    private clearSubscription(name: string): void {
+        this.subscriptions.delete(name);
+    }
+
+    /**
+     * automatically clears subscriptions if the component is destroyed.
+     */
     public ngOnDestroy(): void {
+        this.cleanSubscriptions();
+    }
+
+    /**
+     * Manually clears all stored subscriptions.
+     * Necessary for manual routing control, since the Angular
+     * life cycle does not accept that navigation to the same URL
+     * executes the life cycle again
+     */
+    protected cleanSubscriptions(): void {
         this.subscriptions.clear();
     }
 
@@ -31,8 +49,4 @@ export class BaseUiComponent implements OnDestroy {
     public trackById(_index: number, item: Id | Identifiable): Id {
         return typeof item === `number` ? item : item.id;
     }
-
-    protected closeSnackbar = (): void => {};
-    protected raiseError = (message: string): void => {};
-    protected raiseWarning = (message: string): void => {};
 }

--- a/client/src/app/ui/modules/spinner/components/spinner/spinner.component.ts
+++ b/client/src/app/ui/modules/spinner/components/spinner/spinner.component.ts
@@ -1,15 +1,5 @@
 import { Component, Input } from '@angular/core';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
-import { shuffle } from 'src/app/infrastructure/utils';
-
-const POSSIBLE_MESSAGES = [
-    `Loading data. Please wait ...`,
-    `An administrator has to be elected`,
-    `Motions are being written`,
-    `Change recommendations are being assigned`,
-    `A submitter has finally submitted their motion`,
-    `One topic on the agenda is to eat some cake`
-];
 
 /**
  * Component for the global spinner.
@@ -55,8 +45,6 @@ export class SpinnerComponent {
 
     private _height = `100px`;
     private _width = `100px`;
-
-    private readonly _possibleMessages = shuffle(POSSIBLE_MESSAGES);
 
     public constructor() {
         this.text = this.text || _(`Loading data. Please wait ...`);


### PR DESCRIPTION
- remove unnecessary & inefficient shuffle function
- unify truthy env values with other services
- unify `BaseComponent` & `BaseUiComponent` (the latter provided a subset of the functionality of the former, which leads to the unfortunate class hierarchy where `BaseComponent` extends `BaseUiComponent`, but renaming them would not be worse the hassle, I think)
  - also moved some classes to inherit from `BaseComponent` instead of `BaseUiComponent` - this fixes some errors where subclasses used the e.g. `raiseError` function from `BaseUiComponent` which was previously the empty function (wtf?)
- unified & fixed timestamp handling in history list & motion list sort
- removed unused variables in `ViewOrganization`, `OrganizationService` and `SpinnerService`