### PR TITLE
Implement agenda pdf export dialog

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/services/motion-export-dialog.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/services/motion-export-dialog.service.ts
@@ -1,43 +1,183 @@
 import { Injectable } from '@angular/core';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialog } from '@angular/material/dialog';
+import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { firstValueFrom } from 'rxjs';
+import { Permission } from 'src/app/domain/definitions/permission';
+import { ChangeRecoMode, LineNumberingMode, PERSONAL_NOTE_ID } from 'src/app/domain/models/motions/motions.constants';
 import { MotionRepositoryService } from 'src/app/gateways/repositories/motions';
-import { largeDialogSettings } from 'src/app/infrastructure/utils/dialog-settings';
+import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { ModelRequestService } from 'src/app/site/services/model-request.service';
-import { BaseDialogService } from 'src/app/ui/base/base-dialog-service';
+import { ExportDialogService, ExportDialogSettings } from 'src/app/ui/modules/export-dialog';
 
+import { MotionCommentSectionControllerService } from '../../../modules/comments/services';
 import { getMotionDetailSubscriptionConfig } from '../../../motions.subscription';
 import { AmendmentControllerService } from '../../../services/common/amendment-controller.service';
 import { MotionLineNumberingService } from '../../../services/common/motion-line-numbering.service';
+import {
+    ExportFileFormat,
+    InfoToExport,
+    motionImportExportHeaderOrder,
+    noMetaData
+} from '../../../services/export/definitions';
 import { MotionExportInfo } from '../../../services/export/motion-export.service';
 import { MotionExportService } from '../../../services/export/motion-export.service';
 import { ViewMotion } from '../../../view-models';
-import { MotionExportDialogComponent } from '../components/motion-export-dialog/motion-export-dialog.component';
 import { MotionExportDialogModule } from '../motion-export-dialog.module';
 
 @Injectable({
     providedIn: MotionExportDialogModule
 })
