### PR TITLE
Fix missing projection number

### DIFF
--- a/client/src/app/site/pages/meetings/pages/projectors/projectors.subscription.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/projectors.subscription.ts
@@ -7,7 +7,14 @@ import { DEFAULT_FIELDSET } from 'src/app/site/services/model-request-builder';
 
 import { ViewProjector } from './view-models';
 
-export const projectionContentObjectFieldset = [`name`, `title`, `meeting_id`, `sequential_number`, `owner_id`];
+export const projectionContentObjectFieldset = [
+    `number`,
+    `name`,
+    `title`,
+    `meeting_id`,
+    `sequential_number`,
+    `owner_id`
+];
 
 export const PROJECTOR_LIST_SUBSCRIPTION = `projector_list`;
 


### PR DESCRIPTION
resolves #2443 

This only fixes the not displayed motion numbers. As one does not project agenda items directly but instead topics or elections we cannot display the agenda item numbers currently. 