### PR TITLE
add ability to disable autoupdate compression

### DIFF
--- a/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
@@ -92,7 +92,20 @@ export class AutoupdateCommunicationService {
             } as AutoupdateAuthChange);
         });
 
+        if (window.localStorage.getItem(`DEBUG_MODE`)) {
+            this.enableDebugUtils();
+        }
+
         this.registerConnectionStatusListener();
+    }
+
+    /**
+     * Enable the debug utilities of the shared worker
+     */
+    public enableDebugUtils(): void {
+        this.sharedWorker.sendMessage(`autoupdate`, {
+            action: `enable-debug`
+        });
     }
 
     /**

--- a/client/src/app/worker/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate-stream-pool.ts
@@ -31,6 +31,7 @@ export class AutoupdateStreamPool {
     private _authTokenRefreshTimeout: any | null = null;
     private _updateAuthPromise: Promise<void> | undefined;
     private _waitingForUpdateAuthPromise: boolean = false;
+    private _disableCompression: boolean = false;
 
     public get activeStreams(): AutoupdateStream[] {
         return this.streams.filter(stream => stream.active);
@@ -51,7 +52,12 @@ export class AutoupdateStreamPool {
             this.subscriptions[subscription.id] = subscription;
         }
 
-        const stream = new AutoupdateStream(subscriptions, queryParams, this.endpoint, this.authToken);
+        const params = new URLSearchParams(queryParams);
+        if (this._disableCompression) {
+            params.delete(`compress`);
+        }
+
+        const stream = new AutoupdateStream(subscriptions, params, this.endpoint, this.authToken);
         this.streams.push(stream);
         this.connectStream(stream);
 
@@ -200,6 +206,15 @@ export class AutoupdateStreamPool {
         });
 
         await this._updateAuthPromise;
+    }
+
+    public async disableCompression(): Promise<void> {
+        this._disableCompression = true;
+        for (let stream of this.streams) {
+            stream.queryParams.delete(`compress`);
+        }
+
+        this.reconnectAll(false);
     }
 
     private setAuthToken(token: string | null): void {

--- a/client/src/app/worker/autoupdate-stream.ts
+++ b/client/src/app/worker/autoupdate-stream.ts
@@ -41,7 +41,7 @@ export class AutoupdateStream {
 
     constructor(
         private _subscriptions: AutoupdateSubscription[],
-        public queryParams: string,
+        public queryParams: URLSearchParams,
         private endpoint: AutoupdateSetEndpointParams,
         private authToken: string
     ) {}
@@ -181,7 +181,8 @@ export class AutoupdateStream {
 
         this.abortCtrl = new AbortController();
 
-        const response = await fetch(this.endpoint.url + this.queryParams, {
+        const queryParams = this.queryParams.toString() ? `?${this.queryParams.toString()}` : ``;
+        const response = await fetch(this.endpoint.url + queryParams, {
             signal: this.abortCtrl.signal,
             method: this.endpoint.method,
             headers,
@@ -202,7 +203,7 @@ export class AutoupdateStream {
 
                     next = null;
 
-                    const data = this.decode(line);
+                    const data = this.queryParams.get(`compress`) ? this.decode(line) : new TextDecoder().decode(line);
                     const parsedData = this.parse(data);
                     this.handleContent(parsedData);
                 } else if (next) {

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -25,7 +25,13 @@ let openTimeouts = {
     other: null
 };
 
-if (!environment.production) {
+let debugCommandsRegistered = false;
+function registerDebugCommands() {
+    if (debugCommandsRegistered) {
+        return;
+    }
+
+    debugCommandsRegistered = true;
     (<any>self).printAutoupdateState = function () {
         console.log(`AU POOL INFO`);
         console.log(`Currently open:`, autoupdatePool.activeStreams.length);
@@ -35,7 +41,7 @@ if (!environment.production) {
             console.log(`Current data:`, stream.currentData);
             console.log(`Current data size:`, JSON.stringify(stream.currentData).length);
             console.log(`Current data keys:`, Object.keys(stream.currentData).length);
-            console.log(`Query params:`, stream.queryParams);
+            console.log(`Query params:`, stream.queryParams.toString());
             console.log(`Failed connects:`, stream.failedConnects);
             console.groupCollapsed(`Subscriptions`);
             for (let subscr of stream.subscriptions) {
@@ -54,6 +60,10 @@ if (!environment.production) {
         console.log(`subscriptionQueue\n`, subscriptionQueues);
         console.log(`Pool\n`, autoupdatePool);
         console.groupEnd();
+    };
+
+    (<any>self).disableAutoupdateCompression = function () {
+        autoupdatePool.disableCompression();
     };
 }
 
@@ -119,6 +129,10 @@ function updateOnlineStatus(): void {
     autoupdatePool.updateOnlineStatus(currentlyOnline);
 }
 
+if (!environment.production) {
+    registerDebugCommands();
+}
+
 export function addAutoupdateListener(context: any): void {
     context.addEventListener(`message`, e => {
         const receiver = e.data?.receiver;
@@ -147,6 +161,9 @@ export function addAutoupdateListener(context: any): void {
                 break;
             case `reconnect-inactive`:
                 autoupdatePool.reconnectAll(true);
+                break;
+            case `enable-debug`:
+                registerDebugCommands();
                 break;
         }
     });


### PR DESCRIPTION
resolves #2044 

This adds a method `disableAutoupdateCompression()` to the window object to disable the compression of autoupdate connections.
The method closes all currently open autoupdate connections and reopens them without the `compress=1` parameter. Also all new autoupdate streams will be opened without the `compress=1` parameter after the method has been called. 

Besides that it is now possible to use the worker helper methods (this includes `printAutoupdateState()`) in production by setting the value of the local storage key `DEBUG_MODE`. This can be done by calling `window.localStorage.setItem('DEBUG_MODE', 1);` from the dev tools console. 

Note that the util commands are only available within the shared worker.