-export class MotionExportDialogService extends BaseDialogService<
-    MotionExportDialogComponent,
-    ViewMotion[],
-    MotionExportInfo
-> {
+export class MotionExportDialogService extends ExportDialogService<ViewMotion, MotionExportInfo> {
+    protected override get settings(): ExportDialogSettings<MotionExportInfo> {
+        return {
+            title: _(`Export Motions`),
+            settings: {
+                format: {
+                    label: _(`Format`),
+                    weight: 1,
+                    multiple: false,
+                    choices: new Map([
+                        [ExportFileFormat.PDF, { label: _(`PDF`) }],
+                        [ExportFileFormat.CSV, { label: _(`CSV`) }],
+                        [ExportFileFormat.XLSX, { label: _(`XLSX`) }]
+                    ])
+                },
+                lnMode: {
+                    label: _(`Line Numbering`),
+                    weight: 2,
+                    multiple: false,
+                    offState: LineNumberingMode.None,
+                    disableForFormat: [ExportFileFormat.CSV, ExportFileFormat.XLSX],
+                    choices: new Map([
+                        [LineNumberingMode.None, { label: _(`None`) }],
+                        [LineNumberingMode.Outside, { label: _(`Outside`) }]
+                    ])
+                },
+                crMode: {
+                    label: _(`Change Recommendations`),
+                    weight: 3,
+                    multiple: false,
+                    offState: ChangeRecoMode.Original,
+                    disableForFormat: [ExportFileFormat.CSV, ExportFileFormat.XLSX],
+                    choices: new Map([
+                        [ChangeRecoMode.Original, { label: _(`Original Version`) }],
+                        [ChangeRecoMode.Changed, { label: _(`Changed Version`) }],
+                        [ChangeRecoMode.Diff, { label: _(`Diff Version`) }],
+                        [ChangeRecoMode.ModifiedFinal, { label: _(`Final Version`) }]
+                    ])
+                },
+                content: {
+                    label: _(`Content`),
+                    weight: 4,
+                    multiple: true,
+                    choices: new Map([
+                        [`text`, { label: _(`Text`) }],
+                        [`reason`, { label: _(`Reason`) }]
+                    ])
+                },
+                metaInfo: {
+                    label: _(`Meta Information`),
+                    weight: 5,
+                    multiple: true,
+                    disableForFormat: [ExportFileFormat.CSV, ExportFileFormat.XLSX],
+                    choices: new Map(
+                        (
+                            (
+                                motionImportExportHeaderOrder.filter(
+                                    metaData => !noMetaData.some(noMeta => metaData === noMeta)
+                                ) as InfoToExport[]
+                            ).map(date => [date, { label: this.getLabelForMetadata(date) }]) as [InfoToExport, any][]
+                        ).concat([
+                            [
+                                `speakers`,
+                                {
+                                    label: _(`Speakers`),
+                                    perms: Permission.listOfSpeakersCanSee,
+                                    changeStateForFormat: [
+                                        { format: [ExportFileFormat.XLSX], value: false },
+                                        { format: [ExportFileFormat.PDF, ExportFileFormat.CSV], value: true }
+                                    ]
+                                }
+                            ],
+                            [
+                                `polls`,
+                                {
+                                    label: _(`Voting Result`),
+                                    disableForFormat: [ExportFileFormat.CSV, ExportFileFormat.XLSX]
+                                }
+                            ]
+                        ])
+                    )
+                },
+                pdfOptions: {
+                    label: _(`PDF options`),
+                    weight: 5,
+                    multiple: true,
+                    choices: new Map<string, any>([
+                        [
+                            `toc`,
+                            {
+                                label: _(`Table of contents`),
+                                disableWhen: [{ otherValue: `continuousText`, checked: true }]
+                            }
+                        ],
+                        [`header`, { label: _(`Header`) }],
+                        [`page`, { label: _(`Page numbers`) }],
+                        [`date`, { label: _(`Current date`) }],
+                        [`attachments`, { label: _(`Attachments`) }],
+                        [
+                            `addBreaks`,
+                            {
+                                label: _(`Enforce page breaks`),
+                                disableWhen: [{ otherValue: `continuousText`, checked: true }]
+                            }
+                        ],
+                        [`continuousText`, { label: _(`Continuous text`) }]
+                    ])
+                },
+                comments: {
+                    label: _(`Comments`),
+                    weight: 6,
+                    multiple: true,
+                    choices: new Map(
+                        ([[PERSONAL_NOTE_ID, { label: _(`Personal note`) }]] as [number, { label: string }][]).concat(
+                            this.commentRepo.getViewModelList().map(comment => [comment.id, { label: comment.name }])
+                        )
+                    )
+                }
+            }
+        };
+    }
+    protected override readonly storageKey: string = `motions`;
+    protected override get defaults(): MotionExportInfo {
+        return {
+            format: ExportFileFormat.PDF,
+            lnMode: this.meetingSettings.instant(`motions_default_line_numbering`)!,
+            crMode: ChangeRecoMode.Diff,
+            content: [`text`, `reason`],
+            metaInfo: [`submitters`, `category`, `tags`, `block`, `recommendation`, `state`, `polls`],
+            pdfOptions: [`toc`, `header`, `page`, `addBreaks`],
+            comments: []
+        };
+    }
+
     public constructor(
         dialog: MatDialog,
         private exportService: MotionExportService,
         private modelRequestService: ModelRequestService,
         private motionRepo: MotionRepositoryService,
         private amendmentRepo: AmendmentControllerService,
-        private motionLineNumbering: MotionLineNumberingService
+        private motionLineNumbering: MotionLineNumberingService,
+        private meetingSettings: MeetingSettingsService,
+        public commentRepo: MotionCommentSectionControllerService
     ) {
         super(dialog);
     }
 
-    public async open(data: ViewMotion[]): Promise<MatDialogRef<MotionExportDialogComponent, MotionExportInfo>> {
-        const module = await import(`../motion-export-dialog.module`).then(m => m.MotionExportDialogModule);
-        return this.dialog.open(module.getComponent(), { data, ...largeDialogSettings });
-    }
+    // public override async open(data: ViewMotion[]): Promise<MatDialogRef<MotionExportDialogComponent, MotionExportInfo>> {
+    //     const module = await import(`../motion-export-dialog.module`).then(m => m.MotionExportDialogModule);
+    //     return this.dialog.open(module.getComponent(), { data, ...largeDialogSettings });
+    // }
 
     public async export(motions: ViewMotion[]): Promise<void> {
         const dialogRef = await this.open(motions);
@@ -55,6 +195,26 @@ export class MotionExportDialogService extends BaseDialogService<
                     motions.map(m => this.motionRepo.getViewModel(m.id))
                 );
             }, 2000);
