### PR TITLE
fix os-banner causing extra scroll bar

### DIFF
--- a/client/src/app/site/modules/site-wrapper/components/site-wrapper/site-wrapper.component.html
+++ b/client/src/app/site/modules/site-wrapper/components/site-wrapper/site-wrapper.component.html
@@ -1,5 +1,12 @@
-<os-banner></os-banner>
-<router-outlet></router-outlet>
+<div class="os-site-wrapper-container">
+    <div class="os-banner-container">
+        <os-banner></os-banner>
+    </div>
+
+    <div class="os-router-outlet-container">
+        <router-outlet></router-outlet>
+    </div>
+</div>
 
 <ng-template #updateNotificationTemplate>
     <div class="action-title">

--- a/client/src/app/site/modules/site-wrapper/components/site-wrapper/site-wrapper.component.scss
+++ b/client/src/app/site/modules/site-wrapper/components/site-wrapper/site-wrapper.component.scss
@@ -1,0 +1,13 @@
+.os-site-wrapper-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    .os-banner-container {
+        flex: 0 0 auto;
+    }
+
+    .os-router-outlet-container {
+        flex-grow: 1;
+    }
+}

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projectable-list/components/projectable-list/projectable-list.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projectable-list/components/projectable-list/projectable-list.component.html
@@ -1,7 +1,6 @@
 <os-view-list
     [alsoFilterByProperties]="alsoFilterByProperties"
     [alwaysShowMenu]="alwaysShowMenu"
-    [componentHeight]="componentHeight"
     [filterService]="filterService"
     [filterProps]="filterProps"
     [hiddenColumns]="hiddenColumns"

--- a/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.html
+++ b/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.html
@@ -40,7 +40,7 @@
         vScrollFixed="50"
         [showHeader]="true"
         [dataSource]="dataSource"
-        [ngStyle]="{ height: tableHeight }"
+        [tableHeight]="tableHeight"
     >
         <div *osScrollingTableCell="'remove'; row as file; config: { width: 24 }">
             <button mat-icon-button (click)="onRemoveButton(file)" matTooltip="{{ 'Remove file' | translate }}">

--- a/client/src/app/ui/modules/import-list/components/import-list/import-list.component.html
+++ b/client/src/app/ui/modules/import-list/components/import-list/import-list.component.html
@@ -227,6 +227,7 @@
     <os-scrolling-table
         style="height: 500px"
         class="import-list-preview-table"
+        tableHeight="500px"
         [rowHeight]="50"
         [dataSource]="dataSource"
         [showHeader]="true"

--- a/client/src/app/ui/modules/list/components/list/list.component.html
+++ b/client/src/app/ui/modules/list/components/list/list.component.html
@@ -1,7 +1,6 @@
 <os-view-list
     [alsoFilterByProperties]="alsoFilterByProperties"
     [alwaysShowMenu]="alwaysShowMenu"
-    [componentHeight]="componentHeight"
     [filterService]="filterService"
     [filterProps]="filterProps"
     [hiddenColumns]="hiddenColumns"

--- a/client/src/app/ui/modules/list/components/view-list/view-list.component.html
+++ b/client/src/app/ui/modules/list/components/view-list/view-list.component.html
@@ -1,4 +1,4 @@
-<mat-drawer-container class="list-view-frame" [ngStyle]="{ height: componentHeight }">
+<mat-drawer-container class="list-view-frame">
     <div class="list-view-table-wrapper">
         <os-sort-filter-bar
             *ngIf="showFilterBar"

--- a/client/src/app/ui/modules/list/components/view-list/view-list.component.ts
+++ b/client/src/app/ui/modules/list/components/view-list/view-list.component.ts
@@ -99,15 +99,6 @@ export class ViewListComponent<V extends Identifiable> implements OnInit {
     public vScrollFixed = 110;
 
     /**
-     * The actual height of the ListComponent. You can pass only a string to adjust the height,
-     * because it is passed to the [ngStyle] of the underlying template.
-     * The viewport height is decreased by `90px`. This is almost the summary of the height of the global
-     * and local headbar.
-     */
-    @Input()
-    public componentHeight: string;
-
-    /**
      * Determines whether the table should have a fixed 100vh height or not.
      * If not, the height must be set by the component
      */

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
@@ -1,44 +1,16 @@
 <ng-container *ngIf="cellDefinitionsObservable | async as definitions">
     <ng-container *ngIf="hasDataObservable | async; else noDataTemplate">
-        <cdk-virtual-scroll-viewport class="virtual-scroll-viewport background-card" [itemSize]="rowHeight">
-            <div
-                *ngIf="showHeader"
-                class="flex-vertical-center placeholder divider-bottom scrolling-table-header"
-                [ngStyle]="ngStyle"
-            >
-                <ng-container *ngFor="let definition of definitions; let first = first">
-                    <div
-                        class="scrolling-table-cell flex-vertical-center subtitle"
-                        [ngClass]="{ 'divider-left': !first }"
-                        [ngStyle]="{
-                            flexBasis: definition.width || defaultColumnWidth,
-                            width: definition.width || defaultColumnWidth,
-                            minWidth: definition.minWidth || defaultColumnWidth,
-                            maxWidth: definition.maxWidth || defaultColumnWidth
-                        }"
-                    >
-                        <ng-template [ngIf]="definition.labelTemplate">
-                            <ng-template [cdkPortalOutlet]="definition.labelTemplate"></ng-template>
-                        </ng-template>
-                        <ng-template [ngIf]="!definition.labelTemplate">
-                            <ng-template>{{ definition.labelString }}</ng-template>
-                        </ng-template>
-                    </div>
-                </ng-container>
-            </div>
-            <ng-container *cdkVirtualFor="let item of dataSource">
+        <div [style.height]="calculateContainerHeight()">
+            <cdk-virtual-scroll-viewport class="virtual-scroll-viewport background-card" [itemSize]="rowHeight">
                 <div
