### PR TITLE
Fix poll pdf exports

### DIFF
--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-pdf.service.ts
@@ -2,7 +2,7 @@ import { Directive } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { BallotPaperSelection } from 'src/app/domain/models/meetings/meeting';
-import { PollMethod, PollTableData, VoteValuesVerbose, VotingResult } from 'src/app/domain/models/poll';
+import { PollMethod, PollTableData, PollType, VoteValuesVerbose, VotingResult } from 'src/app/domain/models/poll';
 import { ParticipantControllerService } from 'src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service';
 import { ViewOption, ViewPoll } from 'src/app/site/pages/meetings/pages/polls';
 import { ActiveMeetingService } from 'src/app/site/pages/meetings/services/active-meeting.service';
@@ -14,7 +14,7 @@ import { ViewMeeting } from 'src/app/site/pages/meetings/view-models/view-meetin
 import { ViewAssignment } from '../../../pages/assignments';
 import { ViewUser } from '../../../view-models/view-user';
 import { EntitledUsersTableEntry } from '../definitions';
-import { PollKeyVerbosePipe } from '../pipes';
+import { PollKeyVerbosePipe, PollParseNumberPipe } from '../pipes';
 import { PollService } from '../services/poll.service';
 import { BaseVoteData } from './base-poll-detail.component';
 
