### PR TITLE
Search selectors: Replaced virtual scrolling with normal scrolling

### DIFF
--- a/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.html
+++ b/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.html
@@ -2,7 +2,7 @@
     #matSelect
     [formControl]="contentForm"
     [multiple]="multiple"
-    [panelClass]="{ 'os-search-selector-wider': wider }"
+    [panelClass]="{ 'os-search-selector-wider': wider, 'os-search-selector-panel': true }"
     [errorStateMatcher]="errorStateMatcher"
     (openedChange)="onOpenChanged($event)"
 >
@@ -54,7 +54,7 @@
             <ng-container *ngTemplateOutlet="notFoundTemplate"></ng-container>
         </button>
     </ng-container>
-    <cdk-virtual-scroll-viewport [ngStyle]="{ height: panelHeight + 'px' }" class="vscroll-viewport" minBufferPx="400" maxBufferPx="600" [itemSize]="50">
+    <div #scrollViewport [ngStyle]="{ height: panelHeight + 'px' }" class="vscroll-viewport">
         <mat-option
             *ngIf="(filteredItemsObservable | async)?.length === 0"
             class="os-search-selector--no-options"
@@ -64,7 +64,7 @@
         </mat-option>
         <mat-option
             #currentOption
-            *cdkVirtualFor="let selectableItem of filteredItemsObservable | async"
+            *ngFor="let selectableItem of filteredItemsObservable | async"
             [value]="selectableItem.id"
             [disabled]="disableOptionWhenFn(selectableItem) || selectableItem.disabled"
             [matTooltip]="tooltipFn(selectableItem, currentOption)"
@@ -73,5 +73,5 @@
         >
             {{ selectableItem.getTitle() | translate }} {{ getItemAdditionalInfoFn(selectableItem) }}
         </mat-option>
-    </cdk-virtual-scroll-viewport>
+    </div>
 </mat-select>

--- a/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.scss
+++ b/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.scss
@@ -57,4 +57,9 @@
 
 .vscroll-viewport {
     display: block;
+    overflow: auto;
+}
+
+.os-search-selector-panel {
+    max-height: none !important;
 }

--- a/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
+++ b/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
@@ -1,4 +1,3 @@
-import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import {
     ContentChild,
     Directive,
@@ -25,8 +24,8 @@ import { ParentErrorStateMatcher } from '../../validators';
 
 @Directive()
 export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlComponent<Selectable> implements OnInit {
-    @ViewChild(CdkVirtualScrollViewport, { static: true })
-    public cdkVirtualScrollViewPort!: CdkVirtualScrollViewport;
+    @ViewChild(`scrollViewport`, { static: true })
+    public scrollViewport!: ElementRef<HTMLElement>;
 
     @ViewChild(`matSelect`)
     public matSelect!: MatSelect;
@@ -270,8 +269,8 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
     public onOpenChanged(event: boolean): void {
         this.openedChange.emit(event);
         if (event) {
-            this.cdkVirtualScrollViewPort.scrollToIndex(0);
-            this.cdkVirtualScrollViewPort.checkViewportSize();
+            this.scrollViewport.nativeElement.scroll({ top: 0 });
+            // this.scrollViewport.nativeElement.checkViewportSize();
         }
     }
 


### PR DESCRIPTION
Closes #2310 

Please test if this causes any sort of performance issues.

They may be especially possible when you have
- A lot of options in the search selector
- Multiple search selectors at once
- Search selectors in a long list view

Search selectors are include in the following places:
- [ ] List of speakers
- [ ] Agenda content object form (i.e. where visibility and parents can be set) and topic detail edit view (same as agenda)
- [ ] Attachment control (i.e. selector for mediafile attachments, f.E. for motions)
- [ ] Poll create/edit form (for groups)
- [ ] Assignment detail (Candidate and tag selection)
- [ ] Chat group dialogue (For setting read- and write-groups)
- [ ] Comment section list (For setting read- and write-groups)
- [ ] History list (Model selection)
- [ ] Access group settings for mediafiles (both upload and edit)
- [ ] Meeting settings: group-selection
- [ ] Multiple in motion detail view (submitters, supporters, category, workflow, extension fields)
- [ ] Multiple in participant detail view, participant create wizard and participant "quick-edit dialogue" (groups and delegations) (please pay special attention to the quick edit)
- [ ] Add to meetings wizard
- [ ] Account detail edit (Management level)
- [ ] Committee detail edit (tags, managers forwardings)
- [ ] Meeting create/edit (duplicate from, participants, admins, tags)
- [ ] File list move dialogue (target directory)
- [ ] Mediafile upload (target directory)

If this doesn't work performance-wise, our only option may be #2311 