### PR TITLE
Removed nowrap for referring motions.

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.html
@@ -141,7 +141,7 @@
 <div *ngIf="motion && recommendationReferencingMotions.length > 0 && showReferringMotions">
     <h4>{{ 'Referring motions' | translate }}</h4>
     <span *ngFor="let motion of recommendationReferencingMotions; let last = last">
-        <a [routerLink]="motion.getDetailStateUrl()" class="nowrap">{{ motion.numberOrTitle }}</a>
+        <a [routerLink]="motion.getDetailStateUrl()">{{ motion.numberOrTitle }}</a>
         <span *ngIf="!last">&nbsp;·&nbsp;</span>
     </span>
 </div>


### PR DESCRIPTION
resolves https://github.com/OpenSlides/openslides-client/issues/2012

see 
![referring-motions-wrap](https://user-images.githubusercontent.com/2075427/217231211-2430226f-ec05-40f1-854a-5769d0a8f176.png)
