### PR TITLE
Exit view list filter/search/sort observables on destroy

### DIFF
--- a/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
+++ b/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
@@ -161,14 +161,18 @@ export abstract class BaseFilterListService<V extends BaseViewModel> implements 
             this.storeActiveFilters();
         }
 
-        if (this.inputDataSubscription) {
-            this.inputDataSubscription.unsubscribe();
-            this.inputDataSubscription = null;
-        }
+        this.exitFilterService();
         this.inputDataSubscription = inputData.subscribe(data => {
             this._source.next(this.preFilter(data));
             this.updateFilteredData();
         });
+    }
+
+    public exitFilterService(): void {
+        if (this.inputDataSubscription) {
+            this.inputDataSubscription.unsubscribe();
+            this.inputDataSubscription = null;
+        }
     }
 
     public getViewModelListObservable(): Observable<V[]> {

--- a/client/src/app/site/base/base-sort.service/base-sort-list.service.ts
+++ b/client/src/app/site/base/base-sort.service/base-sort-list.service.ts
@@ -148,10 +148,7 @@ export abstract class BaseSortListService<V extends BaseViewModel>
      * @param definitions The definitions of the possible options
      */
     public async initSorting(inputObservable: Observable<V[]>): Promise<void> {
-        if (this.inputDataSubscription) {
-            this.inputDataSubscription.unsubscribe();
-            this.inputDataSubscription = null;
-        }
+        this.exitSortService();
 
         if (!this.sortDefinition) {
             const storedDefinition = await this.store.get<OsSortingDefinition<V>>(`sorting_` + this.storageKey);
@@ -172,6 +169,13 @@ export abstract class BaseSortListService<V extends BaseViewModel>
             this.inputData = data;
             this.updateSortedData();
         });
+    }
+
+    public exitSortService(): void {
+        if (this.inputDataSubscription) {
+            this.inputDataSubscription.unsubscribe();
+            this.inputDataSubscription = null;
+        }
     }
 
     /**

--- a/client/src/app/ui/modules/list/components/view-list/view-list.component.ts
+++ b/client/src/app/ui/modules/list/components/view-list/view-list.component.ts
@@ -4,6 +4,7 @@ import {
     Component,
     EventEmitter,
     Input,
+    OnDestroy,
     OnInit,
     Output,
     ViewChild,
@@ -23,7 +24,7 @@ import { FilterListService, SearchService, SortListService } from '../../definit
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class ViewListComponent<V extends Identifiable> implements OnInit {
+export class ViewListComponent<V extends Identifiable> implements OnInit, OnDestroy {
     @ViewChild(ScrollingTableComponent, { static: true })
     private readonly _scrollingTableComponent: ScrollingTableComponent<V> | undefined;
 
@@ -152,6 +153,20 @@ export class ViewListComponent<V extends Identifiable> implements OnInit {
 
     public ngOnInit(): void {
         this.initDataListObservable();
+    }
+
+    public ngOnDestroy(): void {
+        if (this.filterService) {
+            this.filterService.exitFilterService();
+        }
+
+        if (this.sortService) {
+            this.sortService.exitSortService();
+        }
+
+        if (this.searchService) {
+            this.searchService.exitSearchService();
+        }
     }
 
     /**

--- a/client/src/app/ui/modules/list/definitions/filter-service.ts
+++ b/client/src/app/ui/modules/list/definitions/filter-service.ts
@@ -13,6 +13,7 @@ export interface FilterListService<V extends Identifiable> extends ViewModelList
     toggleFilterOption(property: keyof V, option: OsFilterOption): void;
     clearAllFilters(): void;
     initFilters(inputObservable: Observable<V[]>): void;
+    exitFilterService(): void;
 }
 
 /**

--- a/client/src/app/ui/modules/list/definitions/search-service.ts
+++ b/client/src/app/ui/modules/list/definitions/search-service.ts
@@ -2,5 +2,6 @@ import { Observable } from 'rxjs';
 export interface SearchService<V> {
     readonly outputObservable: Observable<V[]>;
     initSearchService(source: Observable<V[]>): void;
+    exitSearchService(): void;
     search(input: string): void;
 }

--- a/client/src/app/ui/modules/list/definitions/sort-service.ts
+++ b/client/src/app/ui/modules/list/definitions/sort-service.ts
@@ -32,4 +32,5 @@ export interface SortListService<V> extends SortService<V> {
     getSortIcon(option: OsSortOption<V>): string | null;
     getSortLabel(option: OsSortOption<V>): string;
     initSorting(inputObservable: Observable<V[]>): void;
+    exitSortService(): void;
 }

--- a/client/src/app/ui/modules/list/services/list-search.service.ts
+++ b/client/src/app/ui/modules/list/services/list-search.service.ts
@@ -25,6 +25,13 @@ export class ListSearchService<V extends Identifiable> implements SearchService<
         this.refreshSubscription();
     }
 
+    public exitSearchService(): void {
+        if (this._sourceSubscription) {
+            this._sourceSubscription.unsubscribe();
+            this._sourceSubscription = null;
+        }
+    }
+
     public search(input: string): void {
         this._currentSearchFilter = input?.toLowerCase();
         this.filter();
@@ -35,10 +42,7 @@ export class ListSearchService<V extends Identifiable> implements SearchService<
     }
 
     private refreshSubscription(): void {
-        if (this._sourceSubscription) {
-            this._sourceSubscription.unsubscribe();
-            this._sourceSubscription = null;
-        }
+        this.exitSearchService();
         if (this._sourceObservable) {
             this._sourceSubscription = this._sourceObservable.subscribe(items => {
                 this._source = items;


### PR DESCRIPTION
Fixes an issue where an observable is not unsubscribed on the list view resulting in resorting lists when autoupdates occur. 