### PR TITLE
Make list of speakers rearrangeable on mobile

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
@@ -110,7 +110,8 @@
             [live]="true"
             [input]="waitingSpeakers"
             [count]="canSee"
-            [enable]="canManage && (isSortMode || !isMobile)"
+            [enable]="canManage"
+            [dragDelay]="isMobile ? 500 : 0"
             (sortEvent)="onSortingChanged($event)"
         >
             <!-- implicit speaker references into the component using ng-template slot -->

--- a/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.html
+++ b/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.html
@@ -7,6 +7,7 @@
         class="line margin-bottom-5"
         *ngFor="let item of sortedItems; let i = index"
         cdkDrag
+        [cdkDragStartDelay]="dragDelay"
         (click)="onItemClick($event, i)"
         (cdkDragStarted)="dragStarted(i)"
     >

--- a/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
+++ b/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
@@ -50,6 +50,12 @@ export class SortingListComponent<T extends Selectable = Selectable> implements 
     public enable = true;
 
     /**
+     * The time before dragging starts
+     */
+    @Input()
+    public dragDelay = 0;
+
+    /**
      * The Input List Values
      *
      * If live updates are enabled, new values are always converted into the sorting array.


### PR DESCRIPTION
proposal to resolve #2306 

This PR enables the rearrangement functionality for mobile devices. To deal with accidental rearrangements a delay was added. A user has to hold the rearrangement icon for a certain time before they can move it. This way when scrolling over the page the user will not accidentally move an entry. 

The Angular Material documentation mentions the used functionality to deal with these scenarios so I think this is the way to go here. https://material.angular.io/cdk/drag-drop/overview#delayed-dragging
Although we might need to adjust the delay time. 