### PR TITLE
Limit width of slide meeting title

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/components/projector/projector.component.html
+++ b/client/src/app/site/pages/meetings/modules/projector/components/projector/projector.component.html
@@ -18,7 +18,7 @@
                 >
                     <div
                         *ngIf="eventData.eventName"
-                        class="event-name"
+                        class="event-name ellipsis-overflow"
                         [ngClass]="{ titleonly: !eventData.eventDescription }"
                         [innerHTML]="eventData.eventName"
                     ></div>

--- a/client/src/app/site/pages/meetings/modules/projector/components/projector/projector.component.scss
+++ b/client/src/app/site/pages/meetings/modules/projector/components/projector/projector.component.scss
@@ -49,6 +49,7 @@
             #eventdata {
                 padding-left: 50px;
                 padding-top: 12px;
+                padding-right: 130px;
                 height: 50px;
                 overflow: hidden;
                 line-height: 1.1;


### PR DESCRIPTION
Closes #2353 

Stopped the meeting title in the slide from overlapping with the meeting time by limiting the available space and adding ellipses for the overflow

@emanuelschuetze @MSoeb this means that the title may cut off some of the meeting title (but only really the bits that would've been covered by the clock or slipped into the next line and have the lower half cut off anyway), is that okay?