### PR TITLE
Fixed wrong vote delegation updates

### DIFF
--- a/client/src/app/domain/models/users/user.ts
+++ b/client/src/app/domain/models/users/user.ts
@@ -156,11 +156,16 @@ export class User extends BaseDecimalModel<User> {
     }
 
     public vote_delegated_to_id(meetingId: Id): Id {
-        return (this as any)[`vote_delegated_$${meetingId}_to_id`];
+        return this.vote_delegated_$_to_id?.includes(`${meetingId}`)
+            ? (this as any)[`vote_delegated_$${meetingId}_to_id`]
+            : undefined;
     }
 
     public vote_delegations_from_ids(meetingId: Id): Id[] {
-        return (this as any)[`vote_delegations_$${meetingId}_from_ids`] || [];
+        if (this.vote_delegations_$_from_ids?.includes(`${meetingId}`)) {
+            return (this as any)[`vote_delegations_$${meetingId}_from_ids`] || [];
+        }
+        return [];
     }
 
     /**

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Permission } from 'src/app/domain/definitions/permission';
 import { BaseMeetingComponent } from 'src/app/site/pages/meetings/base/base-meeting.component';
@@ -160,6 +160,8 @@ export class ParticipantDetailViewComponent extends BaseMeetingComponent {
         this.router.navigate([this.activeMeetingId!, `history`], { queryParams: { fqid: this.user.fqid } });
     }
 
+    private subsc: Subscription;
+
     private getUserByUrl(): void {
         if (this.route.snapshot.url[0] && this.route.snapshot.url[0].path === `new`) {
             super.setTitle(`New participant`);
@@ -173,7 +175,13 @@ export class ParticipantDetailViewComponent extends BaseMeetingComponent {
                             this._userId = +params[`id`];
                         }
                         if (this._userId) {
+                            if (this.subsc) {
+                                this.subsc.unsubscribe();
+                            }
                             await this.loadUserById();
+                            this.subsc = this.repo
+                                .getViewModelObservable(this._userId)
+                                .subscribe(user => console.log(`UPDATE:`, user));
                         }
                     }
                 )

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Permission } from 'src/app/domain/definitions/permission';
 import { BaseMeetingComponent } from 'src/app/site/pages/meetings/base/base-meeting.component';
@@ -160,8 +160,6 @@ export class ParticipantDetailViewComponent extends BaseMeetingComponent {
         this.router.navigate([this.activeMeetingId!, `history`], { queryParams: { fqid: this.user.fqid } });
     }
 
-    private subsc: Subscription;
-
     private getUserByUrl(): void {
         if (this.route.snapshot.url[0] && this.route.snapshot.url[0].path === `new`) {
             super.setTitle(`New participant`);
@@ -175,13 +173,7 @@ export class ParticipantDetailViewComponent extends BaseMeetingComponent {
                             this._userId = +params[`id`];
                         }
                         if (this._userId) {
-                            if (this.subsc) {
-                                this.subsc.unsubscribe();
-                            }
                             await this.loadUserById();
-                            this.subsc = this.repo
-                                .getViewModelObservable(this._userId)
-                                .subscribe(user => console.log(`UPDATE:`, user));
                         }
                     }
                 )

--- a/client/src/app/site/services/relation-manager.service.ts
+++ b/client/src/app/site/services/relation-manager.service.ts
@@ -156,6 +156,9 @@ export class RelationManagerService {
                     throw new Error(`You must give a non-empty attribute for this structured relation`);
                 }
             }
+            if (!(model[relation.ownIdField] as string[])?.includes(attr)) {
+                return relation.many ? [] : undefined;
+            }
             const idField = (relation.ownIdFieldPrefix + attr + relation.ownIdFieldSuffix) as keyof M;
             return this.handleNormalRelation(model, relation, idField);
         };


### PR DESCRIPTION
Closes #2304

SUMMARY:
Template field update handling (either in autoupdate or in client) broken. Since this will not matter once the template field removal happens,  I added a temporary quick fix.

MORE VERBOSE:
It seems that the problem came from the fact that the autoupdate doesn't send autoupdates for the empty specified template field values. This meant that, while the main template field variable was updated to not include the meeting id (signalling that there is no data for this meeting), the old meeting variable (`vote_delegated_$2_to`) still held the old value.

I caught that by changing the functions that look up the data per template attribute, so that they check whether there even should be data for this meeting.
This is a bit inefficient, but I figured it would be quicker than re-writing the autoupdate, and it shouldn't really matter too much, given that we'll likely soon finish the template field removal.