### PR TITLE
fix BaseMotionDetailActionCardComponent motion ref update

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/base/base-motion-detail-action-card.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/base/base-motion-detail-action-card.component.ts
@@ -15,6 +15,8 @@ export abstract class BaseMotionDetailActionCardComponent extends BaseComponent 
     public set motion(motion: ViewMotion) {
         if (this._motion?.id !== motion.id) {
             this.onMotionChange(motion);
+        } else {
+            this._motion = motion;
         }
     }
 


### PR DESCRIPTION
resolves #2008

The export didn't work properly when adding a comment or personal note to a motion that previously did not have one. 