### PR TITLE
Make sort lists update only when relevant data is changed

### DIFF
--- a/client/src/app/infrastructure/definitions/tree.ts
+++ b/client/src/app/infrastructure/definitions/tree.ts
@@ -16,6 +16,7 @@ export interface TreeNodeWithoutItem extends TreeIdNode {
 
 /**
  * A representation of nodes with the item atached.
+ * The id of the item should be the id of the node.
  */
 export interface OSTreeNode<T> extends TreeNodeWithoutItem {
     item: T;
@@ -33,7 +34,7 @@ export interface OSTreeNode<T> extends TreeNodeWithoutItem {
  * @param position: The position in the array of the node.
  * @param isExpanded: Boolean if the node is expanded.
  * @param expandable: Boolean if the node is expandable.
- * @param id: The id of the node.
+ * @param id: The id of the node, same as the id of the item if there is an id.
  * @param filtered: Optional boolean to check, if the node is filtered.
  */
 export type FlatNode<T> = T & {
@@ -46,3 +47,26 @@ export type FlatNode<T> = T & {
     id: number;
     filtered?: boolean;
 };
+
+function isIdentifiedItemNode(obj: any): boolean {
+    return obj && obj.id && obj.item && obj.item?.id === obj.id;
+}
+
+export function isFlatNode<T>(obj: any): obj is FlatNode<T> {
+    return (
+        isIdentifiedItemNode(obj) &&
+        Number.isInteger(obj.level) &&
+        obj.isSeen !== undefined &&
+        obj.expandable !== undefined
+    );
+}
+
+export function isOSTreeNode<T>(obj: any): obj is OSTreeNode<T> {
+    if (!obj) {
+        return false;
+    }
+    const correctChildrenType = obj.children
+        ? Array.isArray(obj.children) && (obj.children as any[]).every(child => isOSTreeNode(child))
+        : true;
+    return isIdentifiedItemNode(obj) && correctChildrenType && obj.name?.length;
+}

--- a/client/src/app/infrastructure/utils/functions.spec.ts
+++ b/client/src/app/infrastructure/utils/functions.spec.ts
@@ -5,6 +5,7 @@ import {
     djb2hash,
     escapeRegExp,
     filterObject,
+    findIndexInSortedArray,
     getLongPreview,
     getShortPreview,
     isEasterEggTime,
@@ -662,6 +663,32 @@ describe(`utils: functions`, () => {
                     [`f`, `g h`]
                 ])
             ).toEqual({ b: `b`, e: `e`, 'g h': `g h` });
+        });
+    });
+
+    describe(`findIndexInSortedArray function`, () => {
+        const sortedArray = [1, 4, 5, 7, 8, 9];
+
+        for (let searchValue = 0; searchValue < 10; searchValue++) {
+            let expected = sortedArray.findIndex(val => searchValue === val);
+            it(`test result for ${searchValue} in ${JSON.stringify(sortedArray)}`, () => {
+                expect(findIndexInSortedArray(sortedArray, searchValue, (a, b) => a - b)).toBe(expected);
+            });
+        }
+
+        const sortedStringArray = [`a`, `b`, `d`];
+
+        for (let searchValue of [`b`, `c`, `d`, `e`]) {
+            let expected = sortedStringArray.findIndex(val => searchValue === val);
+            it(`test result for "${searchValue}" in ${JSON.stringify(sortedStringArray)}`, () => {
+                expect(findIndexInSortedArray(sortedStringArray, searchValue, (a, b) => a.localeCompare(b))).toBe(
+                    expected
+                );
+            });
+        }
+
+        it(`finds first among many`, () => {
+            expect(findIndexInSortedArray([1, 1, 1, 1, 1, 1, 1], 1, (a, b) => a - b)).toBe(0);
         });
     });
 });

--- a/client/src/app/infrastructure/utils/functions.ts
+++ b/client/src/app/infrastructure/utils/functions.ts
@@ -452,3 +452,33 @@ export function replaceObjectKeys(
     }
     return result;
 }
+
+/**
+ * A function to efficiently find the index of an item in an array that has been sorted beforehand.
+ * @param array An array sorted in ascending order according to compareFn
+ * @param toFind The item to search for
+ * @param compareFn A compare function the type of which would be used in array.sort
+ * @returns -1 if no index is found, else the index of the item in the array. If the item is in the array multiple times, it will be the first index of the item.
+ */
+export function findIndexInSortedArray<T>(array: T[], toFind: T, compareFn: (a: T, b: T) => number): number {
+    let startId = 0;
+    while (array.length) {
+        let middleId = Math.floor(array.length / 2);
+        let comparison = compareFn(toFind, array[middleId]);
+        if (comparison === 0) {
+            // If toFind is the current item
+            while (middleId > 0 && compareFn(toFind, array[middleId - 1]) === 0) {
+                middleId--;
+            }
+            return startId + middleId;
+        } else if (comparison > 0) {
+            // If toFind is greater than the current item
+            startId += middleId + 1;
+            array = array.slice(middleId + 1);
+        } else {
+            // If toFind is smaller than the current item
+            array = array.slice(0, middleId);
+        }
+    }
+    return -1;
+}


### PR DESCRIPTION
Closes #2458 

How it should work now upon update:
1. If items were deleted they should be removed from the list, immediate sub-items should gain expansion and visibility level of the removed parent, _all_ sub-items should be moved left
2. If items are added they should be appended to the list
3. Other changes like name-changes will not affect the list in any way. (i.e. the sort view will also not update names while opened)

Notes for testing: Please especially check if
- Actual changes with the agenda item (for example change of topic title) still trigger an update
- Other sort lists are negatively/positively affected (for example the motion call list), as this performs changes in the base class