### PR TITLE
Write tests for action class  and MeetingMediaAdapterService

### DIFF
--- a/client/src/app/gateways/actions/action.service.ts
+++ b/client/src/app/gateways/actions/action.service.ts
@@ -74,39 +74,4 @@ export class ActionService {
         }
         return functions.every(fn => !fn());
     }
-
-    /////////////////////////////////////////////////////////////////////////////////////
-    /////////////////////// The following methods will be removed ///////////////////////
-    /////////////////////////////////////////////////////////////////////////////////////
-
-    /**
-     * @deprecated This will be removed pretty soon, use `create` instead!
-     * @param action
-     * @param data
-     * @returns
-     */
-    public async sendRequest<T>(action: string, data: any): Promise<T | void> {
-        const results = await this.sendRequests<T>([{ action, data: [data] }]);
-        if (!results) {
-            return;
-        }
-        if (results.length !== 1) {
-            throw new Error(`The action service did not respond with exactly one response for one request.`);
-        }
-        return results[0];
-    }
-
-    /**
-     * @deprecated This will be removed pretty soon, use `createFromArray` instead!
-     * @param action
-     * @param data
-     * @returns
-     */
-    public async sendBulkRequest<T>(action: string, data: any[]): Promise<T[] | null> {
-        const results = await this.sendRequests<T>([{ action, data }]);
-        if (results && results.length !== data.length) {
-            throw new Error(`Inner resultlength is not ${data.length} from the action service`);
-        }
-        return results;
-    }
 }