-                    class="scrolling-table-row divider-bottom flex-center"
-                    [ngClass]="rowClass"
+                    *ngIf="showHeader"
+                    class="flex-vertical-center placeholder divider-bottom scrolling-table-header"
                     [ngStyle]="ngStyle"
-                    (click)="onRowClick($event, item)"
                 >
-                    <div *ngIf="isSelectionMode" class="selection-cell scrolling-table-cell flex-vertical-center">
-                        <mat-checkbox [class.mat-checkbox-disabled]="false" [checked]="isSelected(item)" disabled></mat-checkbox>
-                    </div>
-                    <ng-container *ngFor="let definition of definitions">
+                    <ng-container *ngFor="let definition of definitions; let first = first">
                         <div
-                            class="scrolling-table-cell flex-vertical-center"
+                            class="scrolling-table-cell flex-vertical-center subtitle"
+                            [ngClass]="{ 'divider-left': !first }"
                             [ngStyle]="{
                                 flexBasis: definition.width || defaultColumnWidth,
                                 width: definition.width || defaultColumnWidth,
@@ -46,21 +18,51 @@
                                 maxWidth: definition.maxWidth || defaultColumnWidth
                             }"
                         >
-                            <ng-container
-                                *ngTemplateOutlet="
-                                    definition.template;
-                                    context: {
-                                        row: item,
-                                        value: item[definition.property],
-                                        definition: definition.property
-                                    }
-                                "
-                            ></ng-container>
+                            <ng-template [ngIf]="definition.labelTemplate">
+                                <ng-template [cdkPortalOutlet]="definition.labelTemplate"></ng-template>
+                            </ng-template>
+                            <ng-template [ngIf]="!definition.labelTemplate">
+                                <ng-template>{{ definition.labelString }}</ng-template>
+                            </ng-template>
                         </div>
                     </ng-container>
                 </div>
-            </ng-container>
-        </cdk-virtual-scroll-viewport>
+                <ng-container *cdkVirtualFor="let item of dataSource">
+                    <div
+                        class="scrolling-table-row divider-bottom flex-center"
+                        [ngClass]="rowClass"
+                        [ngStyle]="ngStyle"
+                        (click)="onRowClick($event, item)"
+                    >
+                        <div *ngIf="isSelectionMode" class="selection-cell scrolling-table-cell flex-vertical-center">
+                            <mat-checkbox [class.mat-checkbox-disabled]="false" [checked]="isSelected(item)" disabled></mat-checkbox>
+                        </div>
+                        <ng-container *ngFor="let definition of definitions">
+                            <div
+                                class="scrolling-table-cell flex-vertical-center"
+                                [ngStyle]="{
+                                    flexBasis: definition.width || defaultColumnWidth,
+                                    width: definition.width || defaultColumnWidth,
+                                    minWidth: definition.minWidth || defaultColumnWidth,
+                                    maxWidth: definition.maxWidth || defaultColumnWidth
+                                }"
+                            >
+                                <ng-container
+                                    *ngTemplateOutlet="
+                                        definition.template;
+                                        context: {
+                                            row: item,
+                                            value: item[definition.property],
+                                            definition: definition.property
+                                        }
+                                    "
+                                ></ng-container>
+                            </div>
+                        </ng-container>
+                    </div>
+                </ng-container>
+            </cdk-virtual-scroll-viewport>
+        </div>
     </ng-container>
 </ng-container>
 

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -43,6 +43,9 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     public scrollViewport: CdkVirtualScrollViewport | undefined;
 
     @Input()
+    public tableHeight: string | undefined = undefined;
+
+    @Input()
     public rowHeight = 70;
 
     @Input()
@@ -205,6 +208,10 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     }
 
     public calculateContainerHeight(): string {
+        if (this.tableHeight) {
+            return this.tableHeight;
+        }
+
         return this.rowHeight * this._dataSource.getValue().length + `px`;
     }
 

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -204,6 +204,10 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
         return this._currentSelection[row.id] !== undefined;
     }
 
+    public calculateContainerHeight(): string {
+        return this.rowHeight * this._dataSource.getValue().length + `px`;
+    }
+
     private buildDataTable(): void {
         const source = [...this._source].sort((a, b) => a.id - b.id);
         const sourceMapKeys = Object.keys(this._dataSourceMap)


### PR DESCRIPTION
resolves #548 

Fixes the mentioned scrollbar using the approach from #1463 but addresses the resulting issue with scroll lists (https://github.com/OpenSlides/openslides-client/pull/1463#issuecomment-1202593637). 

This PR changes the scrolling behavior of the scrolling table. The global headbar and page specific headbar gets hidden when scrolling. 