### PR TITLE
fix mass deletion selection reset

### DIFF
--- a/client/src/app/ui/modules/list/components/view-list/view-list.component.html
+++ b/client/src/app/ui/modules/list/components/view-list/view-list.component.html
@@ -18,6 +18,7 @@
 
         <os-scrolling-table
             [dataSource]="dataListObservable"
+            [fullDataSource]="dataFullListObservable"
             [rowHeight]="vScrollFixed"
             [hiddenColumns]="hiddenColumns"
             [selectionMode]="multiSelect"

--- a/client/src/app/ui/modules/list/components/view-list/view-list.component.ts
+++ b/client/src/app/ui/modules/list/components/view-list/view-list.component.ts
@@ -146,6 +146,7 @@ export class ViewListComponent<V extends Identifiable> implements OnInit {
      * Observable to the raw data
      */
     public dataListObservable: Observable<V[]> = of([]);
+    public dataFullListObservable: Observable<V[]> = of([]);
 
     private _source: Observable<V[]> = of([]);
 
@@ -178,6 +179,7 @@ export class ViewListComponent<V extends Identifiable> implements OnInit {
                 dataListObservable = this.searchService.outputObservable;
             }
             this.dataListObservable = dataListObservable;
+            this.dataFullListObservable = this._source;
         }
     }
 

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -14,6 +14,7 @@ import { ScrollingTableManageService } from '../../services/scrolling-table-mana
 
 const SELECTION_MODE_SUBSCRIPTION = `selection_mode`;
 const DATA_SOURCE_SUBSCRIPTION = `data_source`;
+const FULL_DATA_SOURCE_SUBSCRIPTION = `full_data_source`;
 
 export interface ScrollingTableRowClickEvent {}
 
@@ -66,13 +67,24 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
             DATA_SOURCE_SUBSCRIPTION,
             source.subscribe(items => {
                 this._source = items;
-                this.buildDataTable();
+                this.refresh();
             })
         );
     }
 
     public get dataSource(): Observable<T[]> {
         return this._dataSource;
+    }
+
+    @Input()
+    public set fullDataSource(source: Observable<T[]>) {
+        this.updateSubscription(
+            FULL_DATA_SOURCE_SUBSCRIPTION,
+            source.subscribe(items => {
+                this._fullSource = items;
+                this.buildDataTable();
+            })
+        );
     }
 
     @Input()
@@ -127,6 +139,7 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     private _isHoldingShiftKey = false;
     private _isSelectionMode = false;
     private _source: T[] = [];
+    private _fullSource: T[] = [];
     private _dataSource = new BehaviorSubject<T[]>([]);
     private _dataSourceMap: Mapable<DataSourceProvider<T>> = {};
 
@@ -211,7 +224,7 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     }
 
     private buildDataTable(): void {
-        const source = [...this._source].sort((a, b) => a.id - b.id);
+        const source = [...this._fullSource].sort((a, b) => a.id - b.id);
         const sourceMapKeys = Object.keys(this._dataSourceMap)
             .map(key => Number(key))
             .sort((a, b) => a - b);
@@ -230,7 +243,6 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
             toDelete = toDelete.concat(sourceMapKeys.slice(currentId));
         }
         this.deleteFromDataSourceMap(toDelete);
-        this.refresh();
     }
 
     private addOrChangeItemInDataSourceMap(item: T): void {


### PR DESCRIPTION
resolves #1973
This PR adds a unfiltered dataSource to the scrolling tables for checking whether a entry needs to be deleted from selection. 

This reverts "keep selection in scroll tables if data filtered (#1581)"