--- a/client/src/app/gateways/actions/action.ts
+++ b/client/src/app/gateways/actions/action.ts
@@ -14,16 +14,17 @@ export class Action<T = void> {
         if (actions.length === 0) {
             return this;
         }
-        const concatedActions = actions
-            .filter(action => action !== null)
-            .flatMap(action => {
-                if (action instanceof Action) {
-                    return action._actions;
-                } else {
-                    return [action];
-                }
-            })
-            .concat(this._actions);
+        const concatedActions = this._actions.concat(
+            actions
+                .filter(action => action !== null)
+                .flatMap(action => {
+                    if (action instanceof Action) {
+                        return action._actions;
+                    } else {
+                        return [action];
+                    }
+                })
+        );
         return new Action(
             (actions.find(action => action instanceof Action) as Action<T>)?._sendActionFn ?? this._sendActionFn,
             concatedActions

--- a/client/src/app/gateways/meeting-media-adapter.service.spec.ts
+++ b/client/src/app/gateways/meeting-media-adapter.service.spec.ts
@@ -1,16 +1,84 @@
 import { TestBed } from '@angular/core/testing';
 
+import { FONT_PLACES, LOGO_PLACES } from '../domain/models/mediafiles/mediafile.constants';
+import { ViewMediafile } from '../site/pages/meetings/pages/mediafiles';
+import { ActionService } from './actions/action.service';
+import { ActionRequest } from './actions/action-utils';
 import { MeetingMediaAdapterService } from './meeting-media-adapter.service';
+import { MeetingAction } from './repositories/meetings';
 
-xdescribe(`MeetingMediaAdapterService`, () => {
+class MockAction<T> {
+    public constructor(public requests: ActionRequest[], public handle_separately: boolean) {}
+
+    public async resolve(): Promise<T[] | void> {
+        return;
+    }
+}
+
+class MockActionService {
+    public lastActions: MockAction<unknown>[] = [];
+    public constructor() {}
+
+    public createFromArray<T>(requests: ActionRequest[], handle_separately = false): MockAction<T> {
+        const action = new MockAction<T>(requests, handle_separately);
+        this.lastActions.push(action);
+        return action;
+    }
+}
+
+describe(`MeetingMediaAdapterService`, () => {
     let service: MeetingMediaAdapterService;
+    let actionService: MockActionService;
+
+    const mediafile = { meeting_id: 2, id: 42 } as ViewMediafile;
+
+    const testCases = [
+        {
+            functionName: `setLogo`,
+            place: LOGO_PLACES[0],
+            restPayload: mediafile,
+            expectedAction: MeetingAction.SET_LOGO,
+            expectedData: { id: 2, mediafile_id: 42 }
+        },
+        {
+            functionName: `unsetLogo`,
+            place: LOGO_PLACES[1 % LOGO_PLACES.length],
+            restPayload: 1,
+            expectedAction: MeetingAction.UNSET_LOGO,
+            expectedData: { id: 1 }
+        },
+        {
+            functionName: `setFont`,
+            place: FONT_PLACES[2 % FONT_PLACES.length],
+            restPayload: mediafile,
+            expectedAction: MeetingAction.SET_FONT,
+            expectedData: { id: 2, mediafile_id: 42 }
+        },
+        {
+            functionName: `unsetFont`,
+            place: FONT_PLACES[3 % FONT_PLACES.length],
+            restPayload: 123,
+            expectedAction: MeetingAction.UNSET_FONT,
+            expectedData: { id: 123 }
+        }
+    ];
 
     beforeEach(() => {
-        TestBed.configureTestingModule({});
+        TestBed.configureTestingModule({
+            providers: [MeetingMediaAdapterService, { provide: ActionService, useClass: MockActionService }]
+        });
+
         service = TestBed.inject(MeetingMediaAdapterService);
+        actionService = TestBed.inject(ActionService) as unknown as MockActionService;
     });
 
-    it(`should be created`, () => {
-        expect(service).toBeTruthy();
-    });
+    for (const test of testCases) {
+        it(`test ${test.functionName} function`, async () => {
+            await expectAsync(service[test.functionName](test.place, test.restPayload)).toBeResolved();
+            expect(actionService.lastActions.length).toBe(1);
+            expect(actionService.lastActions[0].requests).toEqual([
+                { action: test.expectedAction, data: [{ ...test.expectedData, place: test.place }] }
+            ]);
+        });
+    }
 });

--- a/client/src/app/gateways/meeting-media-adapter.service.ts
+++ b/client/src/app/gateways/meeting-media-adapter.service.ts
@@ -3,7 +3,11 @@ import { Injectable } from '@angular/core';
 import { Id } from '../domain/definitions/key-types';
 import { ViewMediafile } from '../site/pages/meetings/pages/mediafiles';
 import { ActionService } from './actions';
-import { MeetingAction } from './repositories/meetings';
+
+type MediaAdapterActionParameters = (
+    | { action: `set`; mediafile: ViewMediafile }
+    | { action: `unset`; meetingId: Id }
+) & { type: `logo` | `font`; place: string };
 
 @Injectable({
     providedIn: `root`
@@ -11,37 +15,32 @@ import { MeetingAction } from './repositories/meetings';
 export class MeetingMediaAdapterService {
     public constructor(private actionService: ActionService) {}
 
-    public async setLogo(place: string, mediafile: ViewMediafile): Promise<void> {
-        const payload: any = {
-            id: mediafile.meeting_id,
-            mediafile_id: mediafile.id,
-            place
-        };
-        return this.actionService.sendRequest(MeetingAction.SET_LOGO, payload);
+    public setLogo(place: string, mediafile: ViewMediafile): Promise<void> {
+        return this.performAction({ action: `set`, type: `logo`, place, mediafile });
     }
 
-    public async unsetLogo(place: string, meetingId: Id): Promise<void> {
-        const payload: any = {
-            id: meetingId,
-            place
-        };
-        return this.actionService.sendRequest(MeetingAction.UNSET_LOGO, payload);
+    public unsetLogo(place: string, meetingId: Id): Promise<void> {
+        return this.performAction({ action: `unset`, type: `logo`, place, meetingId });
     }
 
-    public async setFont(place: string, mediafile: ViewMediafile): Promise<void> {
-        const payload: any = {
-            id: mediafile.meeting_id,
-            mediafile_id: mediafile.id,
-            place
-        };
-        return this.actionService.sendRequest(MeetingAction.SET_FONT, payload);
+    public setFont(place: string, mediafile: ViewMediafile): Promise<void> {
+        return this.performAction({ action: `set`, type: `font`, place, mediafile });
     }
 
-    public async unsetFont(place: string, meetingId: Id): Promise<void> {
-        const payload: any = {
-            id: meetingId,
-            place
+    public unsetFont(place: string, meetingId: Id): Promise<void> {
+        return this.performAction({ action: `unset`, type: `font`, place, meetingId });
+    }
+
+    private async performAction(param: MediaAdapterActionParameters): Promise<void> {
+        const data: any = {
+            ...(param.action === `set`
+                ? {
+                      id: param.mediafile.meeting_id,
+                      mediafile_id: param.mediafile.id
+                  }
+                : { id: param.meetingId }),
+            place: param.place
         };
-        return this.actionService.sendRequest(MeetingAction.UNSET_FONT, payload);
+        await this.actionService.createFromArray([{ action: `meeting.${param.action}_${param.type}`, data }]).resolve();
     }
 }

--- a/client/src/app/gateways/meeting-media-adapter.service.ts
+++ b/client/src/app/gateways/meeting-media-adapter.service.ts
@@ -32,15 +32,17 @@ export class MeetingMediaAdapterService {
     }
 
     private async performAction(param: MediaAdapterActionParameters): Promise<void> {
-        const data: any = {
-            ...(param.action === `set`
-                ? {
-                      id: param.mediafile.meeting_id,
-                      mediafile_id: param.mediafile.id
-                  }
-                : { id: param.meetingId }),
-            place: param.place
-        };
+        const data: any[] = [
+            {
+                ...(param.action === `set`
+                    ? {
+                          id: param.mediafile.meeting_id,
+                          mediafile_id: param.mediafile.id
+                      }
+                    : { id: param.meetingId }),
+                place: param.place
+            }
+        ];
         await this.actionService.createFromArray([{ action: `meeting.${param.action}_${param.type}`, data }]).resolve();
     }
 }

--- a/client/src/app/gateways/repositories/agenda/agenda-item-repository.service.ts
+++ b/client/src/app/gateways/repositories/agenda/agenda-item-repository.service.ts
@@ -51,7 +51,7 @@ export class AgendaItemRepositoryService extends BaseMeetingRelatedRepository<Vi
      */
     public async autoNumbering(): Promise<void> {
         const payload = { meeting_id: this.activeMeetingId };
-        await this.actions.sendRequest(AgendaItemAction.NUMBERING, payload);
+        await this.createAction(AgendaItemAction.NUMBERING, payload).resolve();
     }
 
     /**
@@ -66,7 +66,7 @@ export class AgendaItemRepositoryService extends BaseMeetingRelatedRepository<Vi
             id: viewModel.id,
             ...this.getOptionalPayload(update)
         };
-        await this.actions.sendRequest(AgendaItemAction.UPDATE, payload);
+        await this.createAction(AgendaItemAction.UPDATE, payload).resolve();
     }
 
     public assignToParents(content: any, meetingId: Id = this.activeMeetingId!): Action<void> {
@@ -93,7 +93,7 @@ export class AgendaItemRepositoryService extends BaseMeetingRelatedRepository<Vi
         } else {
             payload = items.map(item => ({ id: (item as Identifiable).id }));
         }
-        await this.actions.sendBulkRequest(AgendaItemAction.DELETE, payload);
+        await this.actions.createFromArray([{ action: AgendaItemAction.DELETE, data: payload }]).resolve();
     }
 
     /**
@@ -103,7 +103,7 @@ export class AgendaItemRepositoryService extends BaseMeetingRelatedRepository<Vi
      */
     public async sortItems(data: TreeIdNode[]): Promise<void> {
         const payload = { meeting_id: this.activeMeetingId, tree: data };
-        await this.actions.sendRequest(AgendaItemAction.SORT, payload);
+        await this.createAction(AgendaItemAction.SORT, payload).resolve();
     }
 
     public bulkOpenItems(items: ViewAgendaItem[]): Promise<void> {

--- a/client/src/app/gateways/repositories/base-repository.ts
+++ b/client/src/app/gateways/repositories/base-repository.ts
@@ -434,7 +434,13 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
      */
     protected async sendActionToBackend<T>(action: string, payload: T): Promise<any> {
         try {
-            return await this.actions.sendRequest(action, payload);
+            const results = await this.actions.createFromArray([{ action, data: [payload] }]).resolve();
+            if (results) {
+                if (results.length !== 1) {
+                    throw new Error(`The action service did not respond with exactly one response for the request.`);
+                }
+                return results[0];
+            }
         } catch (e) {
             throw e;
         }
@@ -448,7 +454,7 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
      */
     protected async sendBulkActionToBackend<T>(action: string, payload: T[]): Promise<any> {
         try {
-            return await this.actions.sendBulkRequest(action, payload);
+            return await this.actions.createFromArray<any>([{ action, data: payload }]).resolve();
         } catch (e) {
             throw e;
         }

--- a/client/src/app/gateways/repositories/motions/motion-category-repository.service/motion-category-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-category-repository.service/motion-category-repository.service.ts
@@ -65,7 +65,7 @@ export class MotionCategoryRepositoryService extends BaseMeetingRelatedRepositor
      * @param viewMotionCategory the category it should be updated in
      */
     public async numberMotionsInCategory(viewMotionCategory: Identifiable): Promise<void> {
-        return this.actions.sendRequest(MotionCategoryAction.NUMBER_MOTIONS, { id: viewMotionCategory.id });
+        await this.createAction(MotionCategoryAction.NUMBER_MOTIONS, { id: viewMotionCategory.id }).resolve();
     }
 
     /**
@@ -79,7 +79,7 @@ export class MotionCategoryRepositoryService extends BaseMeetingRelatedRepositor
             id: category.id,
             motion_ids: motionIds
         };
-        return this.actions.sendRequest(MotionCategoryAction.SORT_MOTIONS_IN_CATEGORY, payload);
+        await this.createAction(MotionCategoryAction.SORT_MOTIONS_IN_CATEGORY, payload).resolve();
     }
 
     /**
@@ -92,7 +92,7 @@ export class MotionCategoryRepositoryService extends BaseMeetingRelatedRepositor
             meeting_id: this.activeMeetingId,
             tree: data
         };
-        return this.actions.sendRequest(MotionCategoryAction.SORT, payload);
+        await this.createAction(MotionCategoryAction.SORT, payload).resolve();
     }
 
     private getCreatePayload(partialCategory: Partial<MotionCategory>): any {

--- a/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-section-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-section-repository.service.ts
@@ -64,6 +64,6 @@ export class MotionCommentSectionRepositoryService extends BaseMeetingRelatedRep
             meeting_id: this.activeMeetingId,
             motion_comment_section_ids: sections.map(section => section.id)
         };
-        return this.actions.sendRequest(MotionCommentSectionAction.SORT, payload);
+        await this.createAction(MotionCommentSectionAction.SORT, payload).resolve();
     }
 }

--- a/client/src/app/gateways/repositories/motions/motion-state-repository.service/motion-state-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-state-repository.service/motion-state-repository.service.ts
@@ -36,11 +36,11 @@ export class MotionStateRepositoryService extends BaseMeetingRelatedRepository<V
             previous_state_ids: update.previous_state_ids,
             ...update
         };
-        return this.actions.sendRequest(MotionStateAction.UPDATE, payload);
+        await this.createAction(MotionStateAction.UPDATE, payload).resolve();
     }
 
     public async delete(viewModel: Identifiable): Promise<void> {
-        return this.actions.sendRequest(MotionStateAction.DELETE, { id: viewModel.id });
+        await this.createAction(MotionStateAction.DELETE, { id: viewModel.id }).resolve();
     }
 
     public sort(workflowId: number, viewModels: Identifiable[]): Action<void> {


### PR DESCRIPTION
Found that the Action concat method put the original object at the end of the action result array, and not the front as I'd expected, so I changed that.
Also removed the deprecated `ActionService` methods.
I tested these changes somewhat, but it would probably be better if someone tested this more thoroughly, taking care to try all kinds of different actions in all kinds of different places