### PR TITLE
Slight iconage rework

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
@@ -268,7 +268,7 @@
 
             <!-- Statutes -->
             <button mat-menu-item routerLink="statute-paragraphs" *ngIf="statutesEnabled">
-                <mat-icon>auto_awesome_mosaic</mat-icon>
+                <mat-icon>gavel</mat-icon>
                 <span>{{ 'Statute' | translate }}</span>
             </button>
 

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
@@ -242,7 +242,7 @@
             </button>
 
             <button mat-menu-item [disabled]="!selectedRows.length" (click)="changePhysicalStateOfSelectedUsers()">
-                <mat-icon>auto_awesome_mosaic</mat-icon>
+                <mat-icon>sync</mat-icon>
                 <span>{{ 'Set natural person ...' | translate }}</span>
             </button>
 

--- a/client/src/app/site/pages/organization/modules/navigation/organization-navigation/organization-navigation.component.ts
+++ b/client/src/app/site/pages/organization/modules/navigation/organization-navigation/organization-navigation.component.ts
@@ -17,13 +17,13 @@ export class OrganizationNavigationComponent {
         {
             route: `/`,
             displayName: `Calendar`,
-            icon: `event_available`,
+            icon: `auto_awesome_mosaic`,
             weight: 100
         },
         {
             route: `/committees`,
             displayName: `Committees`,
-            icon: `auto_awesome_mosaic`,
+            icon: `hub`,
             weight: 200
         },
         {

--- a/client/src/app/site/pages/organization/modules/navigation/organization-navigation/organization-navigation.component.ts
+++ b/client/src/app/site/pages/organization/modules/navigation/organization-navigation/organization-navigation.component.ts
@@ -17,7 +17,7 @@ export class OrganizationNavigationComponent {
         {
             route: `/`,
             displayName: `Calendar`,
-            icon: `auto_awesome_mosaic`,
+            icon: `apps`,
             weight: 100
         },
         {

--- a/client/src/app/site/pages/organization/modules/navigation/organization-navigation/organization-navigation.component.ts
+++ b/client/src/app/site/pages/organization/modules/navigation/organization-navigation/organization-navigation.component.ts
@@ -23,7 +23,7 @@ export class OrganizationNavigationComponent {
         {
             route: `/committees`,
             displayName: `Committees`,
-            icon: `hub`,
+            icon: `layers`,
             weight: 200
         },
         {

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail/account-detail.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail/account-detail.component.html
@@ -209,7 +209,7 @@
     </button>
     <ng-container *osOmlPerms="OML.can_manage_users">
         <button mat-menu-item [routerLink]="['/', 'accounts', user?.id, 'meetings']">
-            <mat-icon>auto_awesome_mosaic</mat-icon>
+            <mat-icon>event_available</mat-icon>
             <span>{{ 'Add to meetings' | translate }}</span>
         </button>
         <!-- invitation email -->

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.html
@@ -116,7 +116,7 @@
             <span>{{ 'Edit' | translate }}</span>
         </a>
         <a mat-menu-item [routerLink]="[member.id, 'meetings']" *osOmlPerms="OML.can_manage_users">
-            <mat-icon>auto_awesome_mosaic</mat-icon>
+            <mat-icon>event_available</mat-icon>
             <span>{{ 'Add to meetings' | translate }}</span>
         </a>
         <button mat-menu-item class="red-warning-text" (click)="deleteUsers([member])">
@@ -152,7 +152,7 @@
             (deleting)="deleteUsers()"
         >
             <button mat-menu-item [disabled]="!selectedRows.length" (click)="assignMeetingToUsers()">
-                <mat-icon>auto_awesome_mosaic</mat-icon>
+                <mat-icon>event_available</mat-icon>
                 <span>{{ 'Set/remove meeting' | translate }} ...</span>
             </button>
             <button mat-menu-item [disabled]="!selectedRows.length" (click)="changeActiveState()">

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
@@ -162,7 +162,7 @@
             [routerLink]="['/', 'committees', meeting.committee_id]"
             matTooltip="{{ 'Show committee' | translate }}"
         >
-            <mat-icon>hub</mat-icon>
+            <mat-icon>layers</mat-icon>
         </a>
     </div>
 </ng-template>

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
@@ -162,7 +162,7 @@
             [routerLink]="['/', 'committees', meeting.committee_id]"
             matTooltip="{{ 'Show committee' | translate }}"
         >
-            <mat-icon>auto_awesome_mosaic</mat-icon>
+            <mat-icon>hub</mat-icon>
         </a>
     </div>
 </ng-template>

--- a/client/src/app/site/pages/organization/pages/organization-tags/modules/organization-tag-dialog/components/organization-tag-dialog.component.html
+++ b/client/src/app/site/pages/organization/pages/organization-tags/modules/organization-tag-dialog/components/organization-tag-dialog.component.html
@@ -19,7 +19,7 @@
                 (click)="generateColor()"
                 matTooltip="{{ 'Generate new color' | translate }}"
             >
-                <mat-icon>sync</mat-icon>
+                <mat-icon>autorenew</mat-icon>
             </button>
             <mat-error *ngIf="hasColorFormError('pattern')">
                 {{ 'You have to enter six hexadecimal digits' | translate }}


### PR DESCRIPTION
Closes #1965 

Aside from icon changes described in issue I also did the following (discussed with Martin):

- Orga-tag dialog's random colour generation button now uses mat-icon `autorenew`
- Participant-list > multiselect > set natural person button now uses mat-icon `sync`
- Motion-list > Statute button now uses mat-icon `gavel`