### PR TITLE
fix supporter list names not displayed

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/motions.subscription.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/motions.subscription.ts
@@ -176,7 +176,8 @@ export const getMotionDetailSubscriptionConfig: SubscriptionConfigGenerator = (.
                 idField: `amendment_ids`,
                 fieldset: [`text`, `modified_final_version`, { templateField: `amendment_paragraph_$` }]
             },
-            { idField: `comment_ids`, fieldset: FULL_FIELDSET }
+            { idField: `comment_ids`, fieldset: FULL_FIELDSET },
+            { idField: `supporter_ids`, ...UserFieldsets.FullNameSubscription }
         ],
         fieldset: [
             `reason`,


### PR DESCRIPTION
In motion detail supporter names are currently not displayed. This PR fixes this. 