### PR TITLE
fix empty scrolling tables and scrolling tables with a lot of data

### DIFF
--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
@@ -67,7 +67,7 @@
 </ng-container>
 
 <ng-template #noDataTemplate>
-    <div class="scrolling-table--no-data-wrapper background-card">
+    <div class="scrolling-table--no-data-wrapper" [style.height]="calculateContainerHeight()">
         <ng-template [cdkPortalOutlet]="noDataTemplateObservable | async"></ng-template>
     </div>
 </ng-template>

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
@@ -67,7 +67,7 @@
 </ng-container>
 
 <ng-template #noDataTemplate>
-    <div class="scrolling-table--no-data-wrapper" [style.height]="calculateContainerHeight()">
+    <div #cdkContainer class="scrolling-table--no-data-wrapper" [style.height]="calculateContainerHeight()">
         <ng-template [cdkPortalOutlet]="noDataTemplateObservable | async"></ng-template>
     </div>
 </ng-template>

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="cellDefinitionsObservable | async as definitions">
     <ng-container *ngIf="hasDataObservable | async; else noDataTemplate">
-        <div [style.height]="calculateContainerHeight()">
+        <div #cdkContainer [style.height]="calculateContainerHeight()">
             <cdk-virtual-scroll-viewport class="virtual-scroll-viewport background-card" [itemSize]="rowHeight">
                 <div
                     *ngIf="showHeader"

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -1,8 +1,8 @@
 import { TemplatePortal } from '@angular/cdk/portal';
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
-import { AfterViewInit, Component, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { ChangeDetectorRef, EventEmitter, HostListener, OnDestroy } from '@angular/core';
-import { BehaviorSubject, map, Observable } from 'rxjs';
+import { BehaviorSubject, map, Observable, window } from 'rxjs';
 import { Identifiable } from 'src/app/domain/interfaces';
 import { Mapable, Mutable } from 'src/app/infrastructure/utils';
 import { KeyCode } from 'src/app/infrastructure/utils/key-code';
@@ -41,6 +41,8 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
 {
     @ViewChild(CdkVirtualScrollViewport)
     public scrollViewport: CdkVirtualScrollViewport | undefined;
+
+    @ViewChild(`cdkContainer`) cdkContainer: ElementRef;
 
     @Input()
     public tableHeight: string | undefined = undefined;
@@ -212,11 +214,12 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
             return this.tableHeight;
         }
 
-        if (!this._dataSource.getValue().length) {
-            return `50vh`;
+        if (this.cdkContainer) {
+            const distTop = this.cdkContainer.nativeElement.getBoundingClientRect().top;
+            return `calc(100vh - ${distTop}px)`;
         }
 
-        return this.rowHeight * this._dataSource.getValue().length + `px`;
+        return Math.min(this.rowHeight * this._dataSource.getValue().length, (<any>window).innerHeight - 150) + `px`;
     }
 
     private buildDataTable(): void {

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -2,7 +2,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { AfterViewInit, Component, ElementRef, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { ChangeDetectorRef, EventEmitter, HostListener, OnDestroy } from '@angular/core';
-import { BehaviorSubject, map, Observable, window } from 'rxjs';
+import { BehaviorSubject, map, Observable } from 'rxjs';
 import { Identifiable } from 'src/app/domain/interfaces';
 import { Mapable, Mutable } from 'src/app/infrastructure/utils';
 import { KeyCode } from 'src/app/infrastructure/utils/key-code';

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -212,6 +212,10 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
             return this.tableHeight;
         }
 
+        if (!this._dataSource.getValue().length) {
+            return `50vh`;
+        }
+
         return this.rowHeight * this._dataSource.getValue().length + `px`;
     }
 


### PR DESCRIPTION
When there were no elements within a scrolling table the search bar was scrollable. 

Also when there is too much data there were issues with the cdk scroll view. For that reason the height is now manually calculated by the dom element positions. 
This also reverts the changed behavior of these tables introduced by #1931.