### PR TITLE
move autoupdate received data management to stream

### DIFF
--- a/client/src/app/worker/autoupdate-stream.ts
+++ b/client/src/app/worker/autoupdate-stream.ts
@@ -18,6 +18,14 @@ export class AutoupdateStream {
     private active: boolean = false;
     private error: any | ErrorDescription = null;
     private restarting: boolean = false;
+    private _currentData: Object | null = null;
+
+    /**
+     * Full data object received by autoupdate
+     */
+    public get currentData(): Object | null {
+        return this._currentData;
+    }
 
     public get subscriptions(): AutoupdateSubscription[] {
         return this._subscriptions;
@@ -139,9 +147,7 @@ export class AutoupdateStream {
     }
 
     public clearSubscriptions(): void {
-        for (let subscription of this.subscriptions) {
-            subscription.currentData = null;
-        }
+        this._currentData = null;
     }
 
     public setAuthToken(token: string): void {
@@ -238,6 +244,12 @@ export class AutoupdateStream {
             this.error = data;
             this.sendErrorToSubscriptions(data);
         } else {
+            if (this._currentData !== null) {
+                Object.assign(this._currentData, data);
+            } else {
+                this._currentData = data;
+            }
+
             this.failedCounter = 0;
             this.sendToSubscriptions(data);
         }

--- a/client/src/app/worker/autoupdate-subscription.ts
+++ b/client/src/app/worker/autoupdate-subscription.ts
@@ -3,11 +3,6 @@ import { AutoupdateReceiveData, AutoupdateReceiveError, AutoupdateSetStreamId } 
 
 export class AutoupdateSubscription {
     /**
-     * Full data object received by autoupdate
-     */
-    public currentData: Object | null = null;
-
-    /**
      * The stream handling this subscription
      */
     public stream: AutoupdateStream;
@@ -48,18 +43,11 @@ export class AutoupdateSubscription {
     }
 
     /**
-     * Updates the internal data state and sends the given data
-     * to all registered MessagePorts.
+     * Sends the given data to all registered MessagePorts.
      *
      * @param data The data to be processed
      */
     public updateData(data: Object): void {
-        if (this.currentData === null) {
-            this.currentData = data;
-        } else {
-            this.currentData = Object.assign(this.currentData, data);
-        }
-
         for (let port of this.ports) {
             port.postMessage({
                 sender: `autoupdate`,
@@ -131,13 +119,13 @@ export class AutoupdateSubscription {
      * @param port The MessagePort the data should be send to
      */
     public resendTo(port: MessagePort): void {
-        if (this.currentData !== null) {
+        if (this.stream.currentData !== null) {
             port.postMessage({
                 sender: `autoupdate`,
                 action: `receive-data`,
                 content: {
                     streamId: this.id,
-                    data: this.currentData,
+                    data: this.stream.currentData,
                     description: this.description
                 }
             } as AutoupdateReceiveData);


### PR DESCRIPTION
Currently the data received from autoupdate is saved and managed in every subscription of a stream.
This PR changes that to manage the received data within the stream to prevent unnecessary handling of the received data within every subscription of a stream. 

This closes #1664 as sending of au data multiple times does not seem to cause any issues anymore and the `SequentialNumberMappingService:prepare` is handled differently now. 