### PR TITLE
request has voted state for started polls only

### DIFF
--- a/client/src/app/gateways/repositories/polls/poll-repository.service/poll-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/poll-repository.service/poll-repository.service.ts
@@ -354,7 +354,7 @@ export class PollRepositoryService extends BaseMeetingRelatedRepository<ViewPoll
     protected override createViewModel(model: Poll): ViewPoll {
         const viewPoll = super.createViewModel(model);
 
-        this.voteController.setHasVotedOnPoll(viewPoll).then(() => {});
+        this.voteController.subscribeVoted(viewPoll);
 
         return viewPoll;
     }

--- a/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
@@ -141,7 +141,10 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
         let results: HasVotedResponse = await this.http.get(`${HAS_VOTED_URL}?ids=${ids.join()}`);
         for (let pollId of Object.keys(results)) {
             const subscription = this._subscribedPolls.get(+pollId);
-            subscription.current.next(results[pollId]);
+            const currentVal = subscription.current.value;
+            if (JSON.stringify(currentVal) !== JSON.stringify(results[pollId])) {
+                subscription.current.next(results[pollId]);
+            }
         }
     }
 }

--- a/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { HttpService } from 'src/app/gateways/http.service';
 import { Deferred } from 'src/app/infrastructure/utils/promises';
-import { ViewVote } from 'src/app/site/pages/meetings/pages/polls';
+import { ViewPoll, ViewVote } from 'src/app/site/pages/meetings/pages/polls';
 import { DEFAULT_FIELDSET, Fieldsets } from 'src/app/site/services/model-request-builder';
 
 import { BaseMeetingRelatedRepository } from '../../base-meeting-related-repository';
