### PR TITLE
New unit tests for pipes

### DIFF
--- a/client/src/app/site/pages/meetings/modules/poll/pipes/poll-key-verbose/poll-key-verbose.pipe.spec.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/pipes/poll-key-verbose/poll-key-verbose.pipe.spec.ts
@@ -33,5 +33,7 @@ describe(`PollKeyVerbosePipe`, () => {
         expect(pipe.transform(`bad`)).toBe(`bad`);
         expect(pipe.transform(`sad`)).toBe(`sad`);
         expect(pipe.transform(`AAAAAAAAAAAAAAAAAAAAAAA`)).toBe(`AAAAAAAAAAAAAAAAAAAAAAA`);
+        expect(pipe.transform(undefined)).toBe(undefined);
+        expect(pipe.transform(null)).toBe(null);
     });
 });

--- a/client/src/app/site/pages/meetings/modules/poll/pipes/poll-key-verbose/poll-key-verbose.pipe.spec.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/pipes/poll-key-verbose/poll-key-verbose.pipe.spec.ts
@@ -1,8 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+
 import { PollKeyVerbosePipe } from './poll-key-verbose.pipe';
 
-xdescribe(`PollKeyVerbosePipe`, () => {
-    it(`create an instance`, () => {
-        const pipe = new PollKeyVerbosePipe();
-        expect(pipe).toBeTruthy();
+describe(`PollKeyVerbosePipe`, () => {
+    let pipe: PollKeyVerbosePipe;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            providers: [PollKeyVerbosePipe]
+        }).compileComponents();
+
+        pipe = TestBed.inject(PollKeyVerbosePipe);
+    });
+
+    it(`test with legitimate PollValues`, () => {
+        expect(pipe.transform(`votesvalid`)).toBe(`Valid votes`);
+        expect(pipe.transform(`votesinvalid`)).toBe(`Invalid votes`);
+        expect(pipe.transform(`votescast`)).toBe(`Total votes cast`);
+        expect(pipe.transform(`votesno`)).toBe(`Votes No`);
+        expect(pipe.transform(`votesabstain`)).toBe(`Votes abstain`);
+        expect(pipe.transform(`yes`)).toBe(`Yes`);
+        expect(pipe.transform(`no`)).toBe(`No`);
+        expect(pipe.transform(`abstain`)).toBe(`Abstain`);
+        expect(pipe.transform(`amount_global_yes`)).toBe(`General approval`);
+        expect(pipe.transform(`amount_global_no`)).toBe(`General rejection`);
+        expect(pipe.transform(`amount_global_abstain`)).toBe(`General abstain`);
+    });
+
+    it(`test with other values`, () => {
+        expect(pipe.transform(`born`)).toBe(`born`);
+        expect(pipe.transform(`mad`)).toBe(`mad`);
+        expect(pipe.transform(`bad`)).toBe(`bad`);
+        expect(pipe.transform(`sad`)).toBe(`sad`);
+        expect(pipe.transform(`AAAAAAAAAAAAAAAAAAAAAAA`)).toBe(`AAAAAAAAAAAAAAAAAAAAAAA`);
     });
 });