+        }
+    }
+
+    /**
+     * Gets the untranslated label for metaData
+     */
+    private getLabelForMetadata(metaDataName: string): string {
+        switch (metaDataName) {
+            case `polls`: {
+                return `Voting result`;
+            }
+            case `id`: {
+                return `Sequential number`;
+            }
+            case `block`: {
+                return `Motion block`;
+            }
+            default: {
+                return metaDataName.charAt(0).toUpperCase() + metaDataName.slice(1).replace(`_`, ` `);
+            }
         }
     }
 }

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/services/motion-export-dialog.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/services/motion-export-dialog.service.ts
@@ -93,6 +93,7 @@ export class MotionExportDialogService extends ExportDialogService<ViewMotion, M
                                 {
                                     label: _(`Speakers`),
                                     perms: Permission.listOfSpeakersCanSee,
+                                    disableForFormat: [ExportFileFormat.CSV],
                                     changeStateForFormat: [
                                         { format: [ExportFileFormat.XLSX], value: false },
                                         { format: [ExportFileFormat.PDF, ExportFileFormat.CSV], value: true }

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/services/motion-export-dialog.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/services/motion-export-dialog.service.ts
@@ -70,6 +70,7 @@ export class MotionExportDialogService extends ExportDialogService<ViewMotion, M
                     label: _(`Content`),
                     weight: 4,
                     multiple: true,
+                    disableForFormat: [ExportFileFormat.XLSX],
                     choices: new Map([
                         [`text`, { label: _(`Text`) }],
                         [`reason`, { label: _(`Reason`) }]
@@ -79,7 +80,6 @@ export class MotionExportDialogService extends ExportDialogService<ViewMotion, M
                     label: _(`Meta Information`),
                     weight: 5,
                     multiple: true,
-                    disableForFormat: [ExportFileFormat.CSV, ExportFileFormat.XLSX],
                     choices: new Map(
                         (
                             (
@@ -114,6 +114,7 @@ export class MotionExportDialogService extends ExportDialogService<ViewMotion, M
                     label: _(`PDF options`),
                     weight: 5,
                     multiple: true,
+                    disableForFormat: [ExportFileFormat.CSV, ExportFileFormat.XLSX],
                     choices: new Map<string, any>([
                         [
                             `toc`,

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/definitions.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/definitions.ts
@@ -17,7 +17,7 @@ export type InfoToExport =
     | 'allcomments';
 
 /**
- * Determines the possible file format of a motion export
+ * Determines the possible file format of an export
  */
 export enum ExportFileFormat {
     PDF = 1,

--- a/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.html
+++ b/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.html
@@ -2,7 +2,7 @@
 
 <form [formGroup]="exportForm">
     <!-- Content -->
-    <div mat-dialog-content class="motion-export-dialog-wrapper">
+    <div mat-dialog-content class="export-dialog-wrapper">
         <div *ngFor="let setting of settings">
             <p class="toggle-group-head">{{ getSettingTitle(setting) | translate }}</p>
             <mat-button-toggle-group

--- a/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.html
+++ b/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.html
@@ -1,0 +1,45 @@
+<h1 mat-dialog-title>{{ data.settings.title | translate }}</h1>
+
+<form [formGroup]="exportForm">
+    <!-- Content -->
+    <div mat-dialog-content class="motion-export-dialog-wrapper">
+        <div *ngFor="let setting of settings">
+            <p class="toggle-group-head">{{ getSettingTitle(setting) | translate }}</p>
+            <mat-button-toggle-group
+                class="smaller-buttons"
+                [multiple]="setting.multiple"
+                [formControlName]="setting.key"
+                (change)="onChange($event, setting)"
+            >
+                <ng-container *ngFor="let choice of setting.choices | keyvalue">
+                    <ng-container *ngIf="choice.value.perms && choice.value.perms.length">
+                        <mat-button-toggle
+                            *osPerms="choice.value.perms"
+                            [value]="choice.key"
+                            [disabled]="choice.value.disabled"
+                        >
+                            <span>{{ getChoiceTitle(choice.value, choice.key) | translate }}</span>
+                        </mat-button-toggle>
+                    </ng-container>
+                    <ng-container *ngIf="!(choice.value.perms && choice.value.perms.length)">
+                        <mat-button-toggle [value]="choice.key" [disabled]="choice.value.disabled">
+                            <span>{{ getChoiceTitle(choice.value, choice.key) | translate }}</span>
+                        </mat-button-toggle>
+                    </ng-container>
+                </ng-container>
+            </mat-button-toggle-group>
+        </div>
+
+        <br />
+    </div>
+
+    <!-- Action buttons -->
+    <div mat-dialog-actions>
+        <button mat-button type="button" color="accent" [mat-dialog-close]="exportForm.value">
+            <span>{{ 'Export' | translate }}</span>
+        </button>
+        <button mat-button type="button" (click)="onCloseClick()">
+            <span>{{ 'Cancel' | translate }}</span>
+        </button>
+    </div>
+</form>

--- a/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.scss
+++ b/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.scss
@@ -1,0 +1,16 @@
+.export-dialog-wrapper {
+    .toggle-group-head {
+        margin-bottom: 0;
+    }
+
+    h1 {
+        margin: 0;
+    }
+
+    mat-button-toggle {
+        .mat-button-toggle-label-content {
+            line-height: 2.5;
+            padding: 0 10px;
+        }
+    }
+}

--- a/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.spec.ts
+++ b/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExportDialogComponent } from './export-dialog.component';
+
+describe(`ExportDialogComponent`, () => {
+    let component: ExportDialogComponent;
+    let fixture: ComponentFixture<ExportDialogComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ExportDialogComponent]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ExportDialogComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it(`should create`, () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.ts
+++ b/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.ts
@@ -14,10 +14,10 @@ import { ExportDialogSettings, ExportInfoChoiceType } from '../../services';
 interface Choice<ExportInfo> {
     label?: string;
     perms?: Permission;
-    mandatory?: boolean; // If true, this option will not be shown but still returned as part of the selection
     disableWhen?: { otherValue: ExportInfo[keyof ExportInfo]; checked: boolean }[];
     disableForFormat?: ExportFileFormat[];
     disabled?: boolean;
+    changeStateForFormat?: { format: ExportFileFormat[]; value: boolean }[];
 }
 
 type ChoiceMap<ExportInfo> = Map<ExportInfoChoiceType<ExportInfo[keyof ExportInfo]>, Choice<ExportInfo>>;
@@ -38,7 +38,7 @@ interface ExportInfoTableData<ExportInfo> {
     styleUrls: [`./export-dialog.component.scss`],
     encapsulation: ViewEncapsulation.None
 })
-export class ExportDialogComponent<T extends BaseViewModel, ExportInfo extends { format: ExportFileFormat }>
+export class ExportDialogComponent<T extends BaseViewModel, ExportInfo extends { format?: ExportFileFormat }>
     extends BaseUiComponent
     implements OnInit
 {

--- a/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.ts
+++ b/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.ts
@@ -117,10 +117,6 @@ export class ExportDialogComponent<T extends BaseViewModel, ExportInfo extends {
 
     public onChange(event: MatButtonToggleChange, row: ExportInfoTableData<ExportInfo>): void {
         this.updateDisabled(row);
-        // if (event.value.includes(MOTION_PDF_OPTIONS.ContinuousText)) {
-        //     this.tocButton.checked = false;
-        //     this.addBreaksButton.checked = false;
-        // }
     }
 
     /**
@@ -143,7 +139,7 @@ export class ExportDialogComponent<T extends BaseViewModel, ExportInfo extends {
             for (let choiceKey of setting.choices.keys()) {
                 const choice = setting.choices.get(choiceKey);
                 const value = control.value;
-                const disabled = choice.disabled;
+                const previouslyDisabled = choice.disabled;
                 choice.disabled =
                     choice.disableForFormat?.includes(this.format) ||
                     choice.disableWhen?.some(condition => {
@@ -153,15 +149,11 @@ export class ExportDialogComponent<T extends BaseViewModel, ExportInfo extends {
                                 : value === condition.otherValue) === condition.checked
                         );
                     });
-                if (
-                    choice.disabled &&
-                    !disabled &&
-                    (Array.isArray(value) ? value.includes(choiceKey) : value === choiceKey)
-                ) {
+                if (choice.disabled && !previouslyDisabled) {
                     control.setValue(
                         Array.isArray(value) ? value.filter(val => val !== choiceKey) : this.getOffState(setting.key)
                     );
-                } else if (choice.disabled !== disabled) {
+                } else if (choice.disabled !== previouslyDisabled) {
                     control.setValue(this.data.defaults[setting.key]);
                 }
             }

--- a/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.ts
+++ b/client/src/app/ui/modules/export-dialog/components/export-dialog/export-dialog.component.ts
@@ -1,0 +1,224 @@
+import { Component, Inject, OnInit, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { MatButtonToggle, MatButtonToggleChange, MatButtonToggleGroup } from '@angular/material/button-toggle';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { auditTime } from 'rxjs';
+import { Permission } from 'src/app/domain/definitions/permission';
+import { StorageService } from 'src/app/gateways/storage.service';
+import { BaseViewModel } from 'src/app/site/base/base-view-model';
+import { ExportFileFormat } from 'src/app/site/pages/meetings/pages/motions/services/export/definitions';
+import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
+
+import { ExportDialogSettings, ExportInfoChoiceType } from '../../services';
+
+interface Choice<ExportInfo> {
+    label?: string;
+    perms?: Permission;
+    mandatory?: boolean; // If true, this option will not be shown but still returned as part of the selection
+    disableWhen?: { otherValue: ExportInfo[keyof ExportInfo]; checked: boolean }[];
+    disableForFormat?: ExportFileFormat[];
+    disabled?: boolean;
+}
+
+type ChoiceMap<ExportInfo> = Map<ExportInfoChoiceType<ExportInfo[keyof ExportInfo]>, Choice<ExportInfo>>;
+
+interface ExportInfoTableData<ExportInfo> {
+    key: string;
+    label?: string;
+    weight: number;
+    multiple: boolean;
+    offState?: ExportInfoChoiceType<ExportInfo[keyof ExportInfo]>;
+    disableForFormat?: ExportFileFormat[];
+    choices: ChoiceMap<ExportInfo>;
+}
+
+@Component({
+    selector: `os-export-dialog`,
+    templateUrl: `./export-dialog.component.html`,
+    styleUrls: [`./export-dialog.component.scss`],
+    encapsulation: ViewEncapsulation.None
+})
+export class ExportDialogComponent<T extends BaseViewModel, ExportInfo extends { format: ExportFileFormat }>
+    extends BaseUiComponent
+    implements OnInit
+{
+    public readonly permission = Permission;
+
+    /**
+     * The form that contains the export information.
+     */
+    public exportForm!: UntypedFormGroup;
+
+    public settings: ExportInfoTableData<ExportInfo>[] = [];
+
+    /**
+     * To deactivate the export-as-diff button
+     */
+    @ViewChildren(MatButtonToggleGroup)
+    public toggleGroups!: QueryList<MatButtonToggleGroup>;
+
+    private format: ExportFileFormat;
+
+    /**
+     * Constructor
+     * Sets the default values for the lineNumberingMode and changeRecoMode and creates the form.
+     * This uses "instant" over observables to prevent on-fly-changes by auto update while
+     * the dialog is open.
+     */
+    public constructor(
+        @Inject(MAT_DIALOG_DATA)
+        public data: {
+            data: T[];
+            settings: ExportDialogSettings<ExportInfo>;
+            defaults: ExportInfo;
+            storageKey: string;
+        },
+        public formBuilder: UntypedFormBuilder,
+        public dialogRef: MatDialogRef<ExportDialogComponent<T, ExportInfo>>,
+        private store: StorageService
+    ) {
+        super();
+
+        this.settings = Object.keys(data.settings.settings)
+            .map(key => ({
+                ...data.settings.settings[key as keyof ExportInfo],
+                key
+            }))
+            .sort((a, b) => a.weight - b.weight);
+        this.createForm();
+    }
+
+    /**
+     * Init.
+     * Observes the form for changes to react dynamically
+     */
+    public ngOnInit(): void {
+        this.subscriptions.push(
+            this.exportForm.valueChanges.pipe(auditTime(500)).subscribe((value: ExportInfo) => {
+                this.store.set(`${this.data.storageKey}_export_selection`, value);
+            }),
+
+            this.exportForm
+                .get(`format`)!
+                .valueChanges.subscribe((value: ExportFileFormat) => this.onFormatChange(value))
+        );
+    }
+
+    public getSettingTitle(setting: ExportInfoTableData<ExportInfo>): string {
+        return setting.label ?? String(setting.key).charAt(0).toLocaleUpperCase() + String(setting.key).slice(1);
+    }
+
+    public getChoiceTitle(choice: Choice<ExportInfo>, key: ExportInfoChoiceType<ExportInfo[keyof ExportInfo]>): string {
+        return choice.label ?? String(key).charAt(0).toLocaleUpperCase() + String(key).slice(1);
+    }
+
+    /**
+     * React to changes on the file format
+     * @param format
+     */
+    private onFormatChange(format: ExportFileFormat): void {
+        this.format = format;
+        this.updateDisabled();
+    }
+
+    public onChange(event: MatButtonToggleChange, row: ExportInfoTableData<ExportInfo>): void {
+        this.updateDisabled(row);
+        // if (event.value.includes(MOTION_PDF_OPTIONS.ContinuousText)) {
+        //     this.tocButton.checked = false;
+        //     this.addBreaksButton.checked = false;
+        // }
+    }
+
+    private updateDisabled(row?: ExportInfoTableData<ExportInfo>) {
+        for (let setting of row ? [row] : this.settings) {
+            const control = this.exportForm.get(setting.key);
+            if (setting.disableForFormat?.includes(this.format)) {
+                control.disable();
+            } else {
+                control.enable();
+            }
+            for (let choiceKey of setting.choices.keys()) {
+                const choice = setting.choices.get(choiceKey);
+                const value = control.value;
+                choice.disabled =
+                    choice.disableForFormat?.includes(this.format) ||
+                    choice.disableWhen?.some(condition => {
+                        return (
+                            (Array.isArray(value)
+                                ? value.includes(condition.otherValue)
+                                : value === condition.otherValue) === condition.checked
+                        );
+                    });
+                if (choice.disabled && Array.isArray(value) ? value.includes(choiceKey) : value === choiceKey) {
+                    control.setValue(
+                        Array.isArray(value) ? value.filter(val => val !== choiceKey) : this.getOffState(setting.key)
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Function to change the state of the property `disabled` of a given button.
+     *
+     * Ensures, that the button exists.
+     *
+     * @param button The button whose state will change.
+     * @param nextState The next state the button will assume.
+     */
+    private changeStateOfButton(button: MatButtonToggle, nextState: boolean): void {
+        if (button) {
+            button.disabled = nextState;
+        }
+    }
+
+    /**
+     * Helper function to easier enable a control
+     * @param name
+     */
+    private enableControl(name: string): void {
+        this.exportForm.get(name)!.enable();
+    }
+
+    /**
+     * Helper function to easier disable a control
+     *
+     * @param name
+     */
+    private disableControl(name: string): void {
+        this.exportForm.get(name)!.disable();
+        this.exportForm.get(name)!.setValue(this.getOffState(name));
+    }
+
+    /**
+     * Determine what "off means in certain states"
+     *
+     * @param control
+     */
+    private getOffState(control: string): ExportInfoChoiceType<ExportInfo[keyof ExportInfo]> | null {
+        return this.settings.find(row => row.key === control)?.offState || null;
+    }
+
+    /**
+     * Creates the form with default values
+     */
+    public createForm(): void {
+        this.exportForm = this.formBuilder.group(this.settings.mapToObject(setting => ({ [setting.key]: [] })));
+
+        // restore selection or set default
+        this.store.get<ExportInfo>(`${this.data.storageKey}_export_selection`).then(restored => {
+            if (restored) {
+                this.exportForm.patchValue(restored);
+            } else {
+                this.exportForm.patchValue(this.data.defaults);
+            }
+        });
+    }
+
+    /**
+     * Just close the dialog
+     */
+    public onCloseClick(): void {
+        this.dialogRef.close();
+    }
+}

--- a/client/src/app/ui/modules/export-dialog/components/index.ts
+++ b/client/src/app/ui/modules/export-dialog/components/index.ts
@@ -1,0 +1,1 @@
+export * from './export-dialog/export-dialog.component';

--- a/client/src/app/ui/modules/export-dialog/export-dialog.module.ts
+++ b/client/src/app/ui/modules/export-dialog/export-dialog.module.ts
@@ -1,0 +1,28 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatDialogModule } from '@angular/material/dialog';
+import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
+
+import { DirectivesModule } from '../../directives';
+import { ExportDialogComponent } from './components/export-dialog/export-dialog.component';
+
+@NgModule({
+    declarations: [ExportDialogComponent],
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        MatButtonToggleModule,
+        MatButtonModule,
+        MatDialogModule,
+        DirectivesModule,
+        OpenSlidesTranslationModule.forChild()
+    ]
+})
+export class ExportDialogModule {
+    public static getComponent(): typeof ExportDialogComponent {
+        return ExportDialogComponent;
+    }
+}

--- a/client/src/app/ui/modules/export-dialog/index.ts
+++ b/client/src/app/ui/modules/export-dialog/index.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * from './export-dialog.module';
+export * from './services';

--- a/client/src/app/ui/modules/export-dialog/services/export-dialog.service.spec.ts
+++ b/client/src/app/ui/modules/export-dialog/services/export-dialog.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ExportDialogService } from './export-dialog.service';
+
+describe(`ExportDialogService`, () => {
+    let service: ExportDialogService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        service = TestBed.inject(ExportDialogService);
+    });
+
+    it(`should be created`, () => {
+        expect(service).toBeTruthy();
+    });
+});

--- a/client/src/app/ui/modules/export-dialog/services/export-dialog.service.ts
+++ b/client/src/app/ui/modules/export-dialog/services/export-dialog.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Permission } from 'src/app/domain/definitions/permission';
+import { largeDialogSettings } from 'src/app/infrastructure/utils/dialog-settings';
+import { BaseViewModel } from 'src/app/site/base/base-view-model';
+import { ExportFileFormat } from 'src/app/site/pages/meetings/pages/motions/services/export/definitions';
+import { BaseDialogService } from 'src/app/ui/base/base-dialog-service';
+
+import { ExportDialogComponent } from '../components';
+import { ExportDialogModule } from '../export-dialog.module';
+
+export type ExportInfoChoiceType<T> = T extends Array<any> ? T[number] : T;
+
+type ExportDialogSettingsKeys<ExportInfo extends { format: ExportFileFormat }> = keyof ExportInfo;
+
+export type ExportDialogSettings<ExportInfo extends { format: ExportFileFormat }> = {
+    title: string;
+    settings: {
+        [key in ExportDialogSettingsKeys<ExportInfo>]: {
+            label?: string;
+            weight: number;
+            multiple: ExportInfo[key] extends Array<any> ? true : false;
+            offState?: ExportInfoChoiceType<ExportInfo[key]>;
+            disableForFormat?: ExportFileFormat[];
+            choices: Map<
+                ExportInfoChoiceType<ExportInfo[key]>,
+                {
+                    label?: string;
+                    perms?: Permission;
+                    mandatory?: boolean; // If true, this option will not be shown but still returned as part of the selection
+                    disableWhen?: { otherValue: ExportInfo[key]; checked: boolean }[];
+                    disableForFormat?: ExportFileFormat[];
+                }
+            >;
+        };
+    };
+};
+
+@Injectable({
+    providedIn: ExportDialogModule
+})
+export class ExportDialogService<
+    T extends BaseViewModel,
+    ExportInfo extends { format: ExportFileFormat }
+> extends BaseDialogService<
+    ExportDialogComponent<T, ExportInfo>,
+    {
+        data: T[];
+        settings: ExportDialogSettings<ExportInfo>;
+        storageKey: string;
+        defaults: ExportInfo;
+    },
+    ExportInfo
+> {
+    public constructor(dialog: MatDialog) {
+        super(dialog);
+    }
+
+    public override async open(data: {
+        data: T[];
+        settings: ExportDialogSettings<ExportInfo>;
+        storageKey: string;
+        defaults: ExportInfo;
+    }): Promise<MatDialogRef<ExportDialogComponent<T, ExportInfo>, ExportInfo>> {
+        const module = await import(`../export-dialog.module`).then(m => m.ExportDialogModule);
+        return this.dialog.open(module.getComponent()<T, ExportInfo>, {
+            data,
+            ...largeDialogSettings
+        });
+    }
+}

--- a/client/src/app/ui/modules/export-dialog/services/index.ts
+++ b/client/src/app/ui/modules/export-dialog/services/index.ts
@@ -1,0 +1,1 @@
+export * from './export-dialog.service';


### PR DESCRIPTION
Closes #2032 

So far: Partially implemented a generic `ExportDialogService` (still has some bugs) and used it for Motions (didn't yet delete old `MotionExportDialogComponent` yet even though it should now be unused)

TODO:
- [ ] Rebase to post-rtf main
- [ ] Finish implementation of `ExportDialog`:
   - [ ] Not yet implemented in `ExportDialog`: If `changeStateForFormat` is set and the format is switched to one of the options, the state of the button should be set to the corresponding one
- [ ] Fix bugs in `ExportDialog`:
   - [ ] A bug I found in the `ExportDialog` (there may be others)
      - change to XLSX
      - close dialogue
      - reopen dialogue
      - Pdf options row will not be completely disabled
- [ ] Use `ExportDialogService` for agenda exports
- [ ] Implement the functionality of the settings
- [ ] The motion export dialog has since been extended with new fields, those should be added back in