### PR TITLE
Repaired getUploadFileJson function error catching

### DIFF
--- a/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
+++ b/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
@@ -5,6 +6,35 @@ import { FileData } from 'src/app/ui/modules/file-upload/components/file-upload/
 
 export const WRONG_JSON_IMPORT_FORMAT_ERROR_MSG = _(`Import data needs to have the JSON format`);
 
+@Injectable({
+    providedIn: `root`
+})
+export class UploadFileJsonProcessorService {
+    constructor(private snackbar: MatSnackBar, private translate: TranslateService) {}
+
+    public async getUploadFileJson<ExpectType>(file: FileData): Promise<ExpectType> {
+        const json = await new Promise<ExpectType>(resolve => {
+            const reader = new FileReader();
+            reader.addEventListener(`load`, progress => {
+                let result;
+                try {
+                    result = JSON.parse(progress.target!.result as string);
+                } catch (e) {
+                    this.snackbar.open(
+                        `${this.translate.instant(`Error`)}: ${this.translate.instant(
+                            WRONG_JSON_IMPORT_FORMAT_ERROR_MSG
+                        )}`,
+                        `OK`
+                    );
+                    throw new Error(WRONG_JSON_IMPORT_FORMAT_ERROR_MSG);
+                }
+                resolve(result);
+            });
+            reader.readAsText(file.mediafile);
+        });
+        return json;
+    }
+}
 export async function getUploadFileJson<ExpectType>(
     file: FileData,
     snackbar: MatSnackBar,

--- a/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
+++ b/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
@@ -35,27 +35,3 @@ export class UploadFileJsonProcessorService {
         return json;
     }
 }
-export async function getUploadFileJson<ExpectType>(
-    file: FileData,
-    snackbar: MatSnackBar,
-    translate: TranslateService
-): Promise<ExpectType> {
-    const json = await new Promise<ExpectType>(resolve => {
-        const reader = new FileReader();
-        reader.addEventListener(`load`, progress => {
-            let result;
-            try {
-                result = JSON.parse(progress.target!.result as string);
-            } catch (e) {
-                snackbar.open(
-                    `${translate.instant(`Error`)}: ${translate.instant(WRONG_JSON_IMPORT_FORMAT_ERROR_MSG)}`,
-                    `OK`
-                );
-                throw new Error(WRONG_JSON_IMPORT_FORMAT_ERROR_MSG);
-            }
-            resolve(result);
-        });
-        reader.readAsText(file.mediafile);
-    });
-    return json;
-}

--- a/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
+++ b/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
@@ -1,10 +1,15 @@
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
+import { TranslateService } from '@ngx-translate/core';
 import { FileData } from 'src/app/ui/modules/file-upload/components/file-upload/file-upload.component';
 
 export const WRONG_JSON_IMPORT_FORMAT_ERROR_MSG = _(`Import data needs to have the JSON format`);
 