@@ -24,6 +25,9 @@ export interface HasVotedResponse {
     providedIn: `root`
 })
 export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote, Vote> {
+    private _subscribedPolls: Map<Id, Deferred> = new Map();
+
+    // Old
     private _hasVotedCache: HasVotedResponse = {};
     private _nextRequestIds: Set<Id> = new Set<Id>();
     private _requestHasVotedPromise: Deferred<void>;
@@ -48,6 +52,24 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
 
     public async sendVote(pollId: Id, payload: any): Promise<void> {
         return await this.http.post(`${VOTE_URL}?id=${pollId}`, payload);
+    }
+
+    /**
+     * This method subscribes to polls and waits 
+     *
+     * @param poll The poll that should be subscribed
+     */
+    public async waitUntilVoted(poll: ViewPoll): Promise<ViewPoll> {
+        if (poll.isStarted) {
+            if (!this._subscribedPolls.has(poll.id)) {
+                this._subscribedPolls.set(poll.id, new Deferred());
+                this.restartSubscription();
+            }
+
+            await this._subscribedPolls[poll.id];
+        }
+
+        return poll;
     }
 
     public async updateHasVotedFor(...ids: Id[]): Promise<HasVotedResponse | undefined> {
@@ -80,6 +102,10 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
         }
 
         return this.getIdsFromCache(ids);
+    }
+
+    private restartSubscription(): void {
+        // TODO
     }
 
     private requestHasVoted(): Deferred<void> {

--- a/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
@@ -3,9 +3,7 @@ import { BehaviorSubject } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { HttpService } from 'src/app/gateways/http.service';
-import { Deferred } from 'src/app/infrastructure/utils/promises';
 import { ViewPoll, ViewVote } from 'src/app/site/pages/meetings/pages/polls';
-import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 import { DEFAULT_FIELDSET, Fieldsets } from 'src/app/site/services/model-request-builder';
 import { OperatorService } from 'src/app/site/services/operator.service';
 
@@ -77,7 +75,7 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
             if (!this._subscribedPolls.has(poll.id)) {
                 this._subscribedPolls.set(poll.id, {
                     users: userIds,
-                    current: new BehaviorSubject([])
+                    current: new BehaviorSubject(undefined)
                 });
                 this.updateSubscription();
             }
@@ -108,7 +106,7 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
         let results: HasVotedResponse = await this.http.get(`${HAS_VOTED_URL}?ids=${ids.join()}`);
         for (let pollId of Object.keys(results)) {
             const subscription = this._subscribedPolls.get(+pollId);
-            subscription.current.next(results[pollId])
+            subscription.current.next(results[pollId]);
             if (subscription.users.equals(results[pollId])) {
                 subscription.current.unsubscribe();
                 this._subscribedPolls.delete(+pollId);

--- a/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
@@ -92,6 +92,11 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
                 this.updateSubscription();
             }
         } else {
+            if (this._subscribedPolls.has(poll.id)) {
+                this._subscribedPolls.get(poll.id).current.complete();
+                this._subscribedPolls.delete(poll.id);
+            }
+
             return null;
         }
 
@@ -101,7 +106,7 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
     public updateStartedPolls(polls: Id[]): void {
         for (const id of this._subscribedPolls.keys()) {
             if (polls.indexOf(id) === -1) {
-                this._subscribedPolls.get(id).current.unsubscribe();
+                this._subscribedPolls.get(id).current.complete();
                 this._subscribedPolls.delete(id);
             }
         }

--- a/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
@@ -62,12 +62,12 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
     }
 
     public async sendVote(pollId: Id, payload: VotePayload): Promise<void> {
-        const subject = this._subscribedPolls.get(pollId)?.current;
-        if (subject) {
-            subject.next(subject.value ? subject.value.concat([payload.user_id]) : [payload.user_id]);
-        }
+        const request: Promise<void> = this.http.post(`${VOTE_URL}?id=${pollId}`, payload);
+        request.then(() => {
+            this.updateSubscription();
+        });
 
-        return await this.http.post(`${VOTE_URL}?id=${pollId}`, payload);
+        return request;
     }
 
     /**

--- a/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
+++ b/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
@@ -63,8 +63,9 @@ export class VotingBannerService {
     }
 
     private updateBanner(polls: ViewPoll[], voted: { [key: Id]: Id[] }) {
+        const checkUsers = [this.operator.user, ...this.operator.user.vote_delegations_from()];
         this.pollsToVote = polls.filter(
-            poll => this.votingService.canVote(poll) && !poll.hasVoted && voted[poll.id] !== undefined
+            poll => checkUsers.some(user => this.votingService.canVote(poll, user)) && voted[poll.id] !== undefined
         );
 
         // display no banner if in history mode or there are no polls to vote

--- a/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
+++ b/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
@@ -63,10 +63,14 @@ export class VotingBannerService {
     }
 
     private updateBanner(polls: ViewPoll[], voted: { [key: Id]: Id[] }) {
-        const checkUsers = [this.operator.user, ...this.operator.user.vote_delegations_from()];
-        this.pollsToVote = polls.filter(
-            poll => checkUsers.some(user => this.votingService.canVote(poll, user)) && voted[poll.id] !== undefined
-        );
+        if (this.activeMeeting.meetingId) {
+            const checkUsers = [this.operator.user, ...this.operator.user.vote_delegations_from()];
+            this.pollsToVote = polls.filter(
+                poll => checkUsers.some(user => this.votingService.canVote(poll, user)) && voted[poll.id] !== undefined
+            );
+        } else {
+            this.pollsToVote = [];
+        }
 
         // display no banner if in history mode or there are no polls to vote
         if ((this.historyService.isInHistoryMode() && this.currentBanner) || !this.pollsToVote.length) {

--- a/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
+++ b/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
@@ -28,7 +28,7 @@ export class VotingBannerService {
     private subText = _(`Click here to vote!`);
 
     private pollsToVote: ViewPoll[] = [];
-    private pollsToVoteSubscription: Subscription;
+    private pollsToVoteSubscription: Subscription | null;
 
     public constructor(
         pollRepo: PollControllerService,
@@ -62,13 +62,16 @@ export class VotingBannerService {
      */
     private async checkForVotablePolls(polls: ViewPoll[]): Promise<void> {
         // refresh the voting info on all polls. This is a single request to the vote service
-        await this.sendVotesService.updateHasVotedOnPoll(...polls);
-
-        this.pollsToVote = polls.filter(poll => this.votingService.canVote(poll) && !poll.hasVoted);
+        // await this.sendVotesService.updateHasVotedOnPoll(...polls);
 
         if (this.pollsToVoteSubscription) {
             this.pollsToVoteSubscription.unsubscribe();
         }
+        const bs = this.sendVotesService.subscribeVoted(...polls)
+        console.debug(bs);
+
+        this.pollsToVote = polls.filter(poll => this.votingService.canVote(poll) && !poll.hasVoted);
+
         this.pollsToVoteSubscription = combineLatest(
             this.pollsToVote.map(poll => poll.hasVotedObservable.pipe(distinctUntilChanged()))
         ).subscribe(hasVoted => {

--- a/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
+++ b/client/src/app/site/modules/site-wrapper/services/voting-banner.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
 import { combineLatest, distinctUntilChanged, Subscription } from 'rxjs';
-import { Id } from 'src/app/domain/definitions/key-types';
 import { Permission } from 'src/app/domain/definitions/permission';
 import { PollControllerService } from 'src/app/site/pages/meetings/modules/poll/services/poll-controller.service';
 import { VoteControllerService } from 'src/app/site/pages/meetings/modules/poll/services/vote-controller.service';

--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
@@ -138,6 +138,10 @@ export abstract class BasePollVoteComponent<C extends BaseViewModel = any> exten
     private setupHasVotedSubscription(): void {
         this.subscriptions.push(
             this.voteRepo.subscribeVoted(this.poll).subscribe(() => {
+                if (this.user) {
+                    this.createVotingDataObjects();
+                }
+
                 for (const key of Object.keys(this._canVoteForSubjectMap)) {
                     this._canVoteForSubjectMap[+key].next(this.canVote(this._delegationsMap[+key]));
                 }
@@ -158,7 +162,10 @@ export abstract class BasePollVoteComponent<C extends BaseViewModel = any> exten
 
     private canVote(user: ViewUser = this.user): boolean {
         return (
-            this.votingService.canVote(this.poll, user) && !this.isDeliveringVote(user) && !this.hasAlreadyVoted(user)
+            this.votingService.canVote(this.poll, user) &&
+            !this.isDeliveringVote(user) &&
+            !this.hasAlreadyVoted(user) &&
+            this.hasAlreadyVoted(user) !== undefined
         );
     }
 }

--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Directive, Input } from '@angular/core';
+import { ChangeDetectorRef, Directive, inject, Input } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, debounceTime, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
@@ -12,6 +12,7 @@ import { ComponentServiceCollectorService } from 'src/app/site/services/componen
 import { OperatorService } from 'src/app/site/services/operator.service';
 
 import { MeetingSettingsService } from '../../../services/meeting-settings.service';
+import { VoteControllerService } from '../services/vote-controller.service';
 import { VotingProhibition, VotingService } from '../services/voting.service';
 
 export interface VoteOption {
@@ -62,6 +63,8 @@ export abstract class BasePollVoteComponent<C extends BaseViewModel = any> exten
     private _poll!: ViewPoll<C>;
     private _delegationsMap: { [userId: number]: ViewUser } = {};
     private _canVoteForSubjectMap: { [userId: number]: BehaviorSubject<boolean> } = {};
+
+    private voteRepo = inject(VoteControllerService);
 
     public constructor(
         operator: OperatorService,
@@ -134,7 +137,7 @@ export abstract class BasePollVoteComponent<C extends BaseViewModel = any> exten
 
     private setupHasVotedSubscription(): void {
         this.subscriptions.push(
-            this.poll.hasVotedObservable.subscribe(() => {
+            this.voteRepo.subscribeVoted(this.poll).subscribe(() => {
                 for (const key of Object.keys(this._canVoteForSubjectMap)) {
                     this._canVoteForSubjectMap[+key].next(this.canVote(this._delegationsMap[+key]));
                 }

--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-vote.component.ts
@@ -152,9 +152,9 @@ export abstract class BasePollVoteComponent<C extends BaseViewModel = any> exten
     private setupDelegations(): void {
         for (const delegation of this.delegations) {
             this._delegationsMap[delegation.id] = delegation;
+            this.alreadyVoted[delegation.id] = this.poll.hasVotedForDelegations(delegation.id);
             if (!this.voteRequestData[delegation.id]) {
                 this.voteRequestData[delegation.id] = { value: {} } as VotingData;
-                this.alreadyVoted[delegation.id] = this.poll.hasVotedForDelegations(delegation.id);
                 this.deliveringVote[delegation.id] = false;
             }
         }

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, distinctUntilChanged, Observable, Subject, Subscription } from 'rxjs';
+import { distinctUntilChanged, Observable, Subscription } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { VoteRepositoryService } from 'src/app/gateways/repositories/polls/vote-repository.service';
@@ -24,7 +24,7 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
     }
 
     public subscribeVoted(...viewPolls: ViewPoll[]): Observable<{ [key: Id]: Id[] }> {
-        return new Observable<{ [key: Id]: Id[] }>((subscriber) => {
+        return new Observable<{ [key: Id]: Id[] }>(subscriber => {
             const current = {};
             // const subscriptions: { [key: Id]: BehaviorSubject<Id[]> } = {};
             for (let poll of viewPolls) {
@@ -50,7 +50,6 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
     public async setHasVotedOnPoll(poll: ViewPoll, voteResp: Id[]): Promise<void> {
         await this.operator.ready;
         poll.hasVoted = voteResp?.some(id => id === this.operator.operatorId) ?? false;
-        poll.user_has_voted_for_delegations =
-            voteResp?.filter(id => id !== this.operator.operatorId) ?? [];
+        poll.user_has_voted_for_delegations = voteResp?.filter(id => id !== this.operator.operatorId) ?? [];
     }
 }

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { VoteRepositoryService } from 'src/app/gateways/repositories/polls/vote-repository.service';
@@ -20,13 +21,23 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
         super(controllerServiceCollector, Vote, repo);
     }
 
+    public subscribeVoted(...viewPolls: ViewPoll[]): BehaviorSubject<Id[]>[] {
+        const subscriptions: BehaviorSubject<Id[]>[] = [];
+        for (const poll of viewPolls) {
+            subscriptions.push(this.repo.subscribeVoted(poll));
+        }
+
+        return subscriptions;
+    }
+
     public async updateHasVotedOnPoll(...viewPolls: ViewPoll[]): Promise<void> {
-        const pollIds: Id[] = viewPolls.filter(poll => poll.isStarted).map(poll => poll.id);
-        await this.repo.updateHasVotedFor(...pollIds);
-        await this.setHasVotedOnPoll(...viewPolls);
+        // const pollIds: Id[] = viewPolls.filter(poll => poll.isStarted).map(poll => poll.id);
+        // await this.repo.updateHasVotedFor(...pollIds);
+        // await this.setHasVotedOnPoll(...viewPolls);
     }
 
     public async setHasVotedOnPoll(...viewPolls: ViewPoll[]): Promise<void> {
+        /*
         const pollIds: Id[] = viewPolls.filter(poll => poll.isStarted).map(poll => poll.id);
         const voteResp = await this.repo.hasVotedFor(...pollIds);
 
@@ -38,5 +49,6 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
                     voteResp[poll.id]?.filter(id => id !== this.operator.operatorId) ?? [];
             }
         }
+        */
     }
 }

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { distinctUntilChanged, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { VoteRepositoryService } from 'src/app/gateways/repositories/polls/vote-repository.service';
@@ -38,7 +38,7 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
                     current[poll.id] = subscription.value;
                 }
 
-                subscription.pipe(distinctUntilChanged()).subscribe({
+                subscription.subscribe({
                     next: async (voted: Id[] | null | undefined) => {
                         if (voted !== undefined) {
                             await this.setHasVotedOnPoll(poll, voted);

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -21,13 +21,13 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
     }
 
     public async updateHasVotedOnPoll(...viewPolls: ViewPoll[]): Promise<void> {
-        const pollIds: Id[] = viewPolls.map(poll => poll.id);
+        const pollIds: Id[] = viewPolls.filter(poll => poll.isStarted).map(poll => poll.id);
         await this.repo.updateHasVotedFor(...pollIds);
         await this.setHasVotedOnPoll(...viewPolls);
     }
 
     public async setHasVotedOnPoll(...viewPolls: ViewPoll[]): Promise<void> {
-        const pollIds: Id[] = viewPolls.map(poll => poll.id);
+        const pollIds: Id[] = viewPolls.filter(poll => poll.isStarted).map(poll => poll.id);
         const voteResp = await this.repo.hasVotedFor(...pollIds);
 
         await this.operator.ready;

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { VoteRepositoryService } from 'src/app/gateways/repositories/polls/vote-repository.service';
@@ -21,11 +21,12 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
         super(controllerServiceCollector, Vote, repo);
     }
 
-    public subscribeVoted(...viewPolls: ViewPoll[]): BehaviorSubject<Id[]>[] {
-        const subscriptions: BehaviorSubject<Id[]>[] = [];
+    public subscribeVoted(...viewPolls: ViewPoll[]): { [key: Id]: BehaviorSubject<Id[]> } {
+        const subscriptions: { [key: Id]: BehaviorSubject<Id[]> } = {};
         for (const poll of viewPolls) {
-            subscriptions.push(this.repo.subscribeVoted(poll));
+            subscriptions[poll.id] = this.repo.subscribeVoted(poll);
         }
+        console.debug(subscriptions, viewPolls);
 
         return subscriptions;
     }

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { distinctUntilChanged, Observable } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { VoteRepositoryService } from 'src/app/gateways/repositories/polls/vote-repository.service';
@@ -13,6 +13,8 @@ import { ViewPoll, ViewVote } from '../../../../pages/polls';
     providedIn: `root`
 })
 export class VoteControllerService extends BaseMeetingControllerService<ViewVote, Vote> {
+    private _votedStatus: Map<Id, BehaviorSubject<Id[]>> = new Map();
+
     constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: VoteRepositoryService,
@@ -33,9 +35,12 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
                     continue;
                 }
 
+                this._votedStatus.set(poll.id, subscription);
+
                 if (subscription.value !== undefined) {
-                    current[poll.id] = subscription.value[poll.id];
+                    current[poll.id] = subscription.value;
                 }
+
                 subscription.pipe(distinctUntilChanged()).subscribe(async (voted: Id[] | null | undefined) => {
                     if (voted !== undefined) {
                         await this.setHasVotedOnPoll(poll, voted);

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, distinctUntilChanged, Observable } from 'rxjs';
+import { distinctUntilChanged, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Vote } from 'src/app/domain/models/poll/vote';
 import { VoteRepositoryService } from 'src/app/gateways/repositories/polls/vote-repository.service';
@@ -25,7 +25,10 @@ export class VoteControllerService extends BaseMeetingControllerService<ViewVote
         return new Observable<{ [key: Id]: Id[] }>(subscriber => {
             const current = {};
             for (let poll of viewPolls) {
-                const subscription = this.repo.subscribeVoted(poll, [this.operator.user.id, ...this.operator.user.vote_delegations_from_ids()]);
+                const subscription = this.repo.subscribeVoted(poll, [
+                    this.operator.user.id,
+                    ...this.operator.user.vote_delegations_from_ids()
+                ]);
 
                 if (!subscription) {
                     continue;

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-vote/topic-poll-vote.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-vote/topic-poll-vote.component.html
@@ -131,15 +131,23 @@
             <span>{{ 'Delivering vote... Please wait!' | translate }}</span>
         </div>
 
-        <!-- Permission error error -->
-        <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !(!isUserPresent && delegations.length)">
-            <span>{{ getVotingError(delegation) | translate }}</span>
+        <div *ngIf="hasAlreadyVoted(delegation) === undefined">
+            <mat-spinner class="small-spinner"></mat-spinner>
+            <br />
+            <span>{{ 'Retrieving vote status... Please wait!' | translate }}</span>
         </div>
 
-        <!-- Delegation not present vote error -->
-        <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !isUserPresent && delegations.length">
-            <span>{{ getVotingErrorFromName('USER_NOT_PRESENT') | translate }}</span>
-        </div>
+        <ng-container *ngIf="hasAlreadyVoted(delegation) !== undefined">
+            <!-- Permission error error -->
+            <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !(!isUserPresent && delegations.length)">
+                <span>{{ getVotingError(delegation) | translate }}</span>
+            </div>
+
+            <!-- Delegation not present vote error -->
+            <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !isUserPresent && delegations.length">
+                <span>{{ getVotingErrorFromName('USER_NOT_PRESENT') | translate }}</span>
+            </div>
+        </ng-container>
     </div>
 </ng-template>
 

--- a/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.html
+++ b/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.html
@@ -184,15 +184,23 @@
             <span>{{ 'Delivering vote... Please wait!' | translate }}</span>
         </div>
 
-        <!-- Permission error error -->
-        <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !(!isUserPresent && delegations.length)">
-            <span>{{ getVotingError(delegation) | translate }}</span>
+        <div *ngIf="hasAlreadyVoted(delegation) === undefined">
+            <mat-spinner class="small-spinner"></mat-spinner>
+            <br />
+            <span>{{ 'Retrieving vote status... Please wait!' | translate }}</span>
         </div>
 
-        <!-- Delegation not present vote error -->
-        <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !isUserPresent && delegations.length">
-            <span>{{ getVotingErrorFromName('USER_NOT_PRESENT') | translate }}</span>
-        </div>
+        <ng-container *ngIf="hasAlreadyVoted(delegation) !== undefined">
+            <!-- Permission error error -->
+            <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !(!isUserPresent && delegations.length)">
+                <span>{{ getVotingError(delegation) | translate }}</span>
+            </div>
+
+            <!-- Delegation not present vote error -->
+            <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !isUserPresent && delegations.length">
+                <span>{{ getVotingErrorFromName('USER_NOT_PRESENT') | translate }}</span>
+            </div>
+        </ng-container>
     </div>
 </ng-template>
 

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-vote/motion-poll-vote.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-vote/motion-poll-vote.component.html
@@ -64,11 +64,19 @@
         </div>
     </div>
 
-    <!-- Error -->
-    <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !(!isUserPresent && delegations.length)">
-        <span>{{ getVotingError(delegation) | translate }}</span>
+    <div *ngIf="hasAlreadyVoted(delegation) === undefined">
+        <mat-spinner class="small-spinner"></mat-spinner>
+        <br />
+        <span>{{ 'Retrieving vote status... Please wait!' | translate }}</span>
     </div>
-    <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !isUserPresent && delegations.length">
-        <span>{{ getVotingErrorFromName('USER_NOT_PRESENT') | translate }}</span>
-    </div>
+
+    <ng-container *ngIf="hasAlreadyVoted(delegation) !== undefined">
+        <!-- Error -->
+        <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !(!isUserPresent && delegations.length)">
+            <span>{{ getVotingError(delegation) | translate }}</span>
+        </div>
+        <div *ngIf="!hasAlreadyVoted(delegation) && !isDeliveringVote(delegation) && !isUserPresent && delegations.length">
+            <span>{{ getVotingErrorFromName('USER_NOT_PRESENT') | translate }}</span>
+        </div>
+    </ng-container>
 </ng-template>

--- a/client/src/app/site/pages/meetings/pages/polls/view-models/view-poll.ts
+++ b/client/src/app/site/pages/meetings/pages/polls/view-models/view-poll.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { DetailNavigable } from 'src/app/domain/interfaces';
 import { BaseModel } from 'src/app/domain/models/base/base-model';
 import {
@@ -23,21 +23,23 @@ export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
     extends BaseProjectableViewModel<Poll>
     implements DetailNavigable, PollData
 {
+    private _hasVoted: boolean | undefined;
+
     public get poll(): Poll {
         return this._model;
     }
     public static COLLECTION = Poll.COLLECTION;
 
-    public set hasVoted(value: boolean) {
-        this._hasVotedSubject.next(value);
+    public set hasVoted(value: boolean | undefined) {
+        this._hasVoted = value;
     }
 
-    public get hasVoted(): boolean {
-        if (this._hasVotedSubject.value === undefined) {
-            throw "hasVoted not retrieved for this object";
-        }
-
-        return this._hasVotedSubject.value;
+    /**
+     * @return boolean if a hasVoted state available undefined
+     *         if the state is not set yet
+     */
+    public get hasVoted(): boolean | undefined {
+        return this._hasVoted;
     }
 
     public get pollClassType(): PollClassType | undefined {
@@ -100,10 +102,6 @@ export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
         return this.results.flatMap(option => option.votes).some(vote => vote.weight > 0);
     }
 
-    public get hasVotedObservable(): Observable<boolean | undefined> {
-        return this._hasVotedSubject.asObservable();
-    }
-
     public hasVotedForDelegations(userId?: number): boolean {
         if (!userId) {
             return false;
@@ -126,8 +124,6 @@ export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
     private get results(): ViewOption[] {
         return (this.options || []).concat(this.global_option).filter(option => !!option);
     }
-
-    private readonly _hasVotedSubject = new BehaviorSubject(undefined);
 }
 
 interface IPollRelations<C extends BaseViewModel<BaseModel> = any> {

--- a/client/src/app/site/pages/meetings/pages/polls/view-models/view-poll.ts
+++ b/client/src/app/site/pages/meetings/pages/polls/view-models/view-poll.ts
@@ -33,6 +33,10 @@ export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
     }
 
     public get hasVoted(): boolean {
+        if (this._hasVotedSubject.value === undefined) {
+            throw "hasVoted not retrieved for this object";
+        }
+
         return this._hasVotedSubject.value;
     }
 
@@ -96,7 +100,7 @@ export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
         return this.results.flatMap(option => option.votes).some(vote => vote.weight > 0);
     }
 
-    public get hasVotedObservable(): Observable<boolean> {
+    public get hasVotedObservable(): Observable<boolean | undefined> {
         return this._hasVotedSubject.asObservable();
     }
 
@@ -123,7 +127,7 @@ export class ViewPoll<C extends BaseViewModel<BaseModel> = any>
         return (this.options || []).concat(this.global_option).filter(option => !!option);
     }
 
-    private readonly _hasVotedSubject = new BehaviorSubject(false);
+    private readonly _hasVotedSubject = new BehaviorSubject(undefined);
 }
 
 interface IPollRelations<C extends BaseViewModel<BaseModel> = any> {


### PR DESCRIPTION
This improves the behavior described in #2002. Also the "click here to vote" banner hides faster in the current tab with this changes. 
With this PR only running polls are requested from the vote service. 

To finish #2002 the voted service should return long polling responses. For now instead of requesting the voted status with totally unrelated actions the status is requested every 8-10 seconds. 

Besides that change the following changes are planned in this PR
- [x] Periodically check if a user has voted on a started poll
- [x] Do not display vote buttons when vote status not loaded
- [x] Display vote banner for delegated votes
- [x] Cleanup subscriptions for closed polls