### PR TITLE
improve autoupdate existing subscription handling

### DIFF
--- a/client/src/app/worker/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate-stream-pool.ts
@@ -32,6 +32,10 @@ export class AutoupdateStreamPool {
     private _updateAuthPromise: Promise<void> | undefined;
     private _waitingForUpdateAuthPromise: boolean = false;
 
+    public get activeStreams(): AutoupdateStream[] {
+        return this.streams.filter(stream => stream.active);
+    }
+
     constructor(private endpoint: AutoupdateSetEndpointParams) {
         this.updateAuthentication();
     }

--- a/client/src/app/worker/autoupdate-stream.ts
+++ b/client/src/app/worker/autoupdate-stream.ts
@@ -15,10 +15,14 @@ export class AutoupdateStream {
 
     private abortCtrl: AbortController = undefined;
     private activeSubscriptions: AutoupdateSubscription[] = null;
-    private active: boolean = false;
+    private _active: boolean = false;
     private error: any | ErrorDescription = null;
     private restarting: boolean = false;
     private _currentData: Object | null = null;
+
+    public get active(): Object | null {
+        return this._active;
+    }
 
     /**
      * Full data object received by autoupdate
@@ -71,9 +75,9 @@ export class AutoupdateStream {
     public async start(
         force?: boolean
     ): Promise<{ stopReason: 'error' | 'aborted' | 'unused' | 'resolved' | 'in-use'; error?: any }> {
-        if (this.active && !force) {
+        if (this._active && !force) {
             return { stopReason: `in-use` };
-        } else if (this.active && force) {
+        } else if (this._active && force) {
             this.abort();
         }
 
@@ -81,9 +85,9 @@ export class AutoupdateStream {
         this.error = null;
         try {
             await this.doRequest();
-            this.active = false;
+            this._active = false;
         } catch (e) {
-            this.active = false;
+            this._active = false;
             if (e.name !== `AbortError`) {
                 console.error(e);
 
@@ -155,7 +159,7 @@ export class AutoupdateStream {
     }
 
     private async doRequest(): Promise<void> {
-        this.active = true;
+        this._active = true;
 
         if (this.activeSubscriptions === null) {
             this.activeSubscriptions = [];

--- a/client/src/app/worker/autoupdate-stream.ts
+++ b/client/src/app/worker/autoupdate-stream.ts
@@ -20,7 +20,7 @@ export class AutoupdateStream {
     private restarting: boolean = false;
     private _currentData: Object | null = null;
 
-    public get active(): Object | null {
+    public get active(): boolean {
         return this._active;
     }
 
@@ -148,6 +148,7 @@ export class AutoupdateStream {
     public restart(): void {
         this.restarting = true;
         this.abort();
+        this.clearSubscriptions();
     }
 
     public clearSubscriptions(): void {

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -80,6 +80,9 @@ function openConnection(
     const existingSubscription = autoupdatePool.getMatchingSubscription(queryParams, request);
     if (existingSubscription) {
         existingSubscription.addPort(ctx);
+        if (!existingSubscription.stream.active) {
+            autoupdatePool.reconnect(existingSubscription.stream);
+        }
         return;
     }
 

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -27,8 +27,33 @@ let openTimeouts = {
 
 if (!environment.production) {
     (<any>self).printAutoupdateState = function () {
+        console.log(`AU POOL INFO`);
+        console.log(`Currently open:`, autoupdatePool.activeStreams.length);
+        console.group(`Streams`);
+        for (let stream of autoupdatePool.activeStreams) {
+            console.groupCollapsed(stream.subscriptions.map(s => s.description).join(`, `));
+            console.log(`Current data:`, stream.currentData);
+            console.log(`Current data size:`, JSON.stringify(stream.currentData).length);
+            console.log(`Current data keys:`, Object.keys(stream.currentData).length);
+            console.log(`Query params:`, stream.queryParams);
+            console.log(`Failed connects:`, stream.failedConnects);
+            console.groupCollapsed(`Subscriptions`);
+            for (let subscr of stream.subscriptions) {
+                console.group(subscr.description);
+                console.log(`ID:`, subscr.id);
+                console.log(`Request:`, subscr.request);
+                console.log(`Num subscribers:`, subscr.ports.length);
+                console.groupEnd();
+            }
+            console.groupEnd();
+            console.groupEnd();
+        }
+        console.groupEnd();
+
+        console.groupCollapsed(`Raw`);
         console.log(`subscriptionQueue\n`, subscriptionQueues);
-        console.log(`pool\n`, autoupdatePool);
+        console.log(`Pool\n`, autoupdatePool);
+        console.groupEnd();
     };
 }
 


### PR DESCRIPTION
This PR adds two safety mechanisms to the shared worker and improves the `printAutoupdateState`.

After adding a `MessagePort` to an existing subscription it will be checked whether the corresponding stream is active. If it isn't a reconnect will be performed. If the AU connection is failing this ensures that the client receives a message that the stream was terminated irrecoverable so it can display the `Try reconnect` snackbar. 
This also ensures that when a user attempts a reload irrecoverable AU connections are reconnected. 

When a restart is requested for an `AutoupdateStream` now also the internal cache is reset. This ensures that no outdated data is sent to the client when restarting streams. 

The `printAutoupdateState` got updated to better display the subscriptions of any stream. 