### PR TITLE
Invite to call now only invites selected user

### DIFF
--- a/client/src/app/gateways/notify.service.ts
+++ b/client/src/app/gateways/notify.service.ts
@@ -195,8 +195,7 @@ export class NotifyService extends BaseICCGatewayService<ChannelIdResponse | Not
         const notify: NotifyRequest<T> = {
             name: data.name,
             message: data.message,
-            channel_id: this.channelId,
-            to_meeting: this.activeMeetingIdService.meetingId!
+            channel_id: this.channelId
         };
         if (data.toAll === true) {
             notify.to_all = true;
@@ -207,6 +206,10 @@ export class NotifyService extends BaseICCGatewayService<ChannelIdResponse | Not
         if (data.channels) {
             notify.to_channels = data.channels;
         }
+        if (!(data.channels || data.toAll == true || data.users)) {
+            notify.to_meeting = this.activeMeetingIdService.meetingId!;
+        }
+        console.log(`NOTIFY REQUEST`, notify);
         return notify;
     }
 

--- a/client/src/app/gateways/notify.service.ts
+++ b/client/src/app/gateways/notify.service.ts
@@ -209,7 +209,6 @@ export class NotifyService extends BaseICCGatewayService<ChannelIdResponse | Not
         if (!(data.channels || data.toAll == true || data.users)) {
             notify.to_meeting = this.activeMeetingIdService.meetingId!;
         }
-        console.log(`NOTIFY REQUEST`, notify);
         return notify;
     }
 

--- a/client/src/app/site/pages/meetings/pages/interaction/services/interaction-receive.service.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/services/interaction-receive.service.ts
@@ -15,6 +15,7 @@ import {
 import { NotifyResponse, NotifyService } from 'src/app/gateways/notify.service';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
+import { ActiveMeetingService } from '../../../services/active-meeting.service';
 import { BroadcastService } from './broadcast.service';
 import { CallRestrictionService } from './call-restriction.service';
 import { ConferenceState, InviteMessage, KickMessage, kickMessage, senderMessage } from './interaction.service';
@@ -81,7 +82,7 @@ export class InteractionReceiveService {
 
     private _kickObservable = this.notifyService.getMessageObservable<kickMessage>(KickMessage);
 
-    constructor(private notifyService: NotifyService) {}
+    constructor(private notifyService: NotifyService, private activeMeetingService: ActiveMeetingService) {}
 
     public startListening(lazyServices: InteractionReceiveSetupServices): void {
         if (!!this._inviteSubscription) {
@@ -127,7 +128,11 @@ export class InteractionReceiveService {
         merge(
             this.callRestrictionService.hasToEnterCallObservable,
             this.notifyService.getMessageObservable<senderMessage>(InviteMessage).pipe(
-                filter(message => message.sendByThisUser === false),
+                filter(
+                    message =>
+                        message.sendByThisUser === false &&
+                        message.message.meeting_id === this.activeMeetingService.meetingId
+                ),
                 map(message => message.message)
             )
         ).subscribe(() => {

--- a/client/src/app/site/pages/meetings/pages/interaction/services/interaction.service.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/services/interaction.service.ts
@@ -5,6 +5,7 @@ import { NotifyService } from 'src/app/gateways/notify.service';
 import { OperatorService } from 'src/app/site/services/operator.service';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
+import { ActiveMeetingService } from '../../../services/active-meeting.service';
 import { ViewUser } from '../../../view-models/view-user';
 import { BroadcastService } from './broadcast.service';
 import { CallRestrictionService } from './call-restriction.service';
@@ -21,6 +22,7 @@ export enum ConferenceState {
 
 export interface senderMessage {
     inviter: string;
+    meeting_id: number;
 }
 
 export interface kickMessage {
@@ -67,7 +69,8 @@ export class InteractionService {
         private operator: OperatorService,
         promptService: PromptService,
         broadcast: BroadcastService,
-        private interactionReceive: InteractionReceiveService
+        private interactionReceive: InteractionReceiveService,
+        private activeMeetingService: ActiveMeetingService
     ) {
         interactionReceive.startListening({
             streamService,
@@ -84,7 +87,8 @@ export class InteractionService {
 
     public inviteToCall(userId: Id): void {
         const content: senderMessage = {
-            inviter: this.operator.user.getShortName()
+            inviter: this.operator.user.getShortName(),
+            meeting_id: this.activeMeetingService.meetingId
         };
         this.notifyService.sendToUsers(InviteMessage, content, userId);
     }


### PR DESCRIPTION
Closes #2193

It seems the client was sending the following sort of message to the ICC-notify route:
```
{
  "name":"invitationToCall",
  "message":{
     "inviter":"Administrator"
  },
  "channel_id":"8rLPRvPt:1:7",
  "to_meeting":2,
  "to_users":[6]
}
```

The effect that was seemingly desired with this kind of request, was to only send the message to the user when he is in the meeting.
But this form of request actually caused the message to be sent to all users in the meeting, as well as to the target user regardless of where he is. (This is the correct behaviour from the ICC services definition)

I've fixed this now, but for the future I think it would be a nice feature if the ICC/notify could also handle more exclusive requests, I think I'll write a proposal issue for this => OpenSlides/openslides-icc-service#100