### PR TITLE
fix cors issue in video player reachable check

### DIFF
--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/video-player/video-player.component.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/video-player/video-player.component.ts
@@ -176,7 +176,10 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
          * if a Ressource switches from online to offline
          */
         const ajaxResponse: AjaxResponse<any> = await firstValueFrom(
-            ajax(this.videoUrl).pipe(
+            ajax({
+                url: this.videoUrl,
+                crossDomain: true
+            }).pipe(
                 map(response => response),
                 catchError(error => of(error))
             )


### PR DESCRIPTION
We are currently checking if a stream is available before displaying it via a rxjs ajax method. This method is adding a `x-requested-with` header which makes a cors preflight request necessary. This requires additional configuration of the webserver the stream is hosted an. 
I don't think this is wanted here. 