### PR TITLE
Filtered titleless motions out of motion lists

### DIFF
--- a/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
@@ -263,8 +263,8 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
     }
 
     public override getFieldsets(): Fieldsets<Motion> {
-        const routingFields: TypedFieldset<Motion> = [`sequential_number`, `meeting_id`, `title`];
-        const titleFields: TypedFieldset<Motion> = routingFields.concat([`number`, `created`, `forwarded`]);
+        const routingFields: TypedFieldset<Motion> = [`sequential_number`, `meeting_id`];
+        const titleFields: TypedFieldset<Motion> = routingFields.concat([`title`, `number`, `created`, `forwarded`]);
         const detailFields: TypedFieldset<Motion> = titleFields.concat([
             `sort_weight`,
             `start_line_number`,
@@ -451,6 +451,6 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
     }
 
     private getCurrentMotions(motions: ViewMotion[]): ViewMotion[] {
-        return motions.filter(motion => motion.meeting_id === this.activeMeetingId && !!motion.title);
+        return motions.filter(motion => motion.meeting_id === this.activeMeetingId && !!motion.sequential_number);
     }
 }

--- a/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
@@ -263,8 +263,8 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
     }
 
     public override getFieldsets(): Fieldsets<Motion> {
-        const routingFields: TypedFieldset<Motion> = [`sequential_number`, `meeting_id`];
-        const titleFields: TypedFieldset<Motion> = routingFields.concat([`title`, `number`, `created`, `forwarded`]);
+        const routingFields: TypedFieldset<Motion> = [`sequential_number`, `meeting_id`, `title`];
+        const titleFields: TypedFieldset<Motion> = routingFields.concat([`number`, `created`, `forwarded`]);
         const detailFields: TypedFieldset<Motion> = titleFields.concat([
             `sort_weight`,
             `start_line_number`,
@@ -451,6 +451,6 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
     }
 
     private getCurrentMotions(motions: ViewMotion[]): ViewMotion[] {
-        return motions.filter(motion => motion.meeting_id === this.activeMeetingId);
+        return motions.filter(motion => motion.meeting_id === this.activeMeetingId && !!motion.title);
     }
 }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.ts
@@ -275,7 +275,7 @@ export class MotionMetaDataComponent extends BaseMotionDetailChildComponent {
     public canAccess(origin: ViewMotion | ViewMeeting): boolean {
         if (this.isViewMotion(origin)) {
             const motion = origin as ViewMotion;
-            return motion.meeting?.canAccess();
+            return motion.sequential_number && motion.meeting?.canAccess();
         }
         return origin?.canAccess();
     }


### PR DESCRIPTION
Hotfix for motion relics that may show up in the list for currently invisible forwarded motions.

Please investigate if this destroys any motion functionality. (And also whether or not it is possible to navigate to titleless motions via url)