### PR TITLE
Removed unnecessary sort functions

### DIFF
--- a/client/src/app/gateways/repositories/motions/motion-category-repository.service/motion-category-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-category-repository.service/motion-category-repository.service.ts
@@ -16,8 +16,6 @@ import { MotionCategoryAction } from './motion-category.action';
 export class MotionCategoryRepositoryService extends BaseMeetingRelatedRepository<ViewMotionCategory, MotionCategory> {
     constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionCategory);
-
-        this.setSortFunction((a, b) => a.weight - b.weight);
     }
 
     public create(...categories: Partial<MotionCategory>[]): Promise<Identifiable[]> {

--- a/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail/category-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail/category-detail.component.ts
@@ -125,14 +125,12 @@ export class CategoryDetailComponent extends BaseMeetingComponent {
                 this.selectedCategory = selectedCategory;
                 super.setTitle(this.selectedCategory.prefixedName);
 
-                this.categories = categories
-                    .filter(category =>
-                        [category]
-                            .concat(...category.allParents)
-                            .map(cat => cat.id)
-                            .includes(this._categoryId)
-                    )
-                    .sort((a, b) => a.level - b.level);
+                this.categories = categories.filter(category =>
+                    [category]
+                        .concat(...category.allParents)
+                        .map(cat => cat.id)
+                        .includes(this._categoryId)
+                );
 
                 // setup datasources:
                 this.categories.forEach(category => {

--- a/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-list/category-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-list/category-list.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, map, Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { Permission } from 'src/app/domain/definitions/permission';
 import { infoDialogSettings } from 'src/app/infrastructure/utils/dialog-settings';
 import { isUniqueAmong } from 'src/app/infrastructure/utils/validators/is-unique-among';
@@ -28,9 +28,7 @@ export class CategoryListComponent extends BaseMeetingListViewComponent<ViewMoti
     private dialogRef: MatDialogRef<any> | null = null;
 
     public get categoriesObservable(): Observable<ViewMotionCategory[]> {
-        return this.repo
-            .getViewModelListObservable()
-            .pipe(map(agendaItems => this.treeService.makeFlatTree(agendaItems, `weight`, `parent_id`)));
+        return this.repo.getViewModelListObservable();
     }
 
     /**

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.ts
@@ -11,7 +11,6 @@ import { MeetingComponentServiceCollectorService } from 'src/app/site/pages/meet
 import { MeetingControllerService } from 'src/app/site/pages/meetings/services/meeting-controller.service';
 import { ViewMeeting } from 'src/app/site/pages/meetings/view-models/view-meeting';
 import { OperatorService } from 'src/app/site/services/operator.service';
-import { TreeService } from 'src/app/ui/modules/sorting/modules/sorting-tree/services';
 
 import { MotionForwardDialogService } from '../../../../components/motion-forward-dialog/services/motion-forward-dialog.service';
 import { MotionPermissionService } from '../../../../services/common/motion-permission.service/motion-permission.service';
@@ -114,8 +113,7 @@ export class MotionMetaDataComponent extends BaseMotionDetailChildComponent {
         public perms: MotionPermissionService,
         private operator: OperatorService,
         private motionForwardingService: MotionForwardDialogService,
-        private meetingController: MeetingControllerService,
-        private treeService: TreeService
+        private meetingController: MeetingControllerService
     ) {
         super(componentServiceCollector, translate, motionServiceCollector);
 
@@ -296,9 +294,7 @@ export class MotionMetaDataComponent extends BaseMotionDetailChildComponent {
         return [
             this.amendmentRepo.getViewModelListObservableFor(this.motion).subscribe(value => (this.amendments = value)),
             this.tagRepo.getViewModelListObservable().subscribe(value => (this.tags = value)),
-            this.categoryRepo
-                .getViewModelListObservable()
-                .subscribe(value => (this.categories = this.treeService.makeFlatTree(value, `weight`, `parent_id`))),
+            this.categoryRepo.getViewModelListObservable().subscribe(value => (this.categories = value)),
             this.blockRepo.getViewModelListObservable().subscribe(value => (this.motionBlocks = value))
         ];
     }


### PR DESCRIPTION
Closes #2138 

Turns out said unhelpful sort function was essentially cancelled out by the controller service which replaces the list with the flattened tree.