### PR TITLE
Cleanup worker cache on delete

### DIFF
--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -236,7 +236,9 @@ export class AutoupdateService {
                 changedFullListModels: fullListUpdateCollections,
                 deletedModels: {}
             })
-            .then(() => {
+            .then(deletedModels => {
+                this.communication.cleanupCollections(requestId, deletedModels);
+
                 if (this._resolveDataReceived[requestId]) {
                     this._resolveDataReceived[requestId](modelData);
                     delete this._resolveDataReceived[requestId];

--- a/client/src/app/site/services/view-model-store-update.service.ts
+++ b/client/src/app/site/services/view-model-store-update.service.ts
@@ -56,7 +56,7 @@ export class ViewModelStoreUpdateService {
         changedFullListModels,
         deletedModels,
         patch
-    }: UpdatePatch): Promise<void> {
+    }: UpdatePatch): Promise<DeletedModels> {
         const _deletedModels: DeletedModels = {};
         const _changedModels: ChangedModels = {};
 
@@ -86,6 +86,7 @@ export class ViewModelStoreUpdateService {
         }
 
         await this.doCollectionUpdates(_changedModels, _deletedModels);
+        return _deletedModels;
     }
 
     private createCollectionUpdate(

--- a/client/src/app/worker/autoupdate-stream.ts
+++ b/client/src/app/worker/autoupdate-stream.ts
@@ -167,6 +167,30 @@ export class AutoupdateStream {
         this.clearSubscriptions();
     }
 
+    /**
+     * Removes fqids from the cache.
+     *
+     * @param fqids list of fqids to delete
+     */
+    public removeFqids(fqids: string[]): void {
+        let lastHit: string | null = null;
+        for (const key of Object.keys(this._currentData)) {
+            if (lastHit === null || !key.startsWith(fqids[lastHit] + `/`)) {
+                lastHit = null;
+                for (let i = 0; i < fqids.length; i++) {
+                    if (key.startsWith(fqids[i] + `/`)) {
+                        lastHit = key;
+                        break;
+                    }
+                }
+            }
+
+            if (lastHit !== null) {
+                delete this._currentData[key];
+            }
+        }
+    }
+
     public clearSubscriptions(): void {
         this._currentData = null;
     }

--- a/client/src/app/worker/interfaces-autoupdate.ts
+++ b/client/src/app/worker/interfaces-autoupdate.ts
@@ -34,6 +34,16 @@ export interface AutoupdateCloseStream extends WorkerMessageContent {
     params: AutoupdateCloseStreamParams;
 }
 
+export interface AutoupdateCleanupCacheParams {
+    streamId: number;
+    deletedFqids: string[];
+}
+
+export interface AutoupdateCleanupCache extends WorkerMessageContent {
+    action: 'cleanup-cache';
+    params: AutoupdateCleanupCacheParams;
+}
+
 export interface AutoupdateSetConnectionStatusParams {
     status: 'online' | 'offline';
 }

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -3,6 +3,7 @@ import { environment } from 'src/environments/environment';
 import { AutoupdateStreamPool } from './autoupdate-stream-pool';
 import { AutoupdateSubscription } from './autoupdate-subscription';
 import {
+    AutoupdateCleanupCacheParams,
     AutoupdateCloseStreamParams,
     AutoupdateOpenStreamParams,
     AutoupdateSetEndpointParams
@@ -134,6 +135,15 @@ function closeConnection(ctx: MessagePort, params: AutoupdateCloseStreamParams):
     subscription.closePort(ctx);
 }
 
+function cleanupStream(params: AutoupdateCleanupCacheParams): void {
+    const subscription = autoupdatePool.getSubscriptionById(params.streamId);
+    if (!subscription) {
+        return;
+    }
+
+    subscription.stream.removeFqids(params.deletedFqids);
+}
+
 let currentlyOnline = navigator.onLine;
 function updateOnlineStatus(): void {
     if (currentlyOnline === navigator.onLine) {
@@ -179,6 +189,9 @@ export function addAutoupdateListener(context: any): void {
                 break;
             case `reconnect-force`:
                 autoupdatePool.reconnectAll(false);
+                break;
+            case `cleanup-cache`:
+                cleanupStream(params);
                 break;
             case `enable-debug`:
                 registerDebugCommands();


### PR DESCRIPTION
resolves #2497 

The worker will now be notified if the client deletes models from the modelstore and will delete them within its internal state too. 
Note that in order to test properly this the shared worker needs to be enabled. 

This PR could have some side effects especially if there are misconfigured entries in `relations.ts` or other bugs that result in models being accidentally deleted. 