-export async function getUploadFileJson<ExpectType>(file: FileData, snackbar: MatSnackBar): Promise<ExpectType> {
+export async function getUploadFileJson<ExpectType>(
+    file: FileData,
+    snackbar: MatSnackBar,
+    translate: TranslateService
+): Promise<ExpectType> {
     const json = await new Promise<ExpectType>(resolve => {
         const reader = new FileReader();
         reader.addEventListener(`load`, progress => {
@@ -13,7 +18,7 @@ export async function getUploadFileJson<ExpectType>(file: FileData, snackbar: Ma
                 result = JSON.parse(progress.target!.result as string);
             } catch (e) {
                 snackbar.open(
-                    `${this.translate.instant(`Error`)}: ${this.translate.instant(WRONG_JSON_IMPORT_FORMAT_ERROR_MSG)}`,
+                    `${translate.instant(`Error`)}: ${translate.instant(WRONG_JSON_IMPORT_FORMAT_ERROR_MSG)}`,
                     `OK`
                 );
                 throw new Error(WRONG_JSON_IMPORT_FORMAT_ERROR_MSG);

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-import/workflow-import.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-import/workflow-import.component.ts
@@ -2,7 +2,7 @@ import { Location } from '@angular/common';
 import { Component } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
-import { getUploadFileJson } from 'src/app/infrastructure/utils/import/json-import-file-utils';
+import { UploadFileJsonProcessorService } from 'src/app/infrastructure/utils/import/json-import-file-utils';
 import { FileData } from 'src/app/ui/modules/file-upload/components/file-upload/file-upload.component';
 
 import { MotionWorkflowControllerService } from '../../../../modules/workflows/services';
@@ -17,7 +17,8 @@ export class WorkflowImportComponent {
         private repo: MotionWorkflowControllerService,
         private location: Location,
         private snackbar: MatSnackBar,
-        private translate: TranslateService
+        private translate: TranslateService,
+        private uploadFileProcessor: UploadFileJsonProcessorService
     ) {}
 
     public onUploadSucceeded(): void {
@@ -26,7 +27,7 @@ export class WorkflowImportComponent {
 
     public getUploadFileFn(): (file: FileData) => any {
         return async file => {
-            const workflowJson = await getUploadFileJson<any[]>(file, this.snackbar, this.translate);
+            const workflowJson = await this.uploadFileProcessor.getUploadFileJson<any[]>(file);
             return this.repo.import(workflowJson);
         };
     }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-import/workflow-import.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-import/workflow-import.component.ts
@@ -26,7 +26,7 @@ export class WorkflowImportComponent {
 
     public getUploadFileFn(): (file: FileData) => any {
         return async file => {
-            const workflowJson = await getUploadFileJson<any[]>(file, this.snackbar);
+            const workflowJson = await getUploadFileJson<any[]>(file, this.snackbar, this.translate);
             return this.repo.import(workflowJson);
         };
     }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-import/workflow-import.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-import/workflow-import.component.ts
@@ -1,7 +1,5 @@
 import { Location } from '@angular/common';
 import { Component } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { TranslateService } from '@ngx-translate/core';
 import { UploadFileJsonProcessorService } from 'src/app/infrastructure/utils/import/json-import-file-utils';
 import { FileData } from 'src/app/ui/modules/file-upload/components/file-upload/file-upload.component';
 
@@ -16,8 +14,6 @@ export class WorkflowImportComponent {
     public constructor(
         private repo: MotionWorkflowControllerService,
         private location: Location,
-        private snackbar: MatSnackBar,
-        private translate: TranslateService,
         private uploadFileProcessor: UploadFileJsonProcessorService
     ) {}
 

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Identifiable } from 'src/app/domain/interfaces';
 import { ImportMeeting } from 'src/app/gateways/repositories/meeting-repository.service';
-import { getUploadFileJson } from 'src/app/infrastructure/utils/import/json-import-file-utils';
+import { UploadFileJsonProcessorService } from 'src/app/infrastructure/utils/import/json-import-file-utils';
 import { BaseComponent } from 'src/app/site/base/base.component';
 import { MeetingControllerService } from 'src/app/site/pages/meetings/services/meeting-controller.service';
 import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
@@ -26,7 +26,8 @@ export class MeetingImportComponent extends BaseComponent implements OnInit {
         private repo: MeetingControllerService,
         private osRouter: OpenSlidesRouterService,
         private location: Location,
-        private snackbar: MatSnackBar
+        private snackbar: MatSnackBar,
+        private uploadFileProcessor: UploadFileJsonProcessorService
     ) {
         super(componentServiceCollector, translate);
     }
@@ -47,7 +48,7 @@ export class MeetingImportComponent extends BaseComponent implements OnInit {
 
     public getUploadFileFn(): (file: FileData) => Promise<Identifiable> {
         return async file => {
-            const meeting = await getUploadFileJson<ImportMeeting>(file, this.snackbar, this.translate);
+            const meeting = await this.uploadFileProcessor.getUploadFileJson<ImportMeeting>(file);
             return this.repo.import(this._committeeId, meeting);
         };
     }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
@@ -1,6 +1,5 @@
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Identifiable } from 'src/app/domain/interfaces';
@@ -22,11 +21,10 @@ export class MeetingImportComponent extends BaseComponent implements OnInit {
 
     public constructor(
         componentServiceCollector: ComponentServiceCollectorService,
-        protected override translate: TranslateService,
+        translate: TranslateService,
         private repo: MeetingControllerService,
         private osRouter: OpenSlidesRouterService,
         private location: Location,
-        private snackbar: MatSnackBar,
         private uploadFileProcessor: UploadFileJsonProcessorService
     ) {
         super(componentServiceCollector, translate);

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-import/meeting-import.component.ts
@@ -47,7 +47,7 @@ export class MeetingImportComponent extends BaseComponent implements OnInit {
 
     public getUploadFileFn(): (file: FileData) => Promise<Identifiable> {
         return async file => {
-            const meeting = await getUploadFileJson<ImportMeeting>(file, this.snackbar);
+            const meeting = await getUploadFileJson<ImportMeeting>(file, this.snackbar, this.translate);
             return this.repo.import(this._committeeId, meeting);
         };
     }


### PR DESCRIPTION
Closes #1962 

Meeting and workflow imports should now throw a sensible error message if the json is not formatted correctly.

To test:
1. Take a json file that should  work
2. Break it (f.e. by adding a `,` after the last element of any array that is included in it)
3. When using it in the user import, pressing the upload button should throw an error "Import data needs to have the JSON format" along with showing with an equivalent snackbar message