### PR TITLE
allow svg images as logo

### DIFF
--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -230,7 +230,7 @@ class PdfCreator {
             });
         } else if (doc && typeof doc === `object`) {
             for (let key of Object.keys(doc)) {
-                if (key === `image` && doc[key] === url) {
+                if (key === `image` && (doc[key] === url || doc[key] === `/` + url)) {
                     delete doc[key];
                     doc.svg = image;
                 } else {

--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -122,7 +122,7 @@ export interface PdfImageDescription {
     };
     svgs?: {
         [url: string]: string;
-    }
+    };
 }
 
 export interface PdfFontDescription {
@@ -228,7 +228,7 @@ class PdfCreator {
             return doc.map(el => {
                 return this.replaceSvgRecursive(el, url, image);
             });
-        } else if (doc && typeof doc === 'object') {
+        } else if (doc && typeof doc === `object`) {
             for (let key of Object.keys(doc)) {
                 if (key === `image` && doc[key] === url) {
                     delete doc[key];
@@ -237,7 +237,6 @@ class PdfCreator {
                     doc[key] = this.replaceSvgRecursive(doc[key], url, image);
                 }
             }
-
         }
 
         return doc;

--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -710,14 +710,12 @@ export class PdfDocumentService {
 
     private getImage(data: { image: string; fit?: number[]; width?: string; alignment?: string }): object {
         this.imageUrls.push(data.image);
-        const obj = {
+        return {
             image: this.removeLeadingSlash(data.image),
             fit: data.fit,
             width: data.width,
             alignment: data.alignment
         };
-
-        return obj;
     }
 
     /**

--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -870,14 +870,17 @@ export class PdfDocumentService {
         const urls = this.imageUrls.map(image => {
             return image.indexOf(`/`) === 0 ? image.slice(1) : image;
         });
-        const images = await Promise.all(urls.map(url => this.httpService.downloadAsBase64(url)));
+        const downloads = await Promise.all(urls.map(url => this.httpService.downloadAsBase64(url)));
+        const images = downloads.filter(image => image.type !== `image/svg+xml`);
+        const svgs = downloads.filter(image => image.type === `image/svg+xml`);
+
         return {
             images: urls
-                .filter((_, index) => images[index].type !== `image/svg+xml`)
+                .filter((_, index) => downloads[index].type !== `image/svg+xml`)
                 .mapToObject((url, index) => ({ [url]: images[index].data })),
             svgs: urls
-                .filter((_, index) => images[index].type === `image/svg+xml`)
-                .mapToObject((url, index) => ({ [url]: atob(images[index].data) }))
+                .filter((_, index) => downloads[index].type === `image/svg+xml`)
+                .mapToObject((url, index) => ({ [url]: atob(svgs[index].data) }))
         };
     }
 }

--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -117,7 +117,12 @@ export interface PdfVirtualFileSystem {
 }
 
 export interface PdfImageDescription {
-    [url: string]: string;
+    images?: {
+        [url: string]: string;
+    };
+    svgs?: {
+        [url: string]: string;
+    }
 }
 
 export interface PdfFontDescription {
@@ -195,20 +200,54 @@ class PdfCreator {
     }
 
     private async sendDocumentToPdfWorker(): Promise<void> {
+        const fonts = typeof this._loadFonts === `function` ? await this._loadFonts() : this._loadFonts;
+        const images = typeof this._loadImages === `function` ? await this._loadImages() : this._loadImages;
+
+        let doc = JSON.parse(JSON.stringify(this._document));
+        if (images.svgs) {
+            doc = this.replaceSvgImages(doc, images.svgs);
+        }
+
         this._pdfWorker!.postMessage({
-            doc: JSON.parse(JSON.stringify(this._document)),
+            doc,
             fonts: typeof this._loadFonts === `function` ? await this._loadFonts() : this._loadFonts,
-            vfs: await this.createVfs()
+            vfs: await this.createVfs(fonts, images)
         });
     }
 
-    private async createVfs(): Promise<PdfVirtualFileSystem> {
-        const fonts = typeof this._loadFonts === `function` ? await this._loadFonts() : this._loadFonts;
-        const images = typeof this._loadImages === `function` ? await this._loadImages() : this._loadImages;
+    private replaceSvgImages(doc: any, images: object): any {
+        for (let url of Object.keys(images)) {
+            doc = this.replaceSvgRecursive(doc, url, images[url]);
+        }
+
+        return doc;
+    }
+
+    private replaceSvgRecursive(doc: any, url: string, image: string): any {
+        if (Array.isArray(doc)) {
+            return doc.map(el => {
+                return this.replaceSvgRecursive(el, url, image);
+            });
+        } else if (doc && typeof doc === 'object') {
+            for (let key of Object.keys(doc)) {
+                if (key === `image` && doc[key] === url) {
+                    delete doc[key];
+                    doc.svg = image;
+                } else {
+                    doc[key] = this.replaceSvgRecursive(doc[key], url, image);
+                }
+            }
+
+        }
+
+        return doc;
+    }
+
+    private async createVfs(fonts: PdfFontDescription, images: PdfImageDescription): Promise<PdfVirtualFileSystem> {
         const initialVfs = typeof this._createVfs === `function` ? await this._createVfs() : this._createVfs;
         return {
             ...fonts,
-            ...images,
+            ...images?.images,
             ...initialVfs
         };
     }
@@ -521,13 +560,13 @@ export class PdfDocumentService {
 
         // add the left logo to the header column
         if (logoHeaderLeftUrl) {
-            logoHeaderLeftUrl = this.removeLeadingSlash(logoHeaderLeftUrl);
-            columns.push({
-                image: logoHeaderLeftUrl,
-                fit: [180, 40],
-                width: `20%`
-            });
-            this.imageUrls.push(logoHeaderLeftUrl);
+            columns.push(
+                this.getImage({
+                    image: logoHeaderLeftUrl,
+                    fit: [180, 40],
+                    width: `20%`
+                })
+            );
         }
 
         // Add no heading text if there are logos on the right and left.
@@ -556,14 +595,14 @@ export class PdfDocumentService {
 
         // add the logo to the right
         if (logoHeaderRightUrl) {
-            logoHeaderRightUrl = this.removeLeadingSlash(logoHeaderRightUrl);
-            columns.push({
-                image: logoHeaderRightUrl,
-                fit: [180, 40],
-                alignment: `right`,
-                width: `20%`
-            });
-            this.imageUrls.push(logoHeaderRightUrl);
+            columns.push(
+                this.getImage({
+                    image: logoHeaderRightUrl,
+                    fit: [180, 40],
+                    alignment: `right`,
+                    width: `20%`
+                })
+            );
         }
         const margin = [lrMargin ? lrMargin[0] : 75, 30, lrMargin ? lrMargin[0] : 75, 10];
         // pdfmake order: [left, top, right, bottom]
@@ -633,13 +672,14 @@ export class PdfDocumentService {
 
         // add the left footer logo, if any
         if (logoFooterLeftUrl) {
-            columns.push({
-                image: logoFooterLeftUrl,
-                fit: logoContainerSize,
-                width: logoContainerWidth,
-                alignment: `left`
-            });
-            this.imageUrls.push(logoFooterLeftUrl);
+            columns.push(
+                this.getImage({
+                    image: logoFooterLeftUrl,
+                    fit: logoContainerSize,
+                    width: logoContainerWidth,
+                    alignment: `left`
+                })
+            );
         }
 
         // add the page number
@@ -651,13 +691,14 @@ export class PdfDocumentService {
 
         // add the right footer logo, if any
         if (logoFooterRightUrl) {
-            columns.push({
-                image: logoFooterRightUrl,
-                fit: logoContainerSize,
-                width: logoContainerWidth,
-                alignment: `right`
-            });
-            this.imageUrls.push(logoFooterRightUrl);
+            columns.push(
+                this.getImage({
+                    image: logoFooterRightUrl,
+                    fit: logoContainerSize,
+                    width: logoContainerWidth,
+                    alignment: `right`
+                })
+            );
         }
 
         const margin = [lrMargin ? lrMargin[0] : 75, 0, lrMargin ? lrMargin[0] : 75, 10];
@@ -666,6 +707,18 @@ export class PdfDocumentService {
             columns,
             columnGap: 10
         };
+    }
+
+    private getImage(data: { image: string; fit?: number[]; width?: string; alignment?: string }): object {
+        this.imageUrls.push(data.image);
+        const obj = {
+            image: this.removeLeadingSlash(data.image),
+            fit: data.fit,
+            width: data.width,
+            alignment: data.alignment
+        };
+
+        return obj;
     }
 
     /**
@@ -818,6 +871,13 @@ export class PdfDocumentService {
             return image.indexOf(`/`) === 0 ? image.slice(1) : image;
         });
         const images = await Promise.all(urls.map(url => this.httpService.downloadAsBase64(url)));
-        return urls.mapToObject((url, index) => ({ [url]: images[index] }));
+        return {
+            images: urls
+                .filter((_, index) => images[index].type !== `image/svg+xml`)
+                .mapToObject((url, index) => ({ [url]: images[index].data })),
+            svgs: urls
+                .filter((_, index) => images[index].type === `image/svg+xml`)
+                .mapToObject((url, index) => ({ [url]: atob(images[index].data) }))
+        };
     }
 }

--- a/client/src/app/gateways/export/pdf-document.service/pdf-worker.worker.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-worker.worker.ts
@@ -65,7 +65,7 @@ function addPageNumbers(data: any): void {
         const footer = data.doc.tmpfooter;
 
         // if the tmpfooter starts with an image, the pagenumber will be found in column 1
-        const pageNumberColIndex = !!footer.columns[0].image ? 1 : 0;
+        const pageNumberColIndex = !!(footer.columns[0].image || footer.columns[0].svg) ? 1 : 0;
 
         // "%PAGENR% needs to be found once. After that, the same position should always update page numbers"
         if (footer.columns[pageNumberColIndex]?.stack[0] === `%PAGENR%` || countPageNumbers) {

--- a/client/src/app/gateways/http.service.ts
+++ b/client/src/app/gateways/http.service.ts
@@ -196,10 +196,10 @@ export class HttpService {
      * @param url file url
      * @returns a promise with a base64 string
      */
-    public async downloadAsBase64(url: string): Promise<string> {
+    public async downloadAsBase64(url: string): Promise<{ data: string; type: string }> {
         const headers = new HttpHeaders();
         const file = await this.get<Blob>(url, {}, {}, headers, `blob`);
-        return await toBase64(file);
+        return { data: await toBase64(file), type: file.type };
     }
 
     /**

--- a/client/src/app/site/pages/meetings/pages/mediafiles/definitions/index.ts
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/definitions/index.ts
@@ -1,4 +1,4 @@
-export const IMAGE_MIMETYPES = [`image/png`, `image/jpeg`, `image/gif`];
+export const IMAGE_MIMETYPES = [`image/png`, `image/jpeg`, `image/gif`, `image/svg+xml`];
 export const FONT_MIMETYPES = [`font/ttf`, `font/woff`, `font/woff2`];
 export const PDF_MIMETYPES = [`application/pdf`];
 export const VIDEO_MIMETYPES = [

--- a/client/src/app/site/pages/meetings/pages/mediafiles/modules/mediafile-list/services/mediafile-list-export.service/mediafile-list-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/modules/mediafile-list/services/mediafile-list-export.service/mediafile-list-export.service.ts
@@ -19,8 +19,8 @@ export class MediafileListExportService {
     private async addFileToZip(mediafiles: ViewMediafile[], zip: JSZip, http: HttpService): Promise<void> {
         for (const mediafile of mediafiles) {
             if (!mediafile.is_directory) {
-                const base64Data = await http.downloadAsBase64(mediafile.url);
-                zip.file(mediafile.title, base64Data, { base64: true });
+                const download = await http.downloadAsBase64(mediafile.url);
+                zip.file(mediafile.title, download.data, { base64: true });
             }
         }
     }

--- a/client/src/app/site/pages/meetings/services/export/meeting-pdf-export.service.ts
+++ b/client/src/app/site/pages/meetings/services/export/meeting-pdf-export.service.ts
@@ -147,8 +147,8 @@ export class MeetingPdfExportService {
         );
 
         const promises = fontPathList.map(fontPath =>
-            this.httpService.downloadAsBase64(fontPath).then(base64 => ({
-                [fontPath.split(`/`).pop()!]: base64
+            this.httpService.downloadAsBase64(fontPath).then(file => ({
+                [fontPath.split(`/`).pop()!]: file.data
             }))
         );
         const binaryDataUrls = await Promise.all(promises);

--- a/client/src/app/ui/modules/sidenav/components/logo/logo.component.scss
+++ b/client/src/app/ui/modules/sidenav/components/logo/logo.component.scss
@@ -1,0 +1,3 @@
+.logo-container {
+    width: 100%;
+}


### PR DESCRIPTION
resolves #1978

This requires some bigger changes to the pdf document service which are quite hacky. 
What the code basically does is searching the document definition for `image` properties and replacing them with `svg` properties containing the previously downloaded content of the svg. 