### PR TITLE
Hotfix for participant import

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -123,7 +123,7 @@ export class ParticipantImportService extends BaseUserImportService {
     }
 
     protected override async onCreateImportModel({ model, id }: RawImportModel<User>): Promise<ImportModel<User>> {
-        const duplicates = this._existingUsers[id];
+        const duplicates = this._existingUsers[id] ?? [];
         const newEntry = duplicates.length === 1 ? { ...duplicates[0], ...model } : model;
         const hasDuplicates =
             duplicates.length > 1 ||


### PR DESCRIPTION
Closes #2182 

Fixed typeerror in a way where it will now display the duplicate creation error message from the backend (which shall suffice until the imports are moved)