--- a/client/src/app/site/pages/meetings/modules/poll/pipes/poll-parse-number/poll-parse-number.pipe.spec.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/pipes/poll-parse-number/poll-parse-number.pipe.spec.ts
@@ -1,16 +1,53 @@
 import { TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 
 import { PollParseNumberPipe } from './poll-parse-number.pipe';
 
-xdescribe(`PollParseNumberPipe`, () => {
+class MockTranslateService {
+    public instant(text: string): string {
+        return text;
+    }
+}
+
+describe(`PollParseNumberPipe`, () => {
     let pipe: PollParseNumberPipe;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({});
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            providers: [PollParseNumberPipe, { provide: TranslateService, useClass: MockTranslateService }]
+        }).compileComponents();
+
+        TestBed.inject(TranslateService);
         pipe = TestBed.inject(PollParseNumberPipe);
     });
 
-    it(`create an instance`, () => {
-        expect(pipe).toBeTruthy();
+    it(`test with majority`, () => {
+        expect(pipe.transform(-1)).toBe(`majority`);
+    });
+
+    it(`test with empty values`, () => {
+        expect(pipe.transform(undefined)).toBe(`0`);
+        expect(pipe.transform(null)).toBe(`0`);
+    });
+
+    it(`test with undocumented`, () => {
+        expect(pipe.transform(-2)).toBe(`undocumented`);
+    });
+
+    it(`test with normal numbers`, () => {
+        expect(pipe.transform(0)).toBe(`0`);
+        expect(pipe.transform(1)).toBe(`1`);
+        expect(pipe.transform(42)).toBe(`42`);
+        expect(pipe.transform(99)).toBe(`99`);
+        expect(pipe.transform(255)).toBe(`255`);
+        expect(pipe.transform(256)).toBe(`256`);
+        expect(pipe.transform(1024)).toBe(`1024`);
+        expect(pipe.transform(140737488355328)).toBe(`140737488355328`);
+    });
+
+    it(`test with special numbers`, () => {
+        expect(pipe.transform(Number.NaN)).toBe(`NaN`);
+        expect(pipe.transform(Number.POSITIVE_INFINITY)).toBe(`∞`);
+        expect(pipe.transform(Number.NEGATIVE_INFINITY)).toBe(`-∞`);
     });
 });

--- a/client/src/app/site/pages/meetings/modules/poll/pipes/poll-percent-base/poll-percent-base.pipe.spec.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/pipes/poll-percent-base/poll-percent-base.pipe.spec.ts
@@ -107,7 +107,7 @@ const testPollData: { [key: string]: PollData } = {
     }
 };
 
