### PR TITLE
remove projector detail subscription

### DIFF
--- a/client/src/app/site/pages/meetings/pages/projectors/modules/fullscreen-projector/components/fullscreen-projector-main/fullscreen-projector-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/fullscreen-projector/components/fullscreen-projector-main/fullscreen-projector-main.component.ts
@@ -1,61 +1,9 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
-import { Id } from 'src/app/domain/definitions/key-types';
-import { Projector } from 'src/app/domain/models/projector/projector';
 import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
-import { ViewProjector } from 'src/app/site/pages/meetings/pages/projectors';
-import { SequentialNumberMappingService } from 'src/app/site/pages/meetings/services/sequential-number-mapping.service';
-import { ModelRequestService } from 'src/app/site/services/model-request.service';
-import { DEFAULT_FIELDSET } from 'src/app/site/services/model-request-builder';
-import { OpenSlidesRouterService } from 'src/app/site/services/openslides-router.service';
-
-import { PROJECTOR_DETAIL_SUBSCRIPTION } from '../../../../view-models/view-projector';
 
 @Component({
     selector: `os-fullscreen-projector-main`,
     templateUrl: `./fullscreen-projector-main.component.html`,
     styleUrls: [`./fullscreen-projector-main.component.scss`]
 })
-export class FullscreenProjectorMainComponent extends BaseModelRequestHandlerComponent {
-    private _projectorId: Id | null = null;
-
-    public constructor(
-        modelRequestService: ModelRequestService,
-        router: Router,
-        openslidesRouter: OpenSlidesRouterService,
-        private sequentialNumberMapping: SequentialNumberMappingService
-    ) {
-        super(modelRequestService, router, openslidesRouter);
-    }
-
-    protected override onParamsChanged(params: any, oldParams: any): void {
-        if (params[`id`] !== oldParams[`id`] || params[`meetingId`] !== oldParams[`meetingId`]) {
-            this.sequentialNumberMapping
-                .getIdBySequentialNumber({
-                    collection: Projector.COLLECTION,
-                    meetingId: +params[`meetingId`],
-                    sequentialNumber: +params[`id`]
-                })
-                .then(id => {
-                    if (id && this._projectorId !== id) {
-                        this._projectorId = id;
-                        this.doFullscreenProjectorSubscription();
-                    }
-                });
-        }
-    }
-
-    private doFullscreenProjectorSubscription(): void {
-        if (this._projectorId) {
-            this.subscribeTo({
-                modelRequest: {
-                    viewModelCtor: ViewProjector,
-                    ids: [this._projectorId],
-                    fieldset: DEFAULT_FIELDSET
-                },
-                subscriptionName: PROJECTOR_DETAIL_SUBSCRIPTION,
-                hideWhenDestroyed: true
-            });
-        }
-    }
-}
+export class FullscreenProjectorMainComponent extends BaseModelRequestHandlerComponent {}

--- a/client/src/app/site/pages/meetings/pages/projectors/view-models/view-projector.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/view-models/view-projector.ts
@@ -15,8 +15,6 @@ export const PROJECTOR_CONTENT_FOLLOW: Follow = {
     fieldset: `content`
 };
 
-export const PROJECTOR_DETAIL_SUBSCRIPTION = `projector_detail`;
-
 export class ViewProjector extends BaseViewModel<Projector> {
     public static COLLECTION = Projector.COLLECTION;
     protected _collection = Projector.COLLECTION;


### PR DESCRIPTION
resolves #2020 

A projector subscription with all the necessary data is already opened when accessing a meeting. Therefore a detail subscription is not needed. 
We might want to question if it is really necessary to request all projector data when accessing a meeting. 

This fixes the issue because the `projector_detail` subscription did not request all fields needed to display projections. 