### PR TITLE
Apply 7d490224b for conflict-free merging

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
@@ -261,9 +261,8 @@
             mat-stroked-button
             color="warn"
             (click)="addPointOfOrder()"
-            *ngIf="
-                showPointOfOrders && !isOpInWaitlist(true) && !(restrictPointOfOrderActions && listOfSpeakers.closed)
-            "
+            *ngIf="showPointOfOrders && !isOpInWaitlist(true)"
+            [disabled]="restrictPointOfOrderActions && closed"
         >
             <mat-icon>warning</mat-icon>
             &nbsp;
@@ -275,7 +274,7 @@
             mat-stroked-button
             color="warn"
             (click)="removePointOfOrder()"
-            *ngIf="showPointOfOrders && isOpInWaitlist(true) && !(restrictPointOfOrderActions && listOfSpeakers.closed)"
+            *ngIf="showPointOfOrders && isOpInWaitlist(true)"
         >
             <mat-icon>remove</mat-icon>
             <span translate>Withdraw point of order</span>

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.ts
@@ -260,7 +260,10 @@ export class ListOfSpeakersContentComponent extends BaseMeetingComponent impleme
     public async removePointOfOrder(): Promise<void> {
         const speakerToDelete = this.findOperatorSpeaker(true);
         if (speakerToDelete) {
-            await this.speakerRepo.delete(speakerToDelete.id);
+            const title = this.translate.instant(`Are you sure you want to irrevocably remove your point of order?`);
+            if (!(this.restrictPointOfOrderActions && this.closed) || (await this.promptService.open(title))) {
+                await this.speakerRepo.delete(speakerToDelete.id);
+            }
         }
     }
 


### PR DESCRIPTION
In https://github.com/OpenSlides/openslides-client/pull/2559 7d490224b was added and merged into `stable`. In order for the next `stable` merge to go without conflicts this change also needs to be in `main`.