### PR TITLE
Added unsafe versions of flex center and flex-vertical-center styles

### DIFF
--- a/client/src/app/ui/modules/openslides-overlay/components/overlay/overlay.component.html
+++ b/client/src/app/ui/modules/openslides-overlay/components/overlay/overlay.component.html
@@ -1,4 +1,4 @@
-<div class="flex-center overlay-component stretch-to-fill-parent" data-cy="osOverlay">
+<div class="flex-center-unsafe overlay-component stretch-to-fill-parent" data-cy="osOverlay">
     <div class="overlay-content" #viewContainer></div>
     <div class="overlay-backdrop stretch-to-fill-parent" (click)="backdrop.emit()"></div>
 </div>

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -800,6 +800,16 @@ button.mat-menu-item.selected {
     display: none;
 }
 
+.flex-vertical-center-unsafe {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    &.align-left {
+        justify-content: flex-start;
+    }
+}
+
 .flex-vertical-center {
     display: flex;
     flex-direction: row;
@@ -816,6 +826,11 @@ button.mat-menu-item.selected {
 
 .flex-center {
     @extend .flex-vertical-center;
+    justify-content: center;
+}
+
+.flex-center-unsafe {
+    @extend .flex-vertical-center-unsafe;
     justify-content: center;
 }
 


### PR DESCRIPTION
Closes #1944 

This way the unsafe variants can be used wherever the the safe variants break