### PR TITLE
Fix agenda show deleted items

### DIFF
--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail-main/topic-detail-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail-main/topic-detail-main.component.ts
@@ -5,7 +5,9 @@ import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-r
 import { SequentialNumberMappingService } from 'src/app/site/pages/meetings/services/sequential-number-mapping.service';
 
 import {
+    AGENDA_LIST_ITEM_SUBSCRIPTION,
     getAgendaListMinimalSubscriptionConfig,
+    getAgendaListSubscriptionConfig,
     getTopicDetailSubscriptionConfig
 } from '../../../../../../agenda.subscription';
 
@@ -44,7 +46,12 @@ export class TopicDetailMainComponent extends BaseModelRequestHandlerComponent {
         this.updateSubscribeTo(getTopicDetailSubscriptionConfig(this._currentTopicId), { hideWhenDestroyed: true });
     }
 
-    private loadTopicList(meetingId: number): void {
-        this.updateSubscribeTo(getAgendaListMinimalSubscriptionConfig(meetingId));
+    private async loadTopicList(meetingId: number): Promise<void> {
+        const hasMaxSubscription = await this.modelRequestService.subscriptionGotData(AGENDA_LIST_ITEM_SUBSCRIPTION);
+        this.updateSubscribeTo(
+            hasMaxSubscription
+                ? getAgendaListSubscriptionConfig(meetingId)
+                : getAgendaListMinimalSubscriptionConfig(meetingId)
+        );
     }
 }


### PR DESCRIPTION
Closes #2497 

The problem is the following: 
1. **Open agenda item list** => `agenda_list` subscription is open
2. **Delete one item** => The autoupdate sends a single-field update with the new value for the meetings `agenda_item_ids`, which will cause the client to consider these fields to be deleted, but NOT the autoupdate shared worker, which will continue to store them
3. **Go to the topic detail view** 
4. **Go back from the topic detail view** => In the short moment where the parameters change, the detailview doesn't have an id and therefore subscribes to the `agenda_list_minimal` (as it now believes itself to be the new topic form, which needs the agenda list information) The shared worker will send the already stored data (see point two: it includes the deleted models) as the initial data for the subscription which will then be used by the client completely unfiltered
5. **See that the deleted models seem to have returned**

Honestly we should do something about this quirk of our autoupdate handling system, but I didn't really have any idea what exactly can be done so I "fixed" it this way _for now_