### PR TITLE
Prevent deletion of participants which are part of archived meetings

### DIFF
--- a/client/src/app/gateways/presenter/get-user-related-models-presenter.service.ts
+++ b/client/src/app/gateways/presenter/get-user-related-models-presenter.service.ts
@@ -1,19 +1,19 @@
 import { Injectable } from '@angular/core';
 
 import { Id } from '../../domain/definitions/key-types';
-import { CML } from '../../domain/definitions/organization-permission';
+import { CML, OML } from '../../domain/definitions/organization-permission';
 import { Presenter } from './presenter';
 import { PresenterService } from './presenter.service';
 
 export interface GetUserRelatedModelsUser {
-    name?: string;
+    organization_management_level?: OML;
     meetings?: {
         id: Id;
         is_active_in_organization_id: Id;
         name: string;
-        candidate_ids: Id[];
+        assignment_candidate_ids: Id[];
         speaker_ids: Id[];
-        submitter_ids: Id[];
+        motion_submitter_ids: Id[];
     }[];
     committees?: GetUserRelatedModelsCommittee[];
     error?: string; // This is in case the presenter fails in an unpredicted way

--- a/client/src/app/gateways/presenter/get-user-scope-presenter.service.ts
+++ b/client/src/app/gateways/presenter/get-user-scope-presenter.service.ts
@@ -15,7 +15,7 @@ interface GetUserScopeIdentifiedScope {
 }
 
 interface GetUserScopePresenterResult {
-    [user_id: string]: GetUserScopeIdentifiedScope;
+    [user_id: Id]: GetUserScopeIdentifiedScope;
 }
 
 @Injectable({

--- a/client/src/app/site/modules/user-components/services/user-delete-dialog.service.ts
+++ b/client/src/app/site/modules/user-components/services/user-delete-dialog.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
-import { Selectable } from 'src/app/domain/interfaces';
 import {
     GetUserRelatedModelsPresenterResult,
     GetUserRelatedModelsPresenterService
@@ -15,7 +14,8 @@ import { UserComponentsModule } from '../user-components.module';
 
 interface UserDeleteDialogOpenConfig {
     toRemove: ViewUser[];
-    toDelete: Selectable[];
+    toDelete: ViewUser[];
+    relatedModelsResult?: GetUserRelatedModelsPresenterResult;
 }
 
 @Injectable({
@@ -31,30 +31,35 @@ export class UserDeleteDialogService extends BaseDialogService<
     }
 
     public async open(data: UserDeleteDialogOpenConfig): Promise<MatDialogRef<UserDeleteDialogComponent, boolean>> {
-        let toDelete: GetUserRelatedModelsPresenterResult;
-        try {
-            toDelete = await this.userRelatedModelsPresenter.call({
-                user_ids: data.toDelete.map(user => user.id)
-            });
-        } catch (e) {
-            toDelete = data.toDelete.mapToObject(user => {
-                return {
-                    [user.id]: {
-                        name: user.getTitle(),
-                        error: _(`Relevant information could not be accessed`)
-                    }
-                };
-            });
+        let result: GetUserRelatedModelsPresenterResult = {};
+        if (data.relatedModelsResult !== undefined) {
+            result = data.relatedModelsResult;
+        } else if (data.toDelete.length > 0) {
+            try {
+                result = await this.userRelatedModelsPresenter.call({
+                    user_ids: data.toDelete.map(user => user.id)
+                });
+            } catch (e) {
+                result = data.toDelete.mapToObject(user => {
+                    return {
+                        [user.id]: {
+                            name: user.getTitle(),
+                            error: _(`Relevant information could not be accessed`)
+                        }
+                    };
+                });
+            }
         }
-        for (const user of data.toDelete) {
-            toDelete[user.id].name = user.getTitle();
-        }
+        const toDelete = data.toDelete.map(user => ({
+            ...result[user.id],
+            name: user.getTitle()
+        }));
 
         const module = await import(`../user-components.module`).then(m => m.UserComponentsModule);
 
         return this.dialog.open(module.getComponent(), {
             ...mediumDialogSettings,
-            data: { toDelete, toRemove: data.toRemove }
+            data: { toDelete: toDelete, toRemove: data.toRemove }
         });
     }
 }


### PR DESCRIPTION
How to test:
- Create 2 meetings
- Create 1 user and add him to both meetings
- Archive one meeting
- Go to the participant list of the other meeting and delete the user from there

Expected result: The user itself is not deleted, but only removed from the meeting, since he is also part of an archived meeting.