-fdescribe(`PollPercentBasePipe`, () => {
+describe(`PollPercentBasePipe`, () => {
     let pipe: PollPercentBasePipe;
 
     beforeEach(async () => {

--- a/client/src/app/site/pages/meetings/modules/poll/pipes/poll-percent-base/poll-percent-base.pipe.spec.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/pipes/poll-percent-base/poll-percent-base.pipe.spec.ts
@@ -1,16 +1,172 @@
 import { TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs';
+import {
+    OptionData,
+    PollClassType,
+    PollData,
+    PollMethod,
+    PollPercentBase,
+    PollState,
+    PollTableData,
+    PollType
+} from 'src/app/domain/models/poll';
 
+import { PollService } from '../../services/poll.service';
+import { PollServiceMapperService } from '../../services/poll-service-mapper.service';
 import { PollPercentBasePipe } from './poll-percent-base.pipe';
 
-xdescribe(`PollPercentBasePipe`, () => {
+class MockPollServiceMapperService {
+    public getService(pollClassType: PollClassType): MockPollService {
+        if (pollClassType !== PollClassType.Assignment && pollClassType !== PollClassType.Topic) {
+            return null;
+        }
+        return new MockPollService(pollClassType);
+    }
+}
+
+class MockPollService {
+    private type: string;
+
+    public constructor(type: PollClassType) {
+        this.type = type;
+    }
+
+    public getVoteValueInPercent(
+        value: number,
+        {
+            poll,
+            row
+        }: {
+            poll: PollData;
+            row?: OptionData | PollTableData;
+        }
+    ): string {
+        return `${this.type ?? `default`}: ${value}, "${JSON.stringify(poll)}", "${JSON.stringify(row)}"`;
+    }
+}
+
+class MockInjectablePollService extends MockPollService {
+    public constructor() {
+        super(undefined);
+    }
+}
+
+const testPollData: { [key: string]: PollData } = {
+    assignmentPoll: {
+        pollClassType: PollClassType.Assignment,
+        pollmethod: PollMethod.YN,
+        state: PollState.Created,
+        onehundred_percent_base: PollPercentBase.Entitled,
+        votesvalid: 1,
+        votesinvalid: 2,
+        votescast: 3,
+        type: PollType.Named,
+        entitled_users_at_stop: [],
+        options: [
+            { getOptionTitle: () => ({ title: `A man` }) },
+            { getOptionTitle: () => ({ title: `A woman` }) },
+            { getOptionTitle: () => ({ title: `A child` }) }
+        ],
+        options_as_observable: new Observable<OptionData[]>(),
+        global_option: { getOptionTitle: () => ({ title: `Global yes` }) },
+        getContentObjectTitle: () => `An assignment`
+    },
+    topicPoll: {
+        pollClassType: PollClassType.Topic,
+        pollmethod: PollMethod.Y,
+        state: PollState.Finished,
+        onehundred_percent_base: PollPercentBase.Y,
+        votesvalid: 40,
+        votesinvalid: 2,
+        votescast: 42,
+        type: PollType.Pseudoanonymous,
+        entitled_users_at_stop: [],
+        options: [
+            { getOptionTitle: () => ({ title: `Humans` }) },
+            { getOptionTitle: () => ({ title: `Dolphins` }) },
+            { getOptionTitle: () => ({ title: `Mice` }) }
+        ],
+        options_as_observable: new Observable<OptionData[]>(),
+        global_option: undefined,
+        getContentObjectTitle: () => `On intelligence`
+    },
+    motionPoll: {
+        pollClassType: PollClassType.Motion,
+        pollmethod: PollMethod.YNA,
+        state: PollState.Published,
+        onehundred_percent_base: PollPercentBase.Y,
+        votesvalid: 5,
+        votesinvalid: 6,
+        votescast: 11,
+        type: PollType.Analog,
+        entitled_users_at_stop: [],
+        options: [{ getOptionTitle: () => ({ title: `option` }) }],
+        options_as_observable: new Observable<OptionData[]>(),
+        global_option: undefined,
+        getContentObjectTitle: () => `A motion`
+    }
+};
+
+fdescribe(`PollPercentBasePipe`, () => {
     let pipe: PollPercentBasePipe;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({});
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            providers: [
+                PollPercentBasePipe,
+                { provide: PollServiceMapperService, useClass: MockPollServiceMapperService },
+                { provide: PollService, useClass: MockInjectablePollService }
+            ]
+        }).compileComponents();
+
+        TestBed.inject(PollService);
+        TestBed.inject(PollServiceMapperService);
         pipe = TestBed.inject(PollPercentBasePipe);
     });
 
-    it(`create an instance`, () => {
-        expect(pipe).toBeTruthy();
+    it(`test with assignment poll data`, () => {
+        const poll = testPollData[`assignmentPoll`];
+        const options = poll.options;
+        expect(pipe.transform(0, poll, options[0])).toBe(
+            `(assignment: 0, "{"pollClassType":"assignment","pollmethod":"YN","state":"created","onehundred_percent_base":"entitled","votesvalid":1,"votesinvalid":2,"votescast":3,"type":"named","entitled_users_at_stop":[],"options":[{},{},{}],"options_as_observable":{},"global_option":{}}", "{}")`
+        );
+        expect(pipe.transform(2, poll, options[1])).toBe(
+            `(assignment: 2, "{"pollClassType":"assignment","pollmethod":"YN","state":"created","onehundred_percent_base":"entitled","votesvalid":1,"votesinvalid":2,"votescast":3,"type":"named","entitled_users_at_stop":[],"options":[{},{},{}],"options_as_observable":{},"global_option":{}}", "{}")`
+        );
+        expect(pipe.transform(5, poll, options[6])).toBe(
+            `(assignment: 5, "{"pollClassType":"assignment","pollmethod":"YN","state":"created","onehundred_percent_base":"entitled","votesvalid":1,"votesinvalid":2,"votescast":3,"type":"named","entitled_users_at_stop":[],"options":[{},{},{}],"options_as_observable":{},"global_option":{}}", "undefined")`
+        );
+    });
+
+    it(`test with topic poll data`, () => {
+        const poll = testPollData[`topicPoll`];
+        const options: PollTableData[] = [
+            { votingOption: `Humans`, value: [] },
+            { votingOption: `Dolphins`, value: [] },
+            { votingOption: `Mice`, value: [] }
+        ];
+        expect(pipe.transform(0, poll, options[0])).toBe(
+            `(topic: 0, "{"pollClassType":"topic","pollmethod":"Y","state":"finished","onehundred_percent_base":"Y","votesvalid":40,"votesinvalid":2,"votescast":42,"type":"pseudoanonymous","entitled_users_at_stop":[],"options":[{},{},{}],"options_as_observable":{}}", "{"votingOption":"Humans","value":[]}")`
+        );
+        expect(pipe.transform(2, poll, options[1])).toBe(
+            `(topic: 2, "{"pollClassType":"topic","pollmethod":"Y","state":"finished","onehundred_percent_base":"Y","votesvalid":40,"votesinvalid":2,"votescast":42,"type":"pseudoanonymous","entitled_users_at_stop":[],"options":[{},{},{}],"options_as_observable":{}}", "{"votingOption":"Dolphins","value":[]}")`
+        );
+        expect(pipe.transform(5, poll, options[6])).toBe(
+            `(topic: 5, "{"pollClassType":"topic","pollmethod":"Y","state":"finished","onehundred_percent_base":"Y","votesvalid":40,"votesinvalid":2,"votescast":42,"type":"pseudoanonymous","entitled_users_at_stop":[],"options":[{},{},{}],"options_as_observable":{}}", "undefined")`
+        );
+    });
+
+    it(`test with motion poll data`, () => {
+        const poll = testPollData[`motionPoll`];
+        const options = poll.options;
+        expect(pipe.transform(0, poll, options[0])).toBe(
+            `(default: 0, "{"pollClassType":"motion","pollmethod":"YNA","state":"published","onehundred_percent_base":"Y","votesvalid":5,"votesinvalid":6,"votescast":11,"type":"analog","entitled_users_at_stop":[],"options":[{}],"options_as_observable":{}}", "{}")`
+        );
+        expect(pipe.transform(2, poll, options[1])).toBe(
+            `(default: 2, "{"pollClassType":"motion","pollmethod":"YNA","state":"published","onehundred_percent_base":"Y","votesvalid":5,"votesinvalid":6,"votescast":11,"type":"analog","entitled_users_at_stop":[],"options":[{}],"options_as_observable":{}}", "undefined")`
+        );
+        expect(pipe.transform(5, poll, options[6])).toBe(
+            `(default: 5, "{"pollClassType":"motion","pollmethod":"YNA","state":"published","onehundred_percent_base":"Y","votesvalid":5,"votesinvalid":6,"votescast":11,"type":"analog","entitled_users_at_stop":[],"options":[{}],"options_as_observable":{}}", "undefined")`
+        );
     });
 });

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/services/topic-poll.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/services/topic-poll.service.ts
@@ -23,10 +23,12 @@ import { ChartDate } from 'src/app/site/pages/meetings/modules/poll/components/c
 import { PollKeyVerbosePipe, PollParseNumberPipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
 import { PollService } from 'src/app/site/pages/meetings/modules/poll/services/poll.service';
 import { PollControllerService } from 'src/app/site/pages/meetings/modules/poll/services/poll-controller.service';
+import { PollServiceMapperService } from 'src/app/site/pages/meetings/modules/poll/services/poll-service-mapper.service';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { OrganizationSettingsService } from 'src/app/site/pages/organization/services/organization-settings.service';
 import { ThemeService } from 'src/app/site/services/theme.service';
 
+import { ViewTopic } from '../../../view-models';
 import { TopicPollServiceModule } from './topic-poll-service.module';
 
 @Injectable({
@@ -42,12 +44,14 @@ export class TopicPollService extends PollService {
         organizationSettingsService: OrganizationSettingsService,
         pollKeyVerbose: PollKeyVerbosePipe,
         parsePollNumber: PollParseNumberPipe,
+        pollServiceMapper: PollServiceMapperService,
         translate: TranslateService,
         private pollRepo: PollControllerService,
         private meetingSettingsService: MeetingSettingsService,
         themeService: ThemeService
     ) {
         super(organizationSettingsService, translate, pollKeyVerbose, parsePollNumber, themeService);
+        pollServiceMapper.registerService(ViewTopic.COLLECTION, this);
         this.meetingSettingsService
             .get(`topic_poll_default_onehundred_percent_base`)
             .subscribe(base => (this.defaultPercentBase = base ?? PollPercentBase.Y));

--- a/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.spec.ts
+++ b/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.spec.ts
@@ -1,17 +1,194 @@
+import { ChangeDetectorRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import * as cs from 'date-fns/locale/cs';
+import * as de from 'date-fns/locale/de';
+import * as enUS from 'date-fns/locale/en-US/index';
+import * as es from 'date-fns/locale/es';
+import * as ita from 'date-fns/locale/it';
+import * as ru from 'date-fns/locale/ru';
+import { langToTimeLocale } from 'src/app/infrastructure/utils';
 
 import { LocalizedDateRangePipe } from './localized-date-range.pipe';
 
-xdescribe(`LocalizedDateRangePipe`, () => {
+function getLocale(lang: string) {
+    switch (lang) {
+        case `es`:
+            return es.default;
+        case `de`:
+            return de.default;
+        case `cs`:
+            return cs.default;
+        case `it`:
+            return ita.default;
+        case `ru`:
+            return ru.default;
+        default:
+            return enUS.default;
+    }
+}
+
+const testData: {
+    [testCase: string]: {
+        title: string;
+        range: { start: Date; end: Date };
+        expect: { [lang: string]: { [dateFormat: string]: string } };
+    };
+} = {
+    sameYear: {
+        title: `test with same year`,
+        range: { start: new Date(`January 18, 1995 03:24:00`), end: new Date(`December 17, 1995 03:24:00`) },
+        expect: {
+            en: {
+                PPp: `Jan 18, 1995, 3:24 AM - Dec 17, 1995, 3:24 AM`,
+                PP: `Jan 18 - Dec 17, 1995`
+            },
+            de: {
+                PPp: `18. Jan. 1995 03:24 - 17. Dez. 1995 03:24`,
+                PP: `18. Jan. - 17. Dez. 1995`
+            },
+            es: {
+                PPp: `18 ene 1995, 03:24 - 17 dic 1995, 03:24`,
+                PP: `18 ene - 17 dic 1995`
+            },
+            it: {
+                PPp: `18 gen 1995 03:24 - 17 dic 1995 03:24`,
+                PP: `18 gen - 17 dic 1995`
+            },
+            cs: {
+                PPp: `18. 1. 1995, 3:24 - 17. 12. 1995, 3:24`,
+                PP: `18. 1. - 17. 12. 1995`
+            },
+            ru: {
+                PPp: `18 янв. 1995 г., 3:24 - 17 дек. 1995 г., 3:24`,
+                PP: `18 янв. 1995 г. - 17 дек. 1995 г.`
+            }
+        }
+    },
+    sameMonth: {
+        title: `test with same month of year`,
+        range: { start: new Date(`December 17, 1995 03:24:00`), end: new Date(`December 18, 1995 03:24:00`) },
+        expect: {
+            en: {
+                PPp: `Dec 17, 1995, 3:24 AM - Dec 18, 1995, 3:24 AM`,
+                PP: `Dec 17 - 18, 1995`
+            },
+            de: {
+                PPp: `17. Dez. 1995 03:24 - 18. Dez. 1995 03:24`,
+                PP: `17. - 18. Dez. 1995`
+            },
+            es: {
+                PPp: `17 dic 1995, 03:24 - 18 dic 1995, 03:24`,
+                PP: `17 - 18 dic 1995`
+            },
+            it: {
+                PPp: `17 dic 1995 03:24 - 18 dic 1995 03:24`,
+                PP: `17 - 18 dic 1995`
+            },
+            cs: {
+                PPp: `17. 12. 1995, 3:24 - 18. 12. 1995, 3:24`,
+                PP: `17. - 18. 12. 1995`
+            },
+            ru: {
+                PPp: `17 дек. 1995 г., 3:24 - 18 дек. 1995 г., 3:24`,
+                PP: `17 дек. 1995 г. - 18 дек. 1995 г.`
+            }
+        }
+    },
+    sameDay: {
+        title: `test with same day of year`,
+        range: { start: new Date(`December 17, 1995 03:24:00`), end: new Date(`December 17, 1995 05:24:00`) },
+        expect: {
+            en: {
+                PPp: `Dec 17, 1995, 3:24 AM - 5:24 AM`,
+                PP: `Dec 17, 1995`
+            },
+            de: {
+                PPp: `17. Dez. 1995 03:24 - 05:24`,
+                PP: `17. Dez. 1995`
+            },
+            es: {
+                PPp: `17 dic 1995, 03:24 - 05:24`,
+                PP: `17 dic 1995`
+            },
+            it: {
+                PPp: `17 dic 1995 03:24 - 05:24`,
+                PP: `17 dic 1995`
+            },
+            cs: {
+                PPp: `17. 12. 1995, 3:24 - 5:24`,
+                PP: `17. 12. 1995`
+            },
+            ru: {
+                PPp: `17 дек. 1995 г., 3:24 - 17 дек. 1995 г., 5:24`,
+                PP: `17 дек. 1995 г.`
+            }
+        }
+    },
+    differentMonth: {
+        title: `test with same day and year, different month`,
+        range: { start: new Date(`January 17, 1995 03:24:00`), end: new Date(`December 17, 1995 03:24:00`) },
+        expect: {
+            en: {
+                PPp: `Jan 17, 1995, 3:24 AM - Dec 17, 1995, 3:24 AM`,
+                PP: `Jan 17 - Dec 17, 1995`
+            },
+            de: {
+                PPp: `17. Jan. 1995 03:24 - 17. Dez. 1995 03:24`,
+                PP: `17. Jan. - 17. Dez. 1995`
+            },
+            es: {
+                PPp: `17 ene 1995, 03:24 - 17 dic 1995, 03:24`,
+                PP: `17 ene - 17 dic 1995`
+            },
+            it: {
+                PPp: `17 gen 1995 03:24 - 17 dic 1995 03:24`,
+                PP: `17 gen - 17 dic 1995`
+            },
+            cs: {
+                PPp: `17. 1. 1995, 3:24 - 17. 12. 1995, 3:24`,
+                PP: `17. 1. - 17. 12. 1995`
+            },
+            ru: {
+                PPp: `17 янв. 1995 г., 3:24 - 17 дек. 1995 г., 3:24`,
+                PP: `17 янв. 1995 г. - 17 дек. 1995 г.`
+            }
+        }
+    }
+};
+
+describe(`LocalizedDateRangePipe`, () => {
     let pipe: LocalizedDateRangePipe;
 
     beforeEach(async () => {
-        await TestBed.configureTestingModule({}).compileComponents();
+        await TestBed.configureTestingModule({
+            providers: [LocalizedDateRangePipe, { provide: ChangeDetectorRef, useValue: { markForCheck: () => {} } }]
+        }).compileComponents();
 
         pipe = TestBed.inject(LocalizedDateRangePipe);
     });
 
-    it(`create an instance`, () => {
-        expect(pipe).toBeTruthy();
+    it(`test with timestamp 0`, async () => {
+        pipe.config.setLocale(await langToTimeLocale(`en`));
+        expect(pipe.transform({ start: 0 })).toBe(`Jan 1, 1970, 12:00 AM`);
+        expect(pipe.transform({ end: 0 }, `PP`)).toBe(`Jan 1, 1970`);
+    });
+
+    for (let data of Object.values(testData)) {
+        for (let lang of Object.keys(data.expect)) {
+            for (let dateFormat of Object.keys(data.expect[lang])) {
+                it(`${data.title} for locale '${lang}' in format '${dateFormat}'`, () => {
+                    pipe.config.setLocale(getLocale(lang));
+                    expect(pipe.transform(data.range, dateFormat)).toBe(data.expect[lang][dateFormat]);
+                });
+            }
+        }
+    }
+
+    it(`test with invalid parameters`, async () => {
+        pipe.config.setLocale(await langToTimeLocale(`en`));
+        expect(pipe.transform({ start: Number.NaN })).toBe(``);
+        expect(pipe.transform(undefined)).toBe(``);
+        expect(pipe.transform(null)).toBe(``);
+        expect(pipe.transform({ start: Number.NEGATIVE_INFINITY, end: Number.POSITIVE_INFINITY })).toBe(``);
     });
 });

--- a/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.ts
+++ b/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.ts
@@ -2,11 +2,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { fromUnixTime } from 'date-fns';
 import { FormatPipe } from 'ngx-date-fns';
 
-interface DateInterval {
-    start: Date;
-    end: Date;
-}
-
 @Pipe({
     name: `localizedDateRange`,
     pure: false
@@ -17,13 +12,13 @@ export class LocalizedDateRangePipe extends FormatPipe implements PipeTransform 
             return ``;
         }
 
-        if (!value.start) {
-            if (value.end) {
+        if (!value.start && value.start !== 0) {
+            if (value.end || value.end === 0) {
                 const date = fromUnixTime(value.end);
                 return super.transform(date, dateFormat);
             }
             return ``;
-        } else if (!value.end) {
+        } else if (!value.end && value.end !== 0) {
             const date = fromUnixTime(value.start);
             return super.transform(date, dateFormat);
         }
@@ -41,9 +36,9 @@ export class LocalizedDateRangePipe extends FormatPipe implements PipeTransform 
         const start = typeof interval.start === `number` ? fromUnixTime(interval.start) : interval.start;
         const end = typeof interval.end === `number` ? fromUnixTime(interval.end) : interval.end;
         const startString = super.transform(start, dateFormat);
-        const startArray = startString.split(/[\s,.]+/);
+        const startArray = startString.split(/[\s,]+/);
         const endString = super.transform(end, dateFormat);
-        const endArray = endString.split(/[\s,.]+/);
+        const endArray = endString.split(/[\s,]+/);
         return { startString, startArray, endString, endArray };
     }
 
@@ -56,7 +51,7 @@ export class LocalizedDateRangePipe extends FormatPipe implements PipeTransform 
         locale: Locale,
         dateFormat: string
     ): (startString: string, startArray: string[], endString: string, endArray: string[]) => string {
-        switch (locale.code + `#` + dateFormat) {
+        switch (locale?.code + `#` + dateFormat) {
             case `en-US#PPp`:
             case `de#PPp`:
             case `es#PPp`:
@@ -65,13 +60,11 @@ export class LocalizedDateRangePipe extends FormatPipe implements PipeTransform 
                 return this.formatPPp;
             case `en-US#PP`:
                 return this.formatMDYPPwithCommaNotation;
-            case `de#PP`:
-                return this.formatDMYPPwithSingleDotNotation;
             case `es#PP`:
             case `it#PP`:
-                return this.formatDMYPP;
+            case `de#PP`:
             case `cs#PP`:
-                return this.formatDMYPPwithDoubleDotNotation;
+                return this.formatDMYPP;
             default:
                 return (startString, startArray, endString, endArray) =>
                     this.defaultTransformInterval(startString, endString);
@@ -114,33 +107,5 @@ export class LocalizedDateRangePipe extends FormatPipe implements PipeTransform 
             return startArray[0] + ` ` + startArray[1] + ` - ` + endString;
         }
         return startArray[0] + ` - ` + endString;
-    };
-
-    private formatDMYPPwithSingleDotNotation = (
-        startString: string,
-        startArray: string[],
-        endString: string,
-        endArray: string[]
-    ) => {
-        if (startArray[2] !== endArray[2] || startString === endString) {
-            return this.defaultTransformInterval(startString, endString);
-        } else if (startArray[1] !== endArray[1]) {
-            return startArray[0] + `. ` + startArray[1] + ` - ` + endString;
-        }
-        return startArray[0] + `. - ` + endString;
-    };
-
-    private formatDMYPPwithDoubleDotNotation = (
-        startString: string,
-        startArray: string[],
-        endString: string,
-        endArray: string[]
-    ) => {
-        if (startArray[2] !== endArray[2] || startString === endString) {
-            return this.defaultTransformInterval(startString, endString);
-        } else if (startArray[1] !== endArray[1]) {
-            return startArray[0] + `. ` + startArray[1] + `. - ` + endString;
-        }
-        return startArray[0] + `. - ` + endString;
     };
 }

--- a/client/src/app/ui/pipes/localized-date/localized-date.pipe.spec.ts
+++ b/client/src/app/ui/pipes/localized-date/localized-date.pipe.spec.ts
@@ -1,17 +1,33 @@
+import { ChangeDetectorRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { LocalizedDatePipe } from './localized-date.pipe';
 
-xdescribe(`LocalizedDatePipe`, () => {
+describe(`LocalizedDatePipe`, () => {
     let pipe: LocalizedDatePipe;
 
     beforeEach(async () => {
-        await TestBed.configureTestingModule({}).compileComponents();
+        await TestBed.configureTestingModule({
+            providers: [LocalizedDatePipe, ChangeDetectorRef]
+        }).compileComponents();
 
         pipe = TestBed.inject(LocalizedDatePipe);
     });
 
-    it(`create an instance`, () => {
-        expect(pipe).toBeTruthy();
+    it(`test with timestamp 0`, () => {
+        expect(pipe.transform(0)).toBe(`Jan 1, 1970, 12:00 AM`);
+        expect(pipe.transform(0, `PP`)).toBe(`Jan 1, 1970`);
+    });
+
+    it(`test with timestamp past 1970`, () => {
+        expect(pipe.transform(42424242)).toBe(`May 7, 1971, 12:30 AM`);
+        expect(pipe.transform(42424242, `PP`)).toBe(`May 7, 1971`);
+    });
+
+    it(`test with invalid parameters`, () => {
+        expect(pipe.transform(Number.NaN)).toBe(``);
+        expect(pipe.transform(undefined)).toBe(``);
+        expect(pipe.transform(Number.POSITIVE_INFINITY)).toBe(``);
+        expect(pipe.transform(Number.NEGATIVE_INFINITY)).toBe(``);
     });
 });

--- a/client/src/app/ui/pipes/localized-date/localized-date.pipe.ts
+++ b/client/src/app/ui/pipes/localized-date/localized-date.pipe.ts
@@ -8,7 +8,7 @@ import { FormatPipe } from 'ngx-date-fns';
 })
 export class LocalizedDatePipe extends FormatPipe implements PipeTransform {
     public override transform(value: any, dateFormat: string = `PPp`): any {
-        if (!value) {
+        if (!value && value !== 0) {
             return ``;
         }
 


### PR DESCRIPTION
And some fixes to said pipes.

Pipes are:
- `poll-key-verbose`
- `poll-parse-number`
- `poll-percent-base`
- `localized-date`
- `localized-date-range`