### PR TITLE
check au worker queue for fulfilling subscriptions

### DIFF
--- a/client/src/app/worker/autoupdate-subscription.ts
+++ b/client/src/app/worker/autoupdate-subscription.ts
@@ -121,7 +121,7 @@ export class AutoupdateSubscription {
      * @param port The MessagePort the data should be send to
      */
     public resendTo(port: MessagePort): void {
-        if (this.stream.currentData !== null) {
+        if (this.stream && this.stream.currentData !== null) {
             port.postMessage({
                 sender: `autoupdate`,
                 action: `receive-data`,

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -77,6 +77,14 @@ function openConnection(
         return `other`;
     }
 
+    for (const queue of Object.keys(subscriptionQueues)) {
+        const fulfillingSubscription = subscriptionQueues[queue].find(s => s.fulfills(queryParams, request));
+        if (fulfillingSubscription) {
+            fulfillingSubscription.addPort(ctx);
+            return;
+        }
+    }
+
     const existingSubscription = autoupdatePool.getMatchingSubscription(queryParams, request);
     if (existingSubscription) {
         existingSubscription.addPort(ctx);


### PR DESCRIPTION
Currently only already started subscriptions are checked for fulfillment. 
With #2097 ui components do subscriptions. This results in duplicate subscriptions when using the same component on the same page multiple times. This PR prevents this. 