### PR TITLE
fix removal of single au connections

### DIFF
--- a/client/src/app/worker/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate-stream-pool.ts
@@ -233,6 +233,8 @@ export class AutoupdateStreamPool {
             let params = new URLSearchParams(stream.queryParams);
             if (+params.get(`position`) === 0 && !params.get(`single`)) {
                 await this.handleError(stream, null);
+            } else {
+                this.removeStream(stream);
             }
         }
     }


### PR DESCRIPTION
resolves #1934 

There was an error that single autoupdate connections would not be deleted from the connection pool after they were resolved. This resulted in positive duplicate checks and sending outdated data from the auotupdate service worker. 