### PR TITLE
Display global option in single votes table

### DIFF
--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-detail/assignment-poll-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-detail/assignment-poll-detail.component.ts
@@ -117,6 +117,15 @@ export class AssignmentPollDetailComponent
                 }
             }
         }
+        for (const vote of this.poll.global_option.votes) {
+            if (vote.weight > 0) {
+                // global vote must be the only vote, so we can just ignore any previous value
+                votes[vote.user_token] = {
+                    user: vote.user,
+                    votes: [`${this.translate.instant(`General`)}: ${this.voteValueToLabel(vote.value)}`]
+                };
+            }
+        }
         return Object.values(votes);
     }
 

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-form/motion-poll-form.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-form/motion-poll-form.component.ts
@@ -20,7 +20,9 @@ import { GroupControllerService } from '../../../../../participants';
 })
 export class MotionPollFormComponent extends BasePollFormComponent {
     public get hideSelects(): PollFormHideSelectsData {
-        return {};
+        return {
+            globalOptions: true
+        };
     }
 
     constructor(


### PR DESCRIPTION
Global were not displayed at all in the single votes table. Also disabled global votes for motion polls, since there is AFAIK no way that these can be enabled anyway.