### PR TITLE
Introduce `RawImportModel` with id

### DIFF
--- a/client/src/app/infrastructure/utils/import/import-model.ts
+++ b/client/src/app/infrastructure/utils/import/import-model.ts
@@ -2,23 +2,9 @@ import { Identifiable } from 'src/app/domain/interfaces';
 
 import { CsvImportStatus } from './import-utils';
 
-export type ImportModelConfig<ToCreate> = Partial<ImportModel<ToCreate>> & {
-    model: ToCreate;
-    importTrackId: number;
-    afterImportFields?: { [field: string]: any };
-};
-
-export function createImportModel<ToCreate>(config: ImportModelConfig<ToCreate>): ImportModel<ToCreate> {
-    return new ImportModel(config);
-}
-
 export class ImportModel<ToCreate> implements Identifiable {
     public readonly id: number;
 
-    /**
-     * @deprecated: The `id` property is used as same value
-     */
-    public readonly importTrackId: number;
     public readonly afterImportFields: { [field: string]: any };
 
     public set newEntry(model: ToCreate) {
@@ -35,11 +21,10 @@ export class ImportModel<ToCreate> implements Identifiable {
     public duplicates: Partial<ToCreate>[];
     public hasDuplicates: boolean;
 
-    public constructor({ model, importTrackId, afterImportFields, ...config }: ImportModelConfig<ToCreate>) {
-        this.model = model;
-        this.id = importTrackId;
-        this.importTrackId = importTrackId;
-        this.afterImportFields = afterImportFields || [];
+    public constructor({ model, id, ...config }: Partial<ImportModel<ToCreate>>) {
+        this.model = model as ToCreate;
+        this.id = id;
+        this.afterImportFields = config.afterImportFields || [];
         this.errors = config.errors || [];
         this.hasDuplicates =
             typeof config.hasDuplicates === `boolean` ? config.hasDuplicates : !!config.duplicates?.length;

--- a/client/src/app/infrastructure/utils/import/import-utils.ts
+++ b/client/src/app/infrastructure/utils/import/import-utils.ts
@@ -1,3 +1,5 @@
+import { Identifiable } from 'src/app/domain/interfaces';
+
 import { Id } from '../../../domain/definitions/key-types';
 import { SharedImportContext } from './import-context';
 import { ImportModel } from './import-model';
@@ -59,6 +61,11 @@ export interface CsvJsonMapping {
 }
 
 export type RawObject<ToCreate> = { [key in keyof ToCreate]?: any };
+
+export interface RawImportModel<ToCreate> extends Identifiable {
+    readonly id: number;
+    model: RawObject<ToCreate>;
+}
 
 export type ImportConfig<MainModel = any, K = any> = StaticMainImportConfig<MainModel> & {
     modelHeadersAndVerboseNames: K;

--- a/client/src/app/infrastructure/utils/import/static-main-import-handler.ts
+++ b/client/src/app/infrastructure/utils/import/static-main-import-handler.ts
@@ -1,14 +1,14 @@
 import { BaseMainImportHandler } from './base-main-import-handler';
 import { MainImportHandlerConfig } from './base-main-import-handler';
 import { ImportModel } from './import-model';
-import { ImportIdentifiable } from './import-utils';
+import { ImportIdentifiable, RawImportModel } from './import-utils';
 
 export interface StaticMainImportConfig<ToCreate> extends MainImportHandlerConfig<ToCreate> {
     shouldCreateModelFn?: (model: ImportModel<ToCreate>) => boolean;
     /**
      * This function can be omitted, if the function `onCreateImportModel` is overriden
      */
-    getDuplicatesFn?: (newEntry: Partial<ToCreate>) => any[] | Promise<any[]>;
+    getDuplicatesFn?: (newEntry: RawImportModel<ToCreate>) => any[] | Promise<any[]>;
 }
 
 /**

--- a/client/src/app/site/base/base-import.service/base-import.service.ts
+++ b/client/src/app/site/base/base-import.service/base-import.service.ts
@@ -32,7 +32,7 @@ import {
     hasBeforeFindAction,
     ImportConfig,
     ImportCSVPreview,
-    RawObject,
+    RawImportModel,
     ValueLabelCombination
 } from '../../../infrastructure/utils/import/import-utils';
 import {
@@ -183,7 +183,7 @@ export abstract class BaseImportService<MainModel extends Identifiable> implemen
     private _modelHeadersAndVerboseNames: { [key: string]: string } = {};
 
     private _getDuplicatesFn:
-        | ((entry: Partial<MainModel>) => Partial<MainModel>[] | Promise<Partial<MainModel>[]>)
+        | ((entry: RawImportModel<MainModel>) => Partial<MainModel>[] | Promise<Partial<MainModel>[]>)
         | undefined;
 
     protected readonly translate: TranslateService = this.importServiceCollector.translate;
@@ -508,22 +508,16 @@ export abstract class BaseImportService<MainModel extends Identifiable> implemen
         }
     }
 
-    protected async onCreateImportModel({
-        input,
-        importTrackId
-    }: {
-        input: MainModel;
-        importTrackId: number;
-    }): Promise<ImportModel<MainModel>> {
+    protected async onCreateImportModel(input: RawImportModel<MainModel>): Promise<ImportModel<MainModel>> {
         if (!this._getDuplicatesFn) {
             throw new Error(`No function to check for duplicates defined`);
         }
         const duplicates = await this._getDuplicatesFn(input);
         const hasDuplicates = duplicates.length > 0;
         const entry: ImportModel<MainModel> = new ImportModel({
-            model: input,
+            model: input.model as MainModel,
+            id: input.id,
             hasDuplicates,
-            importTrackId,
             duplicates
         });
         return entry;
@@ -536,22 +530,17 @@ export abstract class BaseImportService<MainModel extends Identifiable> implemen
      *
      * @param _entries
      */
-    protected async onBeforeCreatingImportModels(_entries: MainModel[]): Promise<void> {}
+    protected async onBeforeCreatingImportModels(_entries: RawImportModel<MainModel>[]): Promise<void> {}
 
-    private async createImportModel({
-        input,
-        importTrackId,
-        errors
-    }: {
-        input: MainModel;
-        importTrackId: number;
-        errors: string[];
-    }): Promise<ImportModel<MainModel>> {
-        const nextEntry = await this.onCreateImportModel({ input, importTrackId });
+    private async createImportModel(
+        input: RawImportModel<MainModel>,
+        errors: string[] = []
+    ): Promise<ImportModel<MainModel>> {
+        const nextEntry = await this.onCreateImportModel(input);
         if (nextEntry.hasDuplicates) {
             errors.push(DUPLICATE_IMPORT_ERROR);
         }
-        if (errors?.length) {
+        if (errors.length) {
             nextEntry.errors = errors.map(error => this.getVerboseError(error));
             nextEntry.status = `error`;
         }
@@ -566,11 +555,15 @@ export abstract class BaseImportService<MainModel extends Identifiable> implemen
      *
      * @returns an object which has the headers of the models used internal
      */
-    private createRawObject(line: CsvJsonMapping): RawObject<MainModel> {
-        return Object.keys(this._mapReceivedExpectedHeaders).mapToObject(expectedHeader => {
+    private createRawImportModel(line: CsvJsonMapping, index: number): RawImportModel<MainModel> {
+        const rawObject = Object.keys(this._mapReceivedExpectedHeaders).mapToObject(expectedHeader => {
             const receivedHeader = this._mapReceivedExpectedHeaders[expectedHeader];
             return { [expectedHeader]: line[receivedHeader] };
-        }) as { [key in keyof MainModel]?: any };
+        });
+        return {
+            id: index,
+            model: rawObject as MainModel
+        };
     }
 
     private parseCsvLines(): void {
@@ -761,15 +754,10 @@ export abstract class BaseImportService<MainModel extends Identifiable> implemen
     }
 
     private async propagateNextNewEntries(): Promise<void> {
-        const rawEntries = this._csvLines.map(line => this.createRawObject(line));
-        await this.onBeforeCreatingImportModels(rawEntries.map(entry => entry as MainModel));
-        for (let i = 0; i < rawEntries.length; ++i) {
-            const model = rawEntries[i] as MainModel;
-            const nextEntry = await this.createImportModel({
-                input: model,
-                importTrackId: i + 1,
-                errors: []
-            });
+        const rawEntries = this._csvLines.map((line, i) => this.createRawImportModel(line, i + 1));
+        await this.onBeforeCreatingImportModels(rawEntries);
+        for (let entry of rawEntries) {
+            const nextEntry = await this.createImportModel(entry);
             this.pushNextNewEntry(nextEntry);
         }
         for (const importHandler of this.getEveryImportHandler()) {
@@ -786,7 +774,7 @@ export abstract class BaseImportService<MainModel extends Identifiable> implemen
 
     private pushNextNewEntry(nextEntry: ImportModel<MainModel>): void {
         const oldEntries = this._newEntries.value;
-        oldEntries[nextEntry.importTrackId] = nextEntry;
+        oldEntries[nextEntry.id] = nextEntry;
         this.setNextEntries(oldEntries);
     }
 


### PR DESCRIPTION
I needed a consistent id even before the `ImportModel` was created for https://github.com/OpenSlides/openslides-client/issues/2083, so this was the solution. Also did some cleanup of unneeded/deprecated functionality.