### PR TITLE
Add external id fields to committee, meeting and group edit and create

### DIFF
--- a/client/src/app/domain/models/comittees/committee.ts
+++ b/client/src/app/domain/models/comittees/committee.ts
@@ -9,6 +9,7 @@ export class Committee extends BaseModel<Committee> {
 
     public name!: string;
     public description!: string;
+    public external_id!: string;
 
     public meeting_ids!: Id[]; // (meeting/committee_id)[];
     public default_meeting_id!: Id; // meeting/default_meeting_for_committee_id;
@@ -31,6 +32,7 @@ export class Committee extends BaseModel<Committee> {
         `id`,
         `name`,
         `description`,
+        `external_id`,
         `meeting_ids`,
         `default_meeting_id`,
         `user_ids`,

--- a/client/src/app/domain/models/meetings/meeting.ts
+++ b/client/src/app/domain/models/meetings/meeting.ts
@@ -198,6 +198,9 @@ export class Settings {
     poll_default_onehundred_percent_base: PollPercentBase;
     poll_default_group_ids: Id[]; // (group/used_as_poll_default_id)[];
     poll_default_backend: PollBackendDurationType;
+
+    //SSO
+    public external_id!: string;
 }
 
 export class Meeting extends BaseModel<Meeting> {
@@ -280,6 +283,7 @@ export class Meeting extends BaseModel<Meeting> {
 
     public static readonly REQUESTABLE_FIELDS: (keyof Meeting | { templateField: string })[] = [
         `id`,
+        `external_id`,
         `welcome_title`,
         `welcome_text`,
         `name`,

--- a/client/src/app/domain/models/users/group.ts
+++ b/client/src/app/domain/models/users/group.ts
@@ -13,6 +13,7 @@ export class Group extends BaseModel<Group> {
     public name!: string;
     public permissions!: Permission[];
     public weight!: number;
+    public external_id!: string;
 
     public user_ids!: Id[]; // (user/group_$<meeting_id>_ids)[];
     public default_group_for_meeting_id!: Id; // meeting/default_group_id;
@@ -42,6 +43,7 @@ export class Group extends BaseModel<Group> {
 
     public static readonly REQUESTABLE_FIELDS: (keyof Group | { templateField: string })[] = [
         `id`,
+        `external_id`,
         `name`,
         `permissions`,
         `weight`,

--- a/client/src/app/gateways/repositories/committee-repository.service.ts
+++ b/client/src/app/gateways/repositories/committee-repository.service.ts
@@ -39,7 +39,8 @@ export class CommitteeRepositoryService extends BaseRepository<ViewCommittee, Co
             `receive_forwardings_from_committee_ids`,
             `organization_tag_ids`,
             `user_ids`,
-            { templateField: `user_$_management_level` }
+            { templateField: `user_$_management_level` },
+            `external_id`
         ]);
         return {
             ...super.getFieldsets(),
@@ -120,7 +121,8 @@ export class CommitteeRepositoryService extends BaseRepository<ViewCommittee, Co
             receive_forwardings_from_committee_ids:
                 committee.receive_forwardings_from_committee_ids === null
                     ? []
-                    : committee.receive_forwardings_from_committee_ids
+                    : committee.receive_forwardings_from_committee_ids,
+            external_id: committee.external_id
         };
     }
 }

--- a/client/src/app/gateways/repositories/groups/group-repository.service.ts
+++ b/client/src/app/gateways/repositories/groups/group-repository.service.ts
@@ -45,7 +45,8 @@ export class GroupRepositoryService extends BaseMeetingRelatedRepository<ViewGro
     public update(update: Partial<Group>, group: Identifiable): Promise<void> {
         const payload = {
             id: group.id,
-            name: update.name
+            name: update.name,
+            external_id: update.external_id
         };
         return this.sendActionToBackend(GroupAction.UPDATE, payload);
     }
@@ -62,6 +63,7 @@ export class GroupRepositoryService extends BaseMeetingRelatedRepository<ViewGro
         return {
             meeting_id: this.activeMeetingId!,
             name: partialGroup.name,
+            external_id: partialGroup.external_id,
             permissions: partialGroup.permissions
         };
     }

--- a/client/src/app/site/pages/meetings/pages/participants/modules/groups/components/group-list/group-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/modules/groups/components/group-list/group-list.component.html
@@ -85,6 +85,14 @@
                 />
                 <mat-error *ngIf="!groupForm?.valid">{{ 'Required' | translate }}</mat-error>
             </mat-form-field>
+            <mat-form-field>
+                <input
+                    type="text"
+                    matInput
+                    formControlName="external_id"
+                    placeholder="{{ 'External ID' | translate }}"
+                />
+            </mat-form-field>
         </form>
     </div>
     <div mat-dialog-actions>

--- a/client/src/app/site/pages/meetings/pages/participants/modules/groups/components/group-list/group-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/modules/groups/components/group-list/group-list.component.ts
@@ -112,9 +112,11 @@ export class GroupListComponent extends BaseMeetingComponent implements OnInit, 
         this.newGroup = newGroup;
 
         const name = this.selectedGroup ? this.selectedGroup.name : ``;
+        const external_id = this.selectedGroup?.external_id ?? ``;
 
         this.groupForm = this.formBuilder.group({
-            name: [name, Validators.required]
+            name: [name, Validators.required],
+            external_id: [external_id]
         });
 
         this.dialogRef = this.dialog.open(this.groupEditDialog!, infoDialogSettings);

--- a/client/src/app/site/pages/meetings/services/active-meeting.subscription.ts
+++ b/client/src/app/site/pages/meetings/services/active-meeting.subscription.ts
@@ -47,7 +47,8 @@ export function getActiveMeetingSubscriptionConfig(id: Id, settingsKeys: string[
                         `default_group_for_meeting_id`,
                         `name`,
                         `permissions`,
-                        `weight`
+                        `weight`,
+                        `external_id`
                     ]
                 },
                 {

--- a/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definitions.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definitions.ts
@@ -131,6 +131,10 @@ export const meetingSettings: SettingsGroup[] = fillInSettingsDefaults([
                                     : currentValue;
                             }
                         }
+                    },
+                    {
+                        key: `external_id`,
+                        label: _(`External ID`)
                     }
                 ]
             },

--- a/client/src/app/site/pages/organization/pages/committees/committees.subscription.ts
+++ b/client/src/app/site/pages/organization/pages/committees/committees.subscription.ts
@@ -52,7 +52,8 @@ export const getCommitteeMeetingDetailSubscriptionConfig: SubscriptionConfigGene
             `jitsi_domain`,
             `jitsi_room_name`,
             `jitsi_room_password`,
-            `language`
+            `language`,
+            `external_id`
         ],
         follow: [`admin_group_id`, `default_group_id`]
     },

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
@@ -73,5 +73,10 @@
                 [tooltipFn]="getTooltipFn()"
             ></os-repo-search-selector>
         </mat-form-field>