@@ -71,7 +71,8 @@ export abstract class BasePollPdfService {
         protected pdfExport: MeetingPdfExportService,
         protected translate: TranslateService,
         protected pollService: PollService,
-        private pollKeyVerbose: PollKeyVerbosePipe
+        private pollKeyVerbose: PollKeyVerbosePipe,
+        private pollParseNumber: PollParseNumberPipe
     ) {
         this.meetingSettingsService.get(`name`).subscribe(name => (this.eventName = name));
         this.mediaManageService.getLogoUrlObservable(`pdf_ballot_paper`).subscribe(url => (this.logoUrl = url));
@@ -378,7 +379,7 @@ export abstract class BasePollPdfService {
             pollResultPdfContent.push(resultsData);
         }
 
-        if (exportInfo.votesData?.length) {
+        if (exportInfo.votesData?.length && poll.type !== PollType.Analog) {
             pollResultPdfContent.push({
                 text: this.translate.instant(`Single votes`),
                 margin: [0, 20, 0, 5],
@@ -499,6 +500,11 @@ export abstract class BasePollPdfService {
             ]
         ];
 
+        const showPercent = !resultsTable.some(date =>
+            date.value.some(
+                val => [`yes`, `no`, `abstain`].includes(val.vote ?? date.votingOption) && val.amount && val.amount < 0
+            )
+        );
         let i = 0;
         for (const date of resultsTable) {
             const tableLine = [
@@ -513,8 +519,9 @@ export abstract class BasePollPdfService {
                             : undefined;
                         return hasValue
                             ? {
-                                  text: `${currentValue.amount}${
-                                      [`yes`, `no`, `abstain`].includes(currentValue.vote ?? date.votingOption)
+                                  text: `${this.pollParseNumber.transform(currentValue.amount)}${
+                                      [`yes`, `no`, `abstain`].includes(currentValue.vote ?? date.votingOption) &&
+                                      showPercent
                                           ? ` (${this.pollService.getVoteValueInPercent(
                                                 currentValue.amount,
                                                 currentValue.vote ? { poll, row: resultsTableData[i] } : { poll }

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/services/topic-poll-pdf.service/topic-poll-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/services/topic-poll-pdf.service/topic-poll-pdf.service.ts
@@ -4,7 +4,7 @@ import {
     AbstractPollData,
     BasePollPdfService
 } from 'src/app/site/pages/meetings/modules/poll/base/base-poll-pdf.service';
-import { PollKeyVerbosePipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
+import { PollKeyVerbosePipe, PollParseNumberPipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
 import { ParticipantControllerService } from 'src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service';
 import { ViewPoll } from 'src/app/site/pages/meetings/pages/polls';
 import { ActiveMeetingService } from 'src/app/site/pages/meetings/services/active-meeting.service';
@@ -30,7 +30,8 @@ export class TopicPollPdfService extends BasePollPdfService {
         protected override translate: TranslateService,
         private topicRepo: TopicControllerService,
         pollService: TopicPollService,
-        pollKeyVerbose: PollKeyVerbosePipe
+        pollKeyVerbose: PollKeyVerbosePipe,
+        pollParseNumber: PollParseNumberPipe
     ) {
         super(
             meetingSettingsService,
@@ -40,7 +41,8 @@ export class TopicPollPdfService extends BasePollPdfService {
             pdfService,
             translate,
             pollService,
-            pollKeyVerbose
+            pollKeyVerbose,
+            pollParseNumber
         );
         this.meetingSettingsService
             .get(`motion_poll_ballot_paper_number`)

--- a/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/services/assignment-poll-pdf.service/assignment-poll-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/services/assignment-poll-pdf.service/assignment-poll-pdf.service.ts
@@ -5,7 +5,7 @@ import {
     AbstractPollData,
     BasePollPdfService
 } from 'src/app/site/pages/meetings/modules/poll/base/base-poll-pdf.service';
-import { PollKeyVerbosePipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
+import { PollKeyVerbosePipe, PollParseNumberPipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
 import { ParticipantControllerService } from 'src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service';
 import { ViewPoll } from 'src/app/site/pages/meetings/pages/polls';
 import { ActiveMeetingService } from 'src/app/site/pages/meetings/services/active-meeting.service';
@@ -31,7 +31,8 @@ export class AssignmentPollPdfService extends BasePollPdfService {
         protected override translate: TranslateService,
         private assignmentRepo: AssignmentControllerService,
         pollService: AssignmentPollService,
-        pollKeyVerbose: PollKeyVerbosePipe
+        pollKeyVerbose: PollKeyVerbosePipe,
+        pollParseNumber: PollParseNumberPipe
     ) {
         super(
             meetingSettingsService,
@@ -41,7 +42,8 @@ export class AssignmentPollPdfService extends BasePollPdfService {
             pdfService,
             translate,
             pollService,
-            pollKeyVerbose
+            pollKeyVerbose,
+            pollParseNumber
         );
         meetingSettingsService
             .get(`assignment_poll_ballot_paper_number`)

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/services/motion-poll-pdf.service/motion-poll-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/services/motion-poll-pdf.service/motion-poll-pdf.service.ts
@@ -4,7 +4,7 @@ import {
     AbstractPollData,
     BasePollPdfService
 } from 'src/app/site/pages/meetings/modules/poll/base/base-poll-pdf.service';
-import { PollKeyVerbosePipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
+import { PollKeyVerbosePipe, PollParseNumberPipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
 import { ParticipantControllerService } from 'src/app/site/pages/meetings/pages/participants/services/common/participant-controller.service/participant-controller.service';
 import { ViewPoll } from 'src/app/site/pages/meetings/pages/polls';
 import { ActiveMeetingService } from 'src/app/site/pages/meetings/services/active-meeting.service';
@@ -30,7 +30,8 @@ export class MotionPollPdfService extends BasePollPdfService {
         protected override translate: TranslateService,
         private motionRepo: MotionControllerService,
         pollService: MotionPollService,
-        pollKeyVerbose: PollKeyVerbosePipe
+        pollKeyVerbose: PollKeyVerbosePipe,
+        pollParseNumber: PollParseNumberPipe
     ) {
         super(
             meetingSettingsService,
@@ -40,7 +41,8 @@ export class MotionPollPdfService extends BasePollPdfService {
             pdfService,
             translate,
             pollService,
-            pollKeyVerbose
+            pollKeyVerbose,
+            pollParseNumber
         );
         this.meetingSettingsService
             .get(`motion_poll_ballot_paper_number`)

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
@@ -6,6 +6,7 @@ import {
     MOTION_PDF_OPTIONS,
     PERSONAL_NOTE_ID
 } from 'src/app/domain/models/motions/motions.constants';
+import { VOTE_UNDOCUMENTED } from 'src/app/domain/models/poll';
 import { PdfImagesService } from 'src/app/gateways/export/pdf-document.service/pdf-images.service';
 import { PollKeyVerbosePipe, PollParseNumberPipe } from 'src/app/site/pages/meetings/modules/poll/pipes';
 import { ViewMotion, ViewMotionChangeRecommendation } from 'src/app/site/pages/meetings/pages/motions';
@@ -388,22 +389,24 @@ export class MotionPdfService {
                             this.pollKeyVerbose.transform(votingResult.votingOption)
                         );
                         const value = votingResult.value[0];
-                        const resultValue = this.parsePollNumber.transform(value.amount!);
-                        column1.push(`${votingOption}:`);
-                        if (value.showPercent) {
-                            const resultInPercent = this.motionPollService.getVoteValueInPercent(value.amount!, {
-                                poll
-                            });
-                            // hard check for "null" since 0 is a valid number in this case
-                            if (resultInPercent !== null) {
-                                column2.push(`(${resultInPercent})`);
+                        if (value.amount !== VOTE_UNDOCUMENTED) {
+                            const resultValue = this.parsePollNumber.transform(value.amount!);
+                            column1.push(`${votingOption}:`);
+                            if (value.showPercent) {
+                                const resultInPercent = this.motionPollService.getVoteValueInPercent(value.amount!, {
+                                    poll
+                                });
+                                // hard check for "null" since 0 is a valid number in this case
+                                if (resultInPercent !== null) {
+                                    column2.push(`(${resultInPercent})`);
+                                } else {
+                                    column2.push(``);
+                                }
                             } else {
                                 column2.push(``);
                             }
-                        } else {
-                            column2.push(``);
+                            column3.push(resultValue);
                         }
-                        column3.push(resultValue);
                     });
                     metaTableBody.push([
                         {

--- a/client/src/app/site/pages/meetings/pages/polls/view-models/view-poll.ts
+++ b/client/src/app/site/pages/meetings/pages/polls/view-models/view-poll.ts
@@ -8,7 +8,8 @@ import {
     PollPercentBaseVerbose,
     PollStateChangeActionVerbose,
     PollStateVerbose,
-    PollTypeVerbose
+    PollTypeVerbose,
+    VOTE_MAJORITY
 } from 'src/app/domain/models/poll';
 import { Poll } from 'src/app/domain/models/poll/poll';
 import { Projectiondefault } from 'src/app/domain/models/projector/projection-default';
@@ -102,7 +103,9 @@ export class ViewPoll<C extends PollContentObject = any>
     }
 
     public get hasVotes(): boolean {
-        return this.results.flatMap(option => option.votes).some(vote => vote.weight > 0);
+        return this.results
+            .flatMap(option => option.votes)
+            .some(vote => vote.weight > 0 || +vote.weight === VOTE_MAJORITY);
     }
 
     public hasVotedForDelegations(userId?: number): boolean {


### PR DESCRIPTION
Closes #2515 

Also removed the single votes table from the pdf exports of analog polls, since it also isn't shown in the `poll-detail-view` and the information portrayed did not make sense, as was to be expected.