### PR TITLE
[For testing] Moved poll.vote_count into own subscription

### DIFF
--- a/client/src/app/gateways/repositories/meeting-repository.service.ts
+++ b/client/src/app/gateways/repositories/meeting-repository.service.ts
@@ -90,8 +90,7 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
             detailEdit: detailEditFields,
             list: listFields,
             settings: this.meetingSettingsDefinitionProvider.getSettingsKeys(),
-            group: groupFields,
-            access: accessField
+            group: groupFields
         };
     }
 

--- a/client/src/app/gateways/repositories/meeting-repository.service.ts
+++ b/client/src/app/gateways/repositories/meeting-repository.service.ts
@@ -90,7 +90,8 @@ export class MeetingRepositoryService extends BaseRepository<ViewMeeting, Meetin
             detailEdit: detailEditFields,
             list: listFields,
             settings: this.meetingSettingsDefinitionProvider.getSettingsKeys(),
-            group: groupFields
+            group: groupFields,
+            access: accessField
         };
     }
 

--- a/client/src/app/gateways/repositories/polls/poll-repository.service/poll-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/poll-repository.service/poll-repository.service.ts
@@ -67,13 +67,14 @@ export class PollRepositoryService extends BaseMeetingRelatedRepository<ViewPoll
             `max_votes_amount`,
             `max_votes_per_option`,
             `entitled_users_at_stop`,
-            `vote_count`,
             `backend`
         );
+        const voteCountFieldset: (keyof Poll)[] = [`vote_count`];
         return {
             [DEFAULT_FIELDSET]: detailFieldset,
             [ROUTING_FIELDSET]: routingFields,
-            list: listFieldset
+            list: listFieldset,
+            voteCount: voteCountFieldset
         };
     }
 

--- a/client/src/app/site/services/operator.service.ts
+++ b/client/src/app/site/services/operator.service.ts
@@ -47,7 +47,7 @@ const getPollVoteCountSubscriptionConfig = (id: Id, getNextMeetingIdObservable: 
     modelRequest: {
         viewModelCtor: ViewMeeting,
         ids: [id],
-        fieldset: `access`,
+        fieldset: [],
         follow: [{ idField: `poll_ids`, fieldset: `voteCount` }]
     },
     subscriptionName: POLL_VOTE_COUNT_SUBSCRIPTION,


### PR DESCRIPTION
The field will now only be requested by people who can see it.
There will be a certain interval wherein the progress bar will always show "0/x", even if people have already voted.

The autoupdate-worker sometimes seems to be bundling this new subscription with the `participant_is_present_list` subscription. I think this bundling happens only in the client though, it should therefore (hopefully) have no bearing on the results.

Furthermore:
The new subscription is currently requested in the `operator.service` right after the new permissions for the meeting are calculated. If this new subscription is found to be helpful we might want to rethink whether the placement of the request code is appropriate before merging.