+
+        <mat-form-field>
+            <mat-label>{{ 'External ID' | translate }}</mat-label>
+            <input matInput formControlName="external_id" />
+        </mat-form-field>
     </form>
 </mat-card>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
@@ -212,7 +212,8 @@ export class CommitteeDetailEditComponent extends BaseComponent implements OnIni
             organization_tag_ids: [[]],
             user_$_management_level: [[]],
             forward_to_committee_ids: [[]],
-            receive_forwardings_from_committee_ids: [[]]
+            receive_forwardings_from_committee_ids: [[]],
+            external_id: [``]
         };
         this.committeeForm = this.formBuilder.group(partialForm);
     }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
@@ -74,6 +74,11 @@
                 </ng-template>
             </os-repo-search-selector>
         </mat-form-field>
+
+        <mat-form-field>
+            <mat-label>{{ 'External ID' | translate }}</mat-label>
+            <input matInput formControlName="external_id" />
+        </mat-form-field>
     </mat-card>
 
     <mat-card class="os-card" *osOmlPerms="OML.superadmin; and: !isCreateView">

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
@@ -268,7 +268,8 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
                 end: [currentDate]
             },
             admin_ids: [[], Validators.minLength(1)],
-            organization_tag_ids: [[]]
+            organization_tag_ids: [[]],
+            external_id: [``]
         };
 
         rawForm[`language`] = [this.orgaSettings.instant(`default_language`)];


### PR DESCRIPTION
Closes #2414 

Needs OpenSlides/openslides-backend#1759 and the subsequent autoupdate generation PR to work properly.
If at least one of `committee.create`, `meeting.create` or `group.create` don't allow an `external_id` to be given this will have to be reworked