### PR TITLE
Fix linter warnings

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -53,9 +53,14 @@ module.exports = {
                     }
                 ],
                 '@typescript-eslint/quotes': ['error', 'backtick', { 'avoidEscape': false }],
+                '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
                 'simple-import-sort/imports': 'error',
                 'simple-import-sort/exports': 'error',
                 'unused-imports/no-unused-imports': 'error',
+                'no-restricted-properties': ['error', {
+                    'property': 'asObservable',
+                    'message': 'Please use a typecast or explicitly instantiate a new Observable.'
+                }],
 
                 'jsdoc/require-example': ['off'],
                 'jsdoc/newline-after-description': ['off'],
@@ -68,16 +73,11 @@ module.exports = {
                 '@typescript-eslint/no-unnecessary-type-constraint': ['warn'],
                 '@typescript-eslint/no-this-alias': ['warn'],
                 '@typescript-eslint/ban-types': ['warn'],
-                '@typescript-eslint/no-unused-vars': 'warn',
                 '@typescript-eslint/adjacent-overload-signatures': ['warn'],
                 '@typescript-eslint/ban-ts-comment': ['warn'],
                 '@typescript-eslint/no-explicit-any': ['off'],
                 '@typescript-eslint/no-non-null-assertion': ['off'],
-                'no-console': ['off', { allow: ['warn', 'error', 'info', 'debug'] }],
-                'no-restricted-properties': ['error', {
-                    'property': 'asObservable',
-                    'message': 'Please use a typecast or explicitly instantiate a new Observable.'
-                }]
+                'no-console': ['off', { allow: ['warn', 'error', 'info', 'debug'] }]
             }
         },
         {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,6 +26,7 @@
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
         "@tinymce/tinymce-angular": "^7.0.0",
+        "@types/pdfmake": "^0.2.2",
         "@videojs/http-streaming": "^2.15.0",
         "acorn": "^8.8.0",
         "ascii-art-api": "^1.0.0",
@@ -3938,14 +3939,30 @@
     "node_modules/@types/node": {
       "version": "16.18.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
-      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
-      "dev": true
+      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.12.10.tgz",
+      "integrity": "sha512-DPqNCuLXj50NehiFehndH+fzQLzb2fwHOLOvG+Zsm7rJBHgpMLeJrB4eC3RQf7Zl1uiWVYyBuFqVbZnveUb4mA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pdfmake": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.2.2.tgz",
+      "integrity": "sha512-CBtkugrgklpXsZ9Wj/+cw+zYoeDnJxVev62ahwpdPCz/O405Wxr+iq76JgUiZc/QAo3P2lWbI2nYA5GrrSL8VQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pdfkit": "*"
+      }
     },
     "node_modules/@types/qrcode": {
       "version": "1.5.0",
@@ -20972,14 +20989,30 @@
     "@types/node": {
       "version": "16.18.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
-      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
-      "dev": true
+      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/pdfkit": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.12.10.tgz",
+      "integrity": "sha512-DPqNCuLXj50NehiFehndH+fzQLzb2fwHOLOvG+Zsm7rJBHgpMLeJrB4eC3RQf7Zl1uiWVYyBuFqVbZnveUb4mA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/pdfmake": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.2.2.tgz",
+      "integrity": "sha512-CBtkugrgklpXsZ9Wj/+cw+zYoeDnJxVev62ahwpdPCz/O405Wxr+iq76JgUiZc/QAo3P2lWbI2nYA5GrrSL8VQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/pdfkit": "*"
+      }
     },
     "@types/qrcode": {
       "version": "1.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -54,6 +54,7 @@
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
     "@tinymce/tinymce-angular": "^7.0.0",
+    "@types/pdfmake": "^0.2.2",
     "@videojs/http-streaming": "^2.15.0",
     "acorn": "^8.8.0",
     "ascii-art-api": "^1.0.0",

--- a/client/src/app/gateways/base-icc-gateway.service.ts
+++ b/client/src/app/gateways/base-icc-gateway.service.ts
@@ -96,14 +96,14 @@ export abstract class BaseICCGatewayService<ICCResponseType> {
 
     /**
      * Define what happens when a message is received from the ICC service.
-     * @param response The message that was received.
+     * @param message The message that was received.
      */
     protected abstract onMessage(message: ICCResponseType): void;
 
     /**
      * General send function for messages. Subclasses should call this to build their own more specific send functions.
      */
-    protected async send<T>(data?: any): Promise<void> {
+    protected async send(data?: any): Promise<void> {
         if (!this.sendPath) {
             throw new Error(`Cannot send to ICC, no path was provided`);
         }

--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.spec.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { Content } from 'pdfmake/interfaces';
 import { E2EImportsModule } from 'src/e2e-imports.module';
 
 import { ExportServiceModule } from '../export-service.module';
@@ -20,7 +21,7 @@ describe(`HtmlToPdfService`, () => {
     describe(`addPlainText`, () => {
         it(`create a simple text node`, () => {
             const result = service.addPlainText(`foo`);
-            expect(result).toEqual({
+            const col: Content = {
                 columns: [
                     {
                         stack: [
@@ -30,26 +31,27 @@ describe(`HtmlToPdfService`, () => {
                         ]
                     }
                 ]
-            });
+            };
+            expect(result).toEqual(col);
         });
     });
 
     describe(`convertHtml`, () => {
         it(`should handle empty input`, () => {
             const result = service.convertHtml({ htmlText: `` });
-            expect(result).toEqual([]);
+            expect(result).toEqual(<Content[]>[]);
         });
 
         it(`should handle single main nodes`, () => {
             const result = service.convertHtml({ htmlText: `<p>Row 1</p>` });
-            expect(result).toEqual([
+            expect(result).toEqual(<Content[]>[
                 { text: [{ text: `Row 1` }], lineHeight: LINE_HEIGHT, margin: [0, 0, 0, P_MARGIN_BOTTOM] }
             ]);
         });
 
         it(`should handle multiple main nodes`, () => {
             const result = service.convertHtml({ htmlText: `<p>Row 1</p><p>Row 2</p>` });
-            expect(result).toEqual([
+            expect(result).toEqual(<Content[]>[
                 { text: [{ text: `Row 1` }], lineHeight: LINE_HEIGHT, margin: [0, 0, 0, P_MARGIN_BOTTOM] },
                 { text: [{ text: `Row 2` }], lineHeight: LINE_HEIGHT, margin: [0, 0, 0, P_MARGIN_BOTTOM] }
             ]);
@@ -59,7 +61,7 @@ describe(`HtmlToPdfService`, () => {
     describe(`convert lists`, () => {
         it(`should handle single main nodes`, () => {
             const result = service.convertHtml({ htmlText: `<ul><li>Line 1</li><li>Line 2</li></ul>` });
-            expect(result).toEqual([
+            expect(result).toEqual(<Content[]>[
                 {
                     ul: [
                         { text: [{ text: `Line 1` }], lineHeight: LINE_HEIGHT, margin: [0, 0, 0, P_MARGIN_BOTTOM] },
@@ -75,8 +77,8 @@ describe(`HtmlToPdfService`, () => {
             const result = service.convertHtml({
                 htmlText: `<span style="text-decoration: underline">Underlined</span>`
             });
-            expect(result).toEqual([
-                { text: [{ text: `Underlined`, decoration: [`underline`] }], decoration: [`underline`] }
+            expect(result).toEqual(<Content[]>[
+                { text: [{ text: `Underlined`, decoration: `underline` }], decoration: `underline` }
             ]);
         });
     });
@@ -84,8 +86,8 @@ describe(`HtmlToPdfService`, () => {
     describe(`convert format tags`, () => {
         it(`url`, () => {
             const result = service.convertHtml({ htmlText: `<a href="http://example.test">Link</a>` });
-            expect(result).toEqual([
-                { text: [{ text: `Link`, decoration: [`underline`], color: `blue`, link: `http://example.test/` }] }
+            expect(result).toEqual(<Content[]>[
+                { text: [{ text: `Link`, decoration: `underline`, color: `blue`, link: `http://example.test/` }] }
             ]);
         });
     });

--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.spec.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.spec.ts
@@ -9,7 +9,6 @@ describe(`HtmlToPdfService`, () => {
 
     const LINE_HEIGHT = 1.25;
     const P_MARGIN_BOTTOM = 4.0;
-    const H_MARGIN_TOP = 10.0;
 
     beforeEach(() => {
         TestBed.configureTestingModule({

--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
@@ -480,20 +480,10 @@ export class HtmlToPdfService {
                             break;
                         }
                         case `text-decoration`: {
-                            if (!styleObject.decoration) {
-                                styleObject.decoration = [];
-                            }
                             switch (value) {
+                                case `line-through`:
                                 case `underline`: {
-                                    if (!styleObject.decoration.includes(`underline`)) {
-                                        styleObject.decoration.push(`underline`);
-                                    }
-                                    break;
-                                }
-                                case `line-through`: {
-                                    if (!styleObject.decoration.includes(`lineThrough`)) {
-                                        styleObject.decoration.push(`lineThrough`);
-                                    }
+                                    styleObject.decoration = value;
                                     break;
                                 }
                             }

--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
@@ -481,9 +481,12 @@ export class HtmlToPdfService {
                         }
                         case `text-decoration`: {
                             switch (value) {
-                                case `line-through`:
                                 case `underline`: {
                                     styleObject.decoration = value;
+                                    break;
+                                }
+                                case `line-through`: {
+                                    styleObject.decoration = `lineThrough`;
                                     break;
                                 }
                             }

--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Content, ContentColumns } from 'pdfmake/interfaces';
 import { ExportServiceModule } from 'src/app/gateways/export';
 
 export interface ChildNodeParagraphPayload {
@@ -86,7 +87,7 @@ export class HtmlToPdfService {
      *
      * @returns {object} The converted html as DocDef.
      */
-    public addPlainText(text: string): object {
+    public addPlainText(text: string): ContentColumns {
         return {
             columns: [{ stack: this.convertHtml({ htmlText: text }) }]
         };
@@ -99,7 +100,7 @@ export class HtmlToPdfService {
      * @param htmlText the html text to translate as string
      * @returns pdfmake doc definition as object
      */
-    public convertHtml({ htmlText }: { htmlText: string }): object {
+    public convertHtml({ htmlText }: { htmlText: string }): Content[] {
         const docDef = [];
 
         // Create a HTML DOM tree out of html string

--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
@@ -228,7 +228,7 @@ export class HtmlToPdfService {
     }
 
     protected formatDivParagraph(paragraph: any, data: CreateSpecificParagraphPayload): any {
-        const { element, nodeName, classes, styles } = data;
+        const { element, nodeName, styles } = data;
         paragraph.margin = [0, 0, 0, 0];
 
         // determine the "normal" top and button margins
@@ -428,10 +428,10 @@ export class HtmlToPdfService {
      * Determine the ideal margin for a given node.
      * May be overwritten in subclasses.
      *
-     * @param nodeName the node to parse
+     * @param _nodeName the node to parse
      * @returns the margin bottom as number
      */
-    protected getMarginBottom(nodeName: string): number {
+    protected getMarginBottom(_nodeName: string): number {
         return this.P_MARGIN_BOTTOM;
     }
 

--- a/client/src/app/gateways/export/pdf-document.service/pdf-worker.worker.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-worker.worker.ts
@@ -46,11 +46,11 @@ function applyLayout(content: any): void {
  * Sets the internal PdfMake fonts and VFS
  */
 function initPdfMake(data: any): void {
-    pdfMake.fonts = {
+    (<any>pdfMake).fonts = {
         PdfFont: data.fonts
     };
 
-    pdfMake.vfs = data.vfs;
+    (<any>pdfMake).vfs = data.vfs;
 }
 
 /**

--- a/client/src/app/gateways/repositories/base-list-of-speakers-content-object-repository.ts
+++ b/client/src/app/gateways/repositories/base-list-of-speakers-content-object-repository.ts
@@ -6,11 +6,6 @@ import { HasListOfSpeakers } from 'src/app/site/pages/meetings/pages/agenda';
 import { BaseMeetingRelatedRepository } from './base-meeting-related-repository';
 import { RepositoryMeetingServiceCollectorService } from './repository-meeting-service-collector.service';
 
-function isListOfSpeakersContentObjectRepository(obj: any): obj is BaseListOfSpeakersContentObjectRepository<any, any> {
-    const repo = obj as BaseListOfSpeakersContentObjectRepository<any, any>;
-    return !!obj && repo.getListOfSpeakersTitle !== undefined && repo.getListOfSpeakersSlideTitle !== undefined;
-}
-
 /**
  * Describes a base repository which objects have a list of speakers assigned.
  */

--- a/client/src/app/gateways/repositories/base-repository.ts
+++ b/client/src/app/gateways/repositories/base-repository.ts
@@ -497,7 +497,7 @@ export abstract class BaseRepository<V extends BaseViewModel, M extends BaseMode
         return viewModel;
     }
 
-    protected onCreateViewModel(viewModel: V): void {}
+    protected onCreateViewModel(_viewModel: V): void {}
 
     private updateViewModelListSubject(viewModels: V[]): void {
         this.viewModelListSubject.next(viewModels?.filter(m => m.canAccess())?.sort(this.viewModelSortFn));

--- a/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-repository.service.ts
@@ -15,7 +15,7 @@ export class MotionCommentRepositoryService extends BaseMeetingRelatedRepository
         super(repositoryServiceCollector, MotionComment);
     }
 
-    public getTitle = (viewMotionComment: ViewMotionComment) => `Comment`;
+    public getTitle = () => `Comment`;
 
     public getVerboseName = (plural = false) => this.translate.instant(plural ? `Comments` : `Comment`);
 

--- a/client/src/app/gateways/repositories/motions/personal-note-repository.service/personal-note-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/personal-note-repository.service/personal-note-repository.service.ts
@@ -19,7 +19,7 @@ export class PersonalNoteRepositoryService extends BaseMeetingRelatedRepository<
         super(repositoryServiceCollector, PersonalNote);
     }
 
-    public getTitle = (viewPersonalNote: ViewPersonalNote) => this.getVerboseName();
+    public getTitle = () => this.getVerboseName();
 
     public getVerboseName = (plural = false) => this.translate.instant(plural ? `Personal notes` : `Personal note`);
 

--- a/client/src/app/gateways/repositories/poll-candidate-lists/poll-candidate-list/poll-candidate-list-repository.service.ts
+++ b/client/src/app/gateways/repositories/poll-candidate-lists/poll-candidate-list/poll-candidate-list-repository.service.ts
@@ -29,7 +29,7 @@ export class PollCandidateListRepositoryService extends BaseMeetingRelatedReposi
     }
 
     public getVerboseName = (plural?: boolean): string => (plural ? `PollCandidateLists` : `PollCandidateList`);
-    public getTitle = (viewModel: ViewPollCandidateList): string => _(`Confirmation of the nomination list`);
+    public getTitle = (): string => _(`Confirmation of the nomination list`);
 
     public override getFieldsets(): Fieldsets<PollCandidateList> {
         const detailFieldset: (keyof PollCandidateList)[] = [`poll_candidate_ids`, `option_id`, `meeting_id`];

--- a/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/vote-repository.service/vote-repository.service.ts
@@ -49,7 +49,7 @@ export class VoteRepositoryService extends BaseMeetingRelatedRepository<ViewVote
         super(repositoryServiceCollector, Vote);
     }
 
-    public getTitle = (viewVote: object) => `Vote`;
+    public getTitle = () => `Vote`;
 
     public getVerboseName = (plural = false) => this.translate.instant(plural ? `Votes` : `Vote`);
 

--- a/client/src/app/gateways/repositories/projector-messages/projector-message-repository.service.ts
+++ b/client/src/app/gateways/repositories/projector-messages/projector-message-repository.service.ts
@@ -17,7 +17,7 @@ export class ProjectorMessageRepositoryService extends BaseMeetingRelatedReposit
     public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, ProjectorMessage);
     }
-    public getTitle = (viewProjectorMessage: ViewProjectorMessage) => this.getVerboseName();
+    public getTitle = () => this.getVerboseName();
 
     public getVerboseName = (plural = false) => this.translate.instant(plural ? `Messages` : `Message`);
 

--- a/client/src/app/infrastructure/utils/import/base-additional-import-handler.ts
+++ b/client/src/app/infrastructure/utils/import/base-additional-import-handler.ts
@@ -14,5 +14,5 @@ export abstract class BaseAdditionalImportHandler<MainModel, SideModel>
     extends BaseImportHandler<MainModel, SideModel>
     implements AdditionalImportHandler<MainModel, SideModel>
 {
-    public pipeImportedSideModels(models: CsvMapping<SideModel>[]): void {}
+    public pipeImportedSideModels(_models: CsvMapping<SideModel>[]): void {}
 }

--- a/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
+++ b/client/src/app/site/base/base-filter.service/base-filter-list.service.ts
@@ -413,7 +413,7 @@ export abstract class BaseFilterListService<V extends BaseViewModel> implements 
      * Returns an array with custom arguments for said function.
      * If any filter property needs to receive arguments this function may be expanded.
      */
-    protected getFilterPropertyFunctionArguments(property: keyof V): any[] {
+    protected getFilterPropertyFunctionArguments(_property: keyof V): any[] {
         return [];
     }
 

--- a/client/src/app/site/base/base-import.service/base-backend-import.service.ts
+++ b/client/src/app/site/base/base-import.service/base-backend-import.service.ts
@@ -3,7 +3,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
 import { Papa, ParseConfig } from 'ngx-papaparse';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { Identifiable } from 'src/app/domain/interfaces';
 import { FileReaderProgressEvent, ValueLabelCombination } from 'src/app/infrastructure/utils/import/import-utils';
 import { BackendImportService } from 'src/app/ui/base/import-service';
 import { BackendImportPhase } from 'src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component';
@@ -17,9 +16,7 @@ import {
 import { ImportServiceCollectorService } from '../../services/import-service-collector.service';
 
 @Directive()
-export abstract class BaseBackendImportService<MainModel extends Identifiable>
-    implements BackendImportService<MainModel>
-{
+export abstract class BaseBackendImportService implements BackendImportService {
     /**
      * The minimimal number of header entries needed to successfully create an entry
      */

--- a/client/src/app/site/base/base-import.service/base-backend-import.service.ts
+++ b/client/src/app/site/base/base-import.service/base-backend-import.service.ts
@@ -176,7 +176,7 @@ export abstract class BaseBackendImportService implements BackendImportService {
             header: true,
             skipEmptyLines: `greedy`,
             quoteChar: this.textSeparator,
-            transform: (value, columnOrHeader) => (!value ? undefined : value)
+            transform: value => (!value ? undefined : value)
         };
         if (this.columnSeparator) {
             papaConfig.delimiter = this.columnSeparator;

--- a/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
+++ b/client/src/app/site/base/base-model-request-handler.component/base-model-request-handler.component.ts
@@ -80,8 +80,8 @@ export class BaseModelRequestHandlerComponent extends BaseUiComponent implements
 
     protected onBeforeModelRequests(): void | Promise<void> {}
     protected onShouldCreateModelRequests(): void {}
-    protected onNextMeetingId(id: Id | null): void {}
-    protected onParamsChanged(params: any, oldParams?: any): void {}
+    protected onNextMeetingId(_id: Id | null): void {}
+    protected onParamsChanged(_params: any, _oldParams?: any): void {}
 
     protected async subscribeTo(
         config: ModelRequestConfig | ModelRequestConfig[],

--- a/client/src/app/site/base/base-via-backend-import-list.component.ts
+++ b/client/src/app/site/base/base-via-backend-import-list.component.ts
@@ -6,16 +6,12 @@ import {
     BackendImportPhase
 } from 'src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component';
 
-import { Identifiable } from '../../domain/interfaces';
 import { getLongPreview, getShortPreview } from '../../infrastructure/utils';
 import { ComponentServiceCollectorService } from '../services/component-service-collector.service';
 import { BaseBackendImportService } from './base-import.service/base-backend-import.service';
 
 @Directive()
-export abstract class BaseViaBackendImportListComponent<M extends Identifiable>
-    extends BaseComponent
-    implements OnInit
-{
+export abstract class BaseViaBackendImportListComponent extends BaseComponent implements OnInit {
     @ViewChild(BackendImportListComponent)
     private list: BackendImportListComponent;
 

--- a/client/src/app/site/base/base-via-backend-import-list.component.ts
+++ b/client/src/app/site/base/base-via-backend-import-list.component.ts
@@ -17,7 +17,7 @@ export abstract class BaseViaBackendImportListComponent<M extends Identifiable>
     implements OnInit
 {
     @ViewChild(BackendImportListComponent)
-    private list: BackendImportListComponent<M>;
+    private list: BackendImportListComponent;
 
     /**
      * Helper function for previews
@@ -69,7 +69,7 @@ export abstract class BaseViaBackendImportListComponent<M extends Identifiable>
     public constructor(
         componentServiceCollector: ComponentServiceCollectorService,
         protected override translate: TranslateService,
-        protected importer: BaseBackendImportService<M>
+        protected importer: BaseBackendImportService
     ) {
         super(componentServiceCollector, translate);
     }

--- a/client/src/app/site/base/base-view-model.ts
+++ b/client/src/app/site/base/base-view-model.ts
@@ -51,7 +51,7 @@ export abstract class BaseViewModel<M extends BaseModel = any> implements Detail
         return ``;
     }
 }
-export interface BaseViewModel<M extends BaseModel = any> extends Displayable, Identifiable, HasCollection {
+export interface BaseViewModel extends Displayable, Identifiable, HasCollection {
     getTitle: () => string;
     getListTitle: () => string;
 

--- a/client/src/app/site/base/base.component.ts
+++ b/client/src/app/site/base/base.component.ts
@@ -158,7 +158,7 @@ export abstract class BaseComponent extends BaseUiComponent implements OnDestroy
      * To catch swipe gestures.
      * Should be overwritten by children which need swipe gestures
      */
-    protected swipe(e: TouchEvent, when: string): void {}
+    protected swipe(_e: TouchEvent, _when: string): void {}
 
     /**
      * TinyMCE Init callback. Used for certain mobile editors
@@ -172,7 +172,7 @@ export abstract class BaseComponent extends BaseUiComponent implements OnDestroy
         }
     }
 
-    public onLeaveTinyMce(event: any): void {
+    public onLeaveTinyMce(_event: any): void {
         this.saveHint = false;
     }
 }

--- a/client/src/app/site/modules/global-headbar/components/account-dialog/account-dialog.component.ts
+++ b/client/src/app/site/modules/global-headbar/components/account-dialog/account-dialog.component.ts
@@ -23,8 +23,6 @@ enum MenuItems {
     SHOW_MEETINGS = `My meetings`
 }
 
-const PERSONAL_PERMISSIONS = [`seePersonal`, `seeName`, `changePersonal`];
-
 @Component({
     selector: `os-account-dialog`,
     templateUrl: `./account-dialog.component.html`,

--- a/client/src/app/site/modules/wait-for-action-dialog/components/wait-for-action-banner/wait-for-action-banner.component.ts
+++ b/client/src/app/site/modules/wait-for-action-dialog/components/wait-for-action-banner/wait-for-action-banner.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { ActionWorkerRepositoryService } from 'src/app/gateways/repositories/action-worker/action-worker-repository.service';
 import { BaseUiComponent } from 'src/app/ui/base/base-ui-component';
 
 import { titleVerbose, WaitForActionData, WaitForActionReason, waitForActionReason } from '../../definitions';
@@ -36,14 +35,14 @@ export class WaitForActionBannerComponent extends BaseUiComponent {
 
     private _currentData: Map<WaitForActionReason, WaitForActionData[]>;
 
-    public constructor(private waitService: WaitForActionDialogService, private repo: ActionWorkerRepositoryService) {
+    public constructor(private waitService: WaitForActionDialogService) {
         super();
         this.subscriptions.push(
             this.waitService.dataObservable.subscribe(data => {
                 this._currentData = data;
                 this.nextDataArray();
             }),
-            this.waitService.currentReasonObservable.subscribe(reason => this.nextDataArray())
+            this.waitService.currentReasonObservable.subscribe(() => this.nextDataArray())
         );
     }
 

--- a/client/src/app/site/modules/wait-for-action-dialog/services/wait-for-action-dialog.service.ts
+++ b/client/src/app/site/modules/wait-for-action-dialog/services/wait-for-action-dialog.service.ts
@@ -115,7 +115,7 @@ export class WaitForActionDialogService {
         this.newCurrentReason();
     }
 
-    public wait(all = false, _noConfirmation = false): WaitForActionData[] {
+    public wait(all = false, noConfirmation = false): WaitForActionData[] {
         const map = this._dataSubject.value;
         let removed: WaitForActionData[];
         if (all || map.get(this.currentReason)?.length === 1) {

--- a/client/src/app/site/modules/wait-for-action-dialog/services/wait-for-action-dialog.service.ts
+++ b/client/src/app/site/modules/wait-for-action-dialog/services/wait-for-action-dialog.service.ts
@@ -25,6 +25,19 @@ export class WaitForActionDialogService {
         return this._currentReasonSubject.value;
     }
 
+    private set currentReason(reason: WaitForActionReason) {
+        const oldReason = this.currentReason;
+        if (oldReason !== reason) {
+            this._currentReasonSubject.next(reason);
+            if (oldReason === null) {
+                this.openDialog();
+            }
+            if (reason === null) {
+                this.closeDialog();
+            }
+        }
+    }
+
     public get dataObservable(): Observable<Map<WaitForActionReason, WaitForActionData[]>> {
         return this._dataObservable;
     }
@@ -38,19 +51,6 @@ export class WaitForActionDialogService {
             this._workerWatch = this.injector.get(ActionWorkerWatchService);
         }
         return this._workerWatch;
-    }
-
-    private set currentReason(reason: WaitForActionReason) {
-        const oldReason = this.currentReason;
-        if (oldReason !== reason) {
-            this._currentReasonSubject.next(reason);
-            if (oldReason === null) {
-                this.openDialog();
-            }
-            if (reason === null) {
-                this.closeDialog();
-            }
-        }
     }
 
     private _workerWatch: ActionWorkerWatchService;
@@ -115,7 +115,7 @@ export class WaitForActionDialogService {
         this.newCurrentReason();
     }
 
-    public wait(all = false, noConfirmation = false): WaitForActionData[] {
+    public wait(all = false, _noConfirmation = false): WaitForActionData[] {
         const map = this._dataSubject.value;
         let removed: WaitForActionData[];
         if (all || map.get(this.currentReason).length === 1) {

--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-detail.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-detail.component.ts
@@ -215,7 +215,7 @@ export abstract class BasePollDetailComponent<V extends PollContentObject, S ext
                     this.setVotesAndEntitledUsersData();
                 }
             }),
-            this.userRepo.getViewModelListObservable().subscribe(users => this.setVotesAndEntitledUsersData())
+            this.userRepo.getViewModelListObservable().subscribe(() => this.setVotesAndEntitledUsersData())
         );
     }
 

--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-pdf.service.ts
@@ -1,5 +1,6 @@
 import { Directive } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content, ContentText, StyleDictionary, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { BallotPaperSelection } from 'src/app/domain/models/meetings/meeting.constants';
 import { PollMethod, PollTableData, PollType, VoteValuesVerbose, VotingResult } from 'src/app/domain/models/poll';
@@ -160,11 +161,11 @@ export abstract class BasePollPdfService {
      * @param data predefined data to be used
      * @returns pdfmake definitions
      */
-    protected getPages(rowsPerPage: number, data: AbstractPollData): object {
+    protected getPages(rowsPerPage: number, data: AbstractPollData): Content[] {
         const amount = this.getBallotCount();
         const fullpages = Math.floor(amount / (rowsPerPage * 2));
         let partialpageEntries = amount % (rowsPerPage * 2);
-        const content: object[] = [];
+        const content: Content[] = [];
         for (let i = 0; i < fullpages; i++) {
             const body = [];
             for (let j = 0; j < rowsPerPage; j++) {
@@ -174,10 +175,9 @@ export abstract class BasePollPdfService {
                 table: {
                     headerRows: 1,
                     widths: [`*`, `*`],
-                    body,
-                    pageBreak: `after`
+                    body
                 },
-                rowsperpage: rowsPerPage
+                pageBreak: `after`
             });
         }
         if (partialpageEntries) {
@@ -194,8 +194,7 @@ export abstract class BasePollPdfService {
                     headerRows: 1,
                     widths: [`50%`, `50%`],
                     body: partialPageBody
-                },
-                rowsperpage: rowsPerPage
+                }
             });
         }
         return content;
@@ -206,8 +205,8 @@ export abstract class BasePollPdfService {
      *
      * @returns pdfMake definitions
      */
-    protected getHeader(): object {
-        const columns: object[] = [];
+    protected getHeader(): any {
+        const columns: any[] = [];
         columns.push({
             text: this.eventName,
             fontSize: 8,
@@ -238,7 +237,7 @@ export abstract class BasePollPdfService {
      * @param title
      * @returns pdfmake definition
      */
-    protected getTitle(title: string): object {
+    protected getTitle(title: string): ContentText {
         return {
             text: title,
             style: `title`
@@ -251,7 +250,7 @@ export abstract class BasePollPdfService {
      * @param subtitle
      * @returns pdfmake definition
      */
-    protected getSubtitle(subtitle?: string): object {
+    protected getSubtitle(subtitle?: string): ContentText {
         return {
             text: subtitle,
             style: `description`
@@ -266,7 +265,7 @@ export abstract class BasePollPdfService {
      * @param docDefinition the structure of the PDF document
      * @param filename the name of the file to use
      */
-    public downloadWithBallotPaper(docDefinition: object, filename: string): void {
+    public downloadWithBallotPaper(docDefinition: Content, filename: string): void {
         this.pdfExport.downloadWaitableDoc(filename, () => this.getBallotPaper(docDefinition));
     }
 
@@ -277,8 +276,8 @@ export abstract class BasePollPdfService {
      * @param documentContent the content of the pdf as object
      * @returns the pdf document definition ready to export
      */
-    private async getBallotPaper(documentContent: object): Promise<object> {
-        const result = {
+    private async getBallotPaper(documentContent: Content): Promise<TDocumentDefinitions> {
+        return {
             pageSize: `A4`,
             pageMargins: [0, 0, 0, 0],
             defaultStyle: {
@@ -288,7 +287,6 @@ export abstract class BasePollPdfService {
             content: documentContent,
             styles: this.getBlankPaperStyles()
         };
-        return result;
     }
 
     protected getRowsPerPage(poll: ViewPoll): number {
@@ -347,7 +345,7 @@ export abstract class BasePollPdfService {
             votesData?: BaseVoteData[];
             entitledUsersData?: EntitledUsersTableEntry[];
         }
-    ): object {
+    ): Content[] {
         let pollResultPdfContent: any[] = [];
         const title = this.getTitle(`${poll.content_object?.getTitle()} · ${poll.getTitle()}`);
 
@@ -690,7 +688,7 @@ export abstract class BasePollPdfService {
      * @returns an object that contains a limited set of pdf styles
      *  used for ballots
      */
-    private getBlankPaperStyles(): object {
+    private getBlankPaperStyles(): StyleDictionary {
         return {
             title: {
                 fontSize: 14,

--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll.component.ts
@@ -112,7 +112,7 @@ export abstract class BasePollComponent<C extends PollContentObject = any> exten
      */
     protected onAfterUpdatePoll(_poll: ViewPoll<C>): void {}
 
-    protected loadPoll(id: Id): void {
+    protected loadPoll(_id: Id): void {
         this.subscriptions.push(
             this.repo.getViewModelObservable(this._id).subscribe(poll => {
                 if (poll) {

--- a/client/src/app/site/pages/meetings/modules/poll/components/check-input/check-input.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/check-input/check-input.component.ts
@@ -120,16 +120,16 @@ export class CheckInputComponent extends BaseUiComponent implements OnInit, Cont
     /**
      * To satisfy the interface.
      *
-     * @param fn
+     * @param _fn
      */
-    public registerOnTouched(fn: any): void {}
+    public registerOnTouched(_fn: any): void {}
 
     /**
      * To satisfy the interface
      *
-     * @param isDisabled
+     * @param _isDisabled
      */
-    public setDisabledState?(isDisabled: boolean): void {}
+    public setDisabledState?(_isDisabled: boolean): void {}
 
     /**
      * Helper function to determine which information to give to the parent form

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-dialog/topic-poll-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-dialog/topic-poll-dialog.component.ts
@@ -236,7 +236,7 @@ export class TopicPollDialogComponent extends BasePollDialogComponent implements
         return true;
     }
 
-    public scrolled(event: any): void {
+    public scrolled(_e: any): void {
         this.isNearBottom = this.isUserNearBottom();
     }
 }

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/components/topic-import/topic-import.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/components/topic-import/topic-import.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { AgendaItemType, ItemTypeChoices } from 'src/app/domain/models/agenda/agenda-item';
-import { Topic } from 'src/app/domain/models/topics/topic';
 import { BaseViaBackendImportListComponent } from 'src/app/site/base/base-via-backend-import-list.component';
 import { ComponentServiceCollectorService } from 'src/app/site/services/component-service-collector.service';
 import { DurationService } from 'src/app/site/services/duration.service';
@@ -18,7 +17,7 @@ const TEXT_IMPORT_TAB_INDEX = 0;
     templateUrl: `./topic-import.component.html`,
     styleUrls: [`./topic-import.component.scss`]
 })
-export class TopicImportComponent extends BaseViaBackendImportListComponent<Topic> {
+export class TopicImportComponent extends BaseViaBackendImportListComponent {
     /**
      * A form for text input
      */

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/services/topic-import.service/topic-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/services/topic-import.service/topic-import.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { AgendaItemType } from 'src/app/domain/models/agenda/agenda-item';
-import { Topic } from 'src/app/domain/models/topics/topic';
 import { TopicRepositoryService } from 'src/app/gateways/repositories/topics/topic-repository.service';
 import { BaseBackendImportService } from 'src/app/site/base/base-import.service/base-backend-import.service';
 import { ActiveMeetingIdService } from 'src/app/site/pages/meetings/services/active-meeting-id.service';
@@ -14,7 +13,7 @@ import { TopicImportServiceModule } from '../topic-import-service.module';
 @Injectable({
     providedIn: TopicImportServiceModule
 })
-export class TopicImportService extends BaseBackendImportService<Topic> {
+export class TopicImportService extends BaseBackendImportService {
     /**
      * The minimimal number of header entries needed to successfully create an entry
      */

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/services/topic-pdf.service/topic-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/services/topic-pdf.service/topic-pdf.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content, ContentText } from 'pdfmake/interfaces';
 import { PollMethod, PollTableData, VotingResult } from 'src/app/domain/models/poll';
 import { HtmlToPdfService } from 'src/app/gateways/export/html-to-pdf.service';
 import {
@@ -51,7 +52,7 @@ export class TopicPdfService {
      * @param topic the ViewTopic to create the document for
      * @returns a pdfmake compatible document as document
      */
-    private topicToDocDef(topic: ViewTopic): object {
+    private topicToDocDef(topic: ViewTopic): Content[] {
         const title = this.createTitle(topic);
         const text = this.createTextContent(topic);
         const pollResult = this.createPollResultTable(topic.polls);
@@ -66,7 +67,7 @@ export class TopicPdfService {
      * @param topic the ViewTopic to create the document for
      * @returns the title part of the document
      */
-    private createTitle(topic: ViewTopic): object {
+    private createTitle(topic: ViewTopic): ContentText {
         return {
             text: topic.getListTitle(),
             style: `title`
@@ -79,11 +80,11 @@ export class TopicPdfService {
      * @param topic the ViewTopic to create the document for
      * @returns the description of the topic
      */
-    private createTextContent(topic: ViewTopic): object {
+    private createTextContent(topic: ViewTopic): Content {
         if (topic.text) {
             return this.htmlToPdfService.addPlainText(topic.text);
         } else {
-            return {};
+            return [];
         }
     }
 
@@ -94,7 +95,7 @@ export class TopicPdfService {
      * @param polls the ViewPoll objects to create the document for
      * @returns the table as pdfmake object
      */
-    private createPollResultTable(polls: ViewPoll[]): object {
+    private createPollResultTable(polls: ViewPoll[]): Content[] {
         const resultBody = [];
         for (const poll of polls) {
             if (poll.isPublished) {

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/view-models/view-topic.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/view-models/view-topic.ts
@@ -40,7 +40,7 @@ export class ViewTopic extends BaseProjectableViewModel<Topic> {
         return this.attachments && this.attachments.length > 0;
     }
 
-    public override getProjectorTitle(projection: Projection): ProjectorTitle {
+    public override getProjectorTitle(_projection: Projection): ProjectorTitle {
         return { title: this.getListTitle() };
     }
 }

--- a/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-export.service/agenda-item-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-export.service/agenda-item-export.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content } from 'pdfmake/interfaces';
 import { OSTreeNode } from 'src/app/infrastructure/definitions/tree';
 import { ViewAgendaItem } from 'src/app/site/pages/meetings/pages/agenda';
 import { MeetingPdfExportService } from 'src/app/site/pages/meetings/services/export';
@@ -57,7 +58,7 @@ export class AgendaItemExportService {
      * will be ignored, all other items will be sorted by their parents and weight
      * @returns definitions ready to be opened or exported via {@link PdfDocumentService}
      */
-    private agendaListToDocDef(items: ViewAgendaItem[]): object {
+    private agendaListToDocDef(items: ViewAgendaItem[]): Content[] {
         const tree: OSTreeNode<ViewAgendaItem>[] = this.treeService.makeSortedTree(items, `weight`, `parent_id`);
         const title = {
             text: this.translate.instant(`Agenda`),

--- a/client/src/app/site/pages/meetings/pages/agenda/view-models/view-agenda-item.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/view-models/view-agenda-item.ts
@@ -11,9 +11,7 @@ import { ViewMeeting } from 'src/app/site/pages/meetings/view-models/view-meetin
 
 import { HasTags } from '../../motions';
 
-export class ViewAgendaItem<
-    C extends BaseViewModel & HasAgendaItem = any
-> extends BaseProjectableViewModel<AgendaItem> {
+export class ViewAgendaItem extends BaseProjectableViewModel<AgendaItem> {
     public static COLLECTION = AgendaItem.COLLECTION;
     protected _collection = AgendaItem.COLLECTION;
 
@@ -35,7 +33,7 @@ export class ViewAgendaItem<
         return type ? type.name : ``;
     }
 
-    public override getProjectorTitle = (projection: Projection) => {
+    public override getProjectorTitle = (_projection: Projection) => {
         const subtitle = this.item.comment || undefined;
         return { title: this.getTitle(), subtitle };
     };

--- a/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-detail-content/assignment-poll-detail-content.component.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-detail-content/assignment-poll-detail-content.component.ts
@@ -36,12 +36,12 @@ export class AssignmentPollDetailContentComponent implements OnInit {
         this.cd.markForCheck();
     }
 
-    @Input()
-    public iconSize: 'large' | 'gigantic' = `large`;
-
     public get poll(): PollData {
         return this._poll;
     }
+
+    @Input()
+    public iconSize: 'large' | 'gigantic' = `large`;
 
     public get chartData(): ChartData {
         return this._chartData;
@@ -139,7 +139,7 @@ export class AssignmentPollDetailContentComponent implements OnInit {
                 combineLatestWith(this.themeService.currentGeneralColorsSubject),
                 map(([options, _]) => options)
             )
-            .subscribe(options => this.setupTableData());
+            .subscribe(() => this.setupTableData());
     }
 
     private setupTableData(): void {

--- a/client/src/app/site/pages/meetings/pages/assignments/services/assignment-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/services/assignment-export.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content } from 'pdfmake/interfaces';
 import { PdfError } from 'src/app/gateways/export/pdf-document.service';
 import { MeetingPdfExportService } from 'src/app/site/pages/meetings/services/export';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
@@ -56,7 +57,7 @@ export class AssignmentExportService {
      *
      * @returns doc definition as object
      */
-    private createDocOfMultipleAssignments(assignments: ViewAssignment[]): object {
+    private createDocOfMultipleAssignments(assignments: ViewAssignment[]): Content[] {
         const doc = [];
         const fileList = assignments.map((assignment, index) => {
             try {
@@ -97,7 +98,7 @@ export class AssignmentExportService {
      *
      * @returns The toc as
      */
-    private createToc(assignments: ViewAssignment[]): Object {
+    private createToc(assignments: ViewAssignment[]): Content[] {
         const toc = [];
         const tocTitle = {
             text: this.translate.instant(`Table of contents`),

--- a/client/src/app/site/pages/meetings/pages/home/pages/meeting-info/components/user-statistics/user-statistics.component.ts
+++ b/client/src/app/site/pages/meetings/pages/home/pages/meeting-info/components/user-statistics/user-statistics.component.ts
@@ -70,7 +70,7 @@ export class UserStatisticsComponent extends BaseComponent implements OnInit {
 
     public ngOnInit(): void {
         this.subscriptions.push(
-            this.speakerListRepo.getViewModelListObservable().subscribe(value => {
+            this.speakerListRepo.getViewModelListObservable().subscribe(() => {
                 this.updateRelationSpeakingTimeStructureLevelSubject();
             })
         );

--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call/call.component.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call/call.component.ts
@@ -120,8 +120,8 @@ export class CallComponent extends BaseMeetingComponent implements OnInit, After
 
     // closing the tab should also try to stop jitsi.
     // this will usually not be caught by ngOnDestroy
-    @HostListener(`window:beforeunload`, [`$event`])
-    public beforeunload($event: any): void {
+    @HostListener(`window:beforeunload`)
+    public beforeunload(): void {
         this.rtcService.stopJitsi();
     }
 

--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/stream/stream.component.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/stream/stream.component.ts
@@ -79,8 +79,8 @@ export class StreamComponent extends BaseMeetingComponent implements AfterViewIn
 
     // closing the tab should also try to stop jitsi.
     // this will usually not be caught by ngOnDestroy
-    @HostListener(`window:beforeunload`, [`$event`])
-    public async beforeunload($event: any): Promise<void> {
+    @HostListener(`window:beforeunload`)
+    public async beforeunload(): Promise<void> {
         this.beforeViewCloses();
     }
 

--- a/client/src/app/site/pages/meetings/pages/interaction/services/interaction-receive.service.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/services/interaction-receive.service.ts
@@ -12,7 +12,7 @@ import {
     startWith,
     Subscription
 } from 'rxjs';
-import { NotifyResponse, NotifyService } from 'src/app/gateways/notify.service';
+import { NotifyService } from 'src/app/gateways/notify.service';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
 import { ActiveMeetingService } from '../../../services/active-meeting.service';
@@ -143,7 +143,7 @@ export class InteractionReceiveService {
             this.promptService.close();
         });
 
-        this._kickObservable.subscribe(response => this.onKickMessage(response));
+        this._kickObservable.subscribe(() => this.onKickMessage());
     }
 
     public async enterCall(): Promise<void> {
@@ -174,7 +174,7 @@ export class InteractionReceiveService {
         }
     }
 
-    private async onKickMessage(message: NotifyResponse<kickMessage>): Promise<void> {
+    private async onKickMessage(): Promise<void> {
         if (await firstValueFrom(this.rtcService.isJitsiActiveObservable)) {
             this.rtcService.stopJitsi();
         }

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/allocation-list/allocation-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/allocation-list/allocation-list.component.ts
@@ -187,16 +187,16 @@ export class AllocationListComponent implements ControlValueAccessor, OnInit {
     /**
      * To satisfy the interface.
      *
-     * @param fn
+     * @param _fn
      */
-    public registerOnTouched(fn: any): void {}
+    public registerOnTouched(_fn: any): void {}
 
     /**
      * To satisfy the interface
      *
-     * @param isDisabled
+     * @param _isDisabled
      */
-    public setDisabledState?(isDisabled: boolean): void {}
+    public setDisabledState?(_isDisabled: boolean): void {}
 
     /**
      * Removes a custom allocation

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.ts
@@ -125,7 +125,7 @@ export class MeetingSettingsGroupDetailFieldComponent extends BaseComponent impl
     public get getChangeFn(): (currentValue: any, currentWatchPropertyValues: any[]) => any {
         return (
             this.setting.automaticChangesSetting?.getChangeFn ??
-            ((currentValue, currentWatchPropertyValues) => currentValue)
+            ((currentValue, _currentWatchPropertyValues) => currentValue)
         );
     }
 

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
@@ -113,7 +113,7 @@ export class MeetingSettingsGroupDetailComponent
             const data = deepCopy(this.changedSettings);
             for (const key of Object.keys(this.keyTransformConfigs)) {
                 if (Array.isArray(data[key])) {
-                    data[key] = data[key].map(val =>
+                    data[key] = data[key].map((val: unknown) =>
                         typeof val === `object` ? replaceObjectKeys(val, this.keyTransformConfigs[key], true) : val
                     );
                 } else if (typeof data[key] === `object`) {

--- a/client/src/app/site/pages/meetings/pages/motions/definitions/index.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/definitions/index.ts
@@ -7,7 +7,7 @@ export * from './recommendation-type-names';
  * (`node1` and `node2`)
  * within the same Document Fragment.
  */
-interface CommonAncestorData {
+export interface CommonAncestorData {
     /**
      * The most specific common ancestor node.
      */
@@ -33,7 +33,7 @@ interface CommonAncestorData {
  * information about the context in which these lines occur.
  * This additional information is meant to render the snippet correctly without producing broken HTML
  */
-interface ExtractedContent {
+export interface ExtractedContent {
     /**
      * The HTML between the two line numbers. Line numbers and automatically set line breaks are stripped.
      * All HTML tags are converted to uppercase

--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
@@ -4,7 +4,13 @@ import { ModificationType } from 'src/app/domain/models/motions/motions.constant
 import { djb2hash, splitStringKeepSeperator } from 'src/app/infrastructure/utils';
 import * as DomHelpers from 'src/app/infrastructure/utils/dom-helpers';
 
-import { DiffCache, DiffLinesInParagraph, LineRange } from '../../../../definitions';
+import {
+    CommonAncestorData,
+    DiffCache,
+    DiffLinesInParagraph,
+    ExtractedContent,
+    LineRange
+} from '../../../../definitions';
 import { ViewUnifiedChangeType } from '../../definitions';
 import { ViewUnifiedChange } from '../../view-models';
 import { LineNumberedString, LineNumberingService, LineNumberRange } from '../line-numbering.service';
@@ -12,83 +18,6 @@ import { LineNumberedString, LineNumberingService, LineNumberRange } from '../li
 const ELEMENT_NODE = Node.ELEMENT_NODE;
 const TEXT_NODE = Node.TEXT_NODE;
 const DOCUMENT_FRAGMENT_NODE = Node.DOCUMENT_FRAGMENT_NODE;
-
-/**
- * This data structure is used when determining the most specific common ancestor of two HTML node
- * (`node1` and `node2`)
- * within the same Document Fragment.
- */
-interface CommonAncestorData {
-    /**
-     * The most specific common ancestor node.
-     */
-    commonAncestor: Node;
-    /**
-     * The nodes inbetween `commonAncestor` and the `node1` in the DOM hierarchy.
-     * Empty, if node1 is a direct descendant.
-     */
-    trace1: Node[];
-    /**
-     * The nodes inbetween `commonAncestor` and the `node2` in the DOM hierarchy.
-     * Empty, if node2 is a direct descendant.
-     */
-    trace2: Node[];
-    /**
-     * Starting the root node, this indicates the depth level of the `commonAncestor`.
-     */
-    index: number;
-}
-
-/**
- * An object produced by `extractRangeByLineNumbers``. It contains both the extracted lines as well as
- * information about the context in which these lines occur.
- * This additional information is meant to render the snippet correctly without producing broken HTML
- */
-interface ExtractedContent {
-    /**
-     * The HTML between the two line numbers. Line numbers and automatically set line breaks are stripped.
-     * All HTML tags are converted to uppercase
-     * (e.g. Line 2</LI><LI>Line3</LI><LI>Line 4 <br>)
-     */
-    html: string;
-    /**
-     * The most specific DOM element that contains the HTML snippet (e.g. a UL, if several LIs are selected)
-     */
-    ancestor: Node;
-    /**
-     * An HTML string that opens all necessary tags to get the browser into the rendering mode
-     * of the ancestor element (e.g. <DIV><UL> in the case of the multiple LIs)
-     */
-    outerContextStart: string;
-    /**
-     * An HTML string that closes all necessary tags from the ancestor element (e.g. </UL></DIV>
-     */
-    outerContextEnd: string;
-    /**
-     * A string that opens all necessary tags between the ancestor and the beginning of the selection (e.g. <LI>)
-     */
-    innerContextStart: string;
-    /**
-     * A string that closes all tags after the end of the selection to the ancestor (e.g. </LI>)
-     */
-    innerContextEnd: string;
-    /**
-     * The HTML before the selected area begins (including line numbers)
-     */
-    previousHtml: string;
-    /**
-     * A HTML snippet that closes all open tags from previousHtml
-     */
-    previousHtmlEndSnippet: string;
-    /**
-     * The HTML after the selected area
-     */
-    followingHtml: string;
-    /**
-     * A HTML snippet that opens all HTML tags necessary to render "followingHtml"
-     */
-    followingHtmlStartSnippet: string;
-}
 
 /**
  * Functionality regarding diffing, merging and extracting line ranges.

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-detail-content/motion-poll-detail-content.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-detail-content/motion-poll-detail-content.component.ts
@@ -91,7 +91,7 @@ export class MotionPollDetailContentComponent extends BaseUiComponent implements
 
     public ngOnInit(): void {
         this.subscriptions.push(
-            this._poll.options_as_observable.subscribe(data => {
+            this._poll.options_as_observable.subscribe(() => {
                 this.setupTableData();
             })
         );

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-content/motion-content.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-content/motion-content.component.ts
@@ -147,7 +147,6 @@ export class MotionContentComponent extends BaseMotionDetailChildComponent {
     public participantSubscriptionConfig = getParticipantMinimalSubscriptionConfig(this.activeMeetingId);
 
     private titleFieldUpdateSubscription: Subscription;
-    private textFieldUpdateSubscription: Subscription;
 
     private _canSaveParagraphBasedAmendment = true;
     private _paragraphBasedAmendmentContent: any = {};
@@ -190,9 +189,9 @@ export class MotionContentComponent extends BaseMotionDetailChildComponent {
     /**
      * If the checkbox is deactivated, the statute_paragraph_id-field needs to be reset, as only that field is saved
      *
-     * @param {MatCheckboxChange} $event
+     * @param {MatCheckboxChange} _event
      */
-    public onStatuteAmendmentChange($event: MatCheckboxChange): void {
+    public onStatuteAmendmentChange(_event: MatCheckboxChange): void {
         this.contentForm.patchValue({
             statute_paragraph_id: null,
             workflow_id: this.getWorkflowIdForCreateFormByParagraph()

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-title/motion-manage-title.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-title/motion-manage-title.component.ts
@@ -85,7 +85,7 @@ export class MotionManageTitleComponent extends BaseMotionDetailChildComponent {
             this.changeRecoRepo
                 .getTitleChangeRecoOfMotionObservable(this.motion?.id)
                 ?.subscribe(changeReco => (this.titleChangeRecommendation = changeReco)),
-            this.viewService.changeRecommendationModeSubject.pipe(distinctUntilChanged()).subscribe(reco => {
+            this.viewService.changeRecommendationModeSubject.pipe(distinctUntilChanged()).subscribe(() => {
                 if (this.titleComponent) {
                     this.titleComponent.update();
                 }

--- a/client/src/app/site/pages/meetings/pages/motions/services/common/motion-controller.service/motion-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/common/motion-controller.service/motion-controller.service.ts
@@ -239,7 +239,7 @@ export class MotionControllerService extends BaseMeetingControllerService<ViewMo
                 );
             };
         } else {
-            viewModel.getAmendmentParagraphLines = (recoMode: ChangeRecoMode) => [];
+            viewModel.getAmendmentParagraphLines = () => [];
         }
         viewModel.getExtendedStateLabel = () => this.getExtendedStateLabel(viewModel);
         viewModel.getExtendedRecommendationLabel = () => this.getExtendedRecommendationLabel(viewModel);

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/amendment-list-pdf.service/amendment-list-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/amendment-list-pdf.service/amendment-list-pdf.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content, ContentTable, TableCell } from 'pdfmake/interfaces';
 import { HtmlToPdfService } from 'src/app/gateways/export/html-to-pdf.service';
 
 import { ViewMotion } from '../../../view-models';
@@ -37,7 +38,7 @@ export class AmendmentListPdfService {
      * @amendment the amendment to convert
      * @returns a line in the row as PDF doc definition
      */
-    private amendmentToTableRow(amendment: ViewMotion): object {
+    private amendmentToTableRow(amendment: ViewMotion): TableCell[] {
         let recommendationText = ``;
         if (amendment.recommendation) {
             if (amendment.recommendation.show_recommendation_extension_field && amendment.recommendationExtension) {
@@ -72,13 +73,13 @@ export class AmendmentListPdfService {
      * @param docTitle the header
      * @param amendments the amendments to render
      */
-    public overviewToDocDef(docTitle: string, amendments: ViewMotion[]): object {
+    public overviewToDocDef(docTitle: string, amendments: ViewMotion[]): Content[] {
         const title = {
             text: docTitle,
             style: `title`
         };
 
-        const amendmentTableBody: object[] = [
+        const amendmentTableBody: TableCell[][] = [
             [
                 {
                     text: this.translate.instant(`Motion`),
@@ -103,12 +104,12 @@ export class AmendmentListPdfService {
             ]
         ];
 
-        const amendmentRows: object[] = [];
+        const amendmentRows: TableCell[][] = [];
         for (const amendment of amendments) {
             amendmentRows.push(this.amendmentToTableRow(amendment));
         }
 
-        const table: object = {
+        const table: ContentTable = {
             table: {
                 widths: [`auto`, `auto`, `auto`, `*`, `auto`],
                 headerRows: 1,

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-html-to-pdf.service/motion-html-to-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-html-to-pdf.service/motion-html-to-pdf.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Content, ContentColumns } from 'pdfmake/interfaces';
 import { LineNumberingMode } from 'src/app/domain/models/motions/motions.constants';
 import {
     ChildNodeParagraphPayload,
@@ -37,13 +38,13 @@ export class MotionHtmlToPdfService extends HtmlToPdfService {
      */
     private lineNumberingMode: LineNumberingMode = LineNumberingMode.Outside;
 
-    public override addPlainText(htmlText: string): object {
+    public override addPlainText(htmlText: string): ContentColumns {
         return {
             columns: [{ stack: this.convertHtml({ htmlText, lnMode: LineNumberingMode.None }) }]
         };
     }
 
-    public override convertHtml({ htmlText, lnMode, lineHeight }: HtmlToPdfConfig): object {
+    public override convertHtml({ htmlText, lnMode, lineHeight }: HtmlToPdfConfig): Content[] {
         this.lineNumberingMode = lnMode || LineNumberingMode.None;
 
         if (lineHeight) {
@@ -153,7 +154,7 @@ export class MotionHtmlToPdfService extends HtmlToPdfService {
             return super.createListParagraph(data);
         }
 
-        const { element, nodeName, classes, styles } = data;
+        const { element, nodeName, styles } = data;
         const list = this.create(nodeName);
 
         // keep the numbers of the ol list

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf-catalog.service/motion-pdf-catalog.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf-catalog.service/motion-pdf-catalog.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content } from 'pdfmake/interfaces';
 import { MOTION_PDF_OPTIONS } from 'src/app/domain/models/motions/motions.constants';
 import { BorderType, PdfError, StyleType } from 'src/app/gateways/export/pdf-document.service';
 import { ViewMotion } from 'src/app/site/pages/meetings/pages/motions';
@@ -40,7 +41,7 @@ export class MotionPdfCatalogService {
      * @param motions the list of view motions to convert
      * @returns pdfmake doc definition as object
      */
-    public motionListToDocDef(motions: ViewMotion[], exportInfo: MotionExportInfo): object {
+    public motionListToDocDef(motions: ViewMotion[], exportInfo: MotionExportInfo): Content {
         let doc = [];
         const motionDocList = [];
         const printToc = exportInfo.pdfOptions?.includes(MOTION_PDF_OPTIONS.Toc);
@@ -99,10 +100,9 @@ export class MotionPdfCatalogService {
      * Considers sorting by categories and no sorting.
      *
      * @param motions The motions to add in the TOC
-     * @param sorting The optional sorting strategy
      * @returns the table of contents as document definition
      */
-    private createToc(motions: ViewMotion[], sorting?: string): object {
+    private createToc(motions: ViewMotion[]): Content {
         const toc = [];
         const categories = this.categoryRepo.getViewModelList();
 
@@ -227,9 +227,9 @@ export class MotionPdfCatalogService {
      * for exporting motion-list as PDF. Needed, if submitters
      * and recommendation should also be exported to the `Table of contents`.
      *
-     * @returns {object} The DocDefinition for `pdfmake.js`.
+     * @returns {Content} The DocDefinition for `pdfmake.js`.
      */
-    private getTocHeaderDefinition(): object {
+    private getTocHeaderDefinition(): Content {
         return [
             { text: this.translate.instant(`Number`), style: `tocHeaderRow` },
             {
@@ -249,9 +249,9 @@ export class MotionPdfCatalogService {
      * @param motion The motion containing the information
      * @param style Optional `StyleType`. Defaults to `tocEntry`.
      *
-     * @returns {Array<Object>} An array containing the `DocDefinitions` for `pdf-make`.
+     * @returns {Array<Content>} An array containing the `DocDefinitions` for `pdf-make`.
      */
-    private appendSubmittersAndRecommendation(motion: ViewMotion, style: StyleType = StyleType.DEFAULT): Object[] {
+    private appendSubmittersAndRecommendation(motion: ViewMotion, style: StyleType = StyleType.DEFAULT): Content[] {
         let submitterList = ``;
         let state = ``;
         if (motion.state!.isFinalState) {

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-pdf.service/motion-pdf.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content, ContentTable, ContentText, TableCell } from 'pdfmake/interfaces';
 import {
     ChangeRecoMode,
     LineNumberingMode,
@@ -98,7 +99,7 @@ export class MotionPdfService {
      * @param motion the motion to convert to pdf
      * @returns doc def for the motion
      */
-    public motionToDocDef({ motion, continuousText, exportInfo }: MotionToDocDefData): object {
+    public motionToDocDef({ motion, continuousText, exportInfo }: MotionToDocDefData): Content {
         let lnMode = exportInfo && exportInfo.lnMode ? exportInfo.lnMode : null;
         let crMode = exportInfo && exportInfo.crMode ? exportInfo.crMode : null;
         const infoToExport = exportInfo ? exportInfo.metaInfo : null;
@@ -197,7 +198,7 @@ export class MotionPdfService {
      * @param lineLength the line length
      * @returns doc def for the document title
      */
-    private createTitle(motion: ViewMotion, crMode: ChangeRecoMode, lineLength: number): object {
+    private createTitle(motion: ViewMotion, crMode: ChangeRecoMode, lineLength: number): ContentText {
         // summary of change recommendations (for motion diff version only)
         const changes = this.motionFormatService.getUnifiedChanges(motion, lineLength);
         const titleChange = changes.find(change => change?.isTitleChange())!;
@@ -219,7 +220,7 @@ export class MotionPdfService {
      * @param sequential set to true to include the sequential number
      * @returns doc def for the subtitle
      */
-    private createSubtitle(motion: ViewMotion, sequential?: boolean): object {
+    private createSubtitle(motion: ViewMotion, sequential?: boolean): ContentText {
         const subtitleLines = [];
         if (sequential) {
             subtitleLines.push(`${this.translate.instant(`Sequential number`)}: ${motion.sequential_number}`);
@@ -252,7 +253,7 @@ export class MotionPdfService {
         crMode: ChangeRecoMode,
         infoToExport: InfoToExport[] | null | undefined,
         optionToFollowRecommendation?: boolean
-    ): object {
+    ): Content {
         const metaTableBody = [];
 
         // submitters
@@ -571,7 +572,7 @@ export class MotionPdfService {
             };
         }
 
-        return {};
+        return [];
     }
 
     /**
@@ -579,7 +580,7 @@ export class MotionPdfService {
      *
      * @returns doc def for the motion text
      */
-    private createPreamble(): object {
+    private createPreamble(): ContentText {
         const motions_preamble = this.meetingSettingsService.instant(`motions_preamble`) as string;
         return {
             text: `${motions_preamble}`,
@@ -596,7 +597,7 @@ export class MotionPdfService {
      * @param crMode determine the used change Recommendation mode
      * @returns doc def for the "the assembly may decide" preamble
      */
-    private createText({ crMode, lineHeight, lineLength, lnMode, motion }: CreateTextData): object {
+    private createText({ crMode, lineHeight, lineLength, lnMode, motion }: CreateTextData): Content {
         let htmlText = ``;
 
         if (motion.isParagraphBasedAmendment()) {
@@ -734,13 +735,13 @@ export class MotionPdfService {
      * @param motions A list of motions
      * @returns definitions ready to be opened or exported via {@link PdfDocumentService}
      */
-    public callListToDoc(motions: ViewMotion[]): object {
+    public callListToDoc(motions: ViewMotion[]): Content {
         motions.sort((a, b) => a.sort_weight - b.sort_weight);
         const title = {
             text: this.translate.instant(`Call list`),
             style: `title`
         };
-        const callListTableBody: object[] = [
+        const callListTableBody: TableCell[][] = [
             [
                 {
                     text: this.translate.instant(`Called`),
@@ -769,7 +770,7 @@ export class MotionPdfService {
             ]
         ];
 
-        const callListRows: object[] = [];
+        const callListRows: TableCell[][] = [];
         let currentTitle = ``;
 
         motions.forEach(motion => {
@@ -795,7 +796,7 @@ export class MotionPdfService {
             callListRows.push(this.createCallListRow(motion));
         });
 
-        const table: object = {
+        const table: ContentTable = {
             table: {
                 widths: [`auto`, `auto`, `auto`, `*`, `auto`, `auto`],
                 headerRows: 1,
@@ -813,7 +814,7 @@ export class MotionPdfService {
      * @param motion
      * @returns pdfmakre definitions
      */
-    private createCallListRow(motion: ViewMotion): object {
+    private createCallListRow(motion: ViewMotion): Content[] {
         return [
             {
                 text: motion.sort_parent_id ? `` : motion.numberOrTitle
@@ -837,7 +838,7 @@ export class MotionPdfService {
      * @param noteTitle additional heading to be used (will be translated)
      * @returns pdfMake definitions
      */
-    public textToDocDef(note: string, motion: ViewMotion, noteTitle: string): object {
+    public textToDocDef(note: string, motion: ViewMotion, noteTitle: string): Content[] {
         const lineLength = this.meetingSettingsService.instant(`motions_line_length`)!;
         const crMode = this.meetingSettingsService.instant(`motions_recommendation_text_mode`)!;
         const title = this.createTitle(motion, crMode, lineLength);

--- a/client/src/app/site/pages/meetings/pages/participants/export/participant-pdf-export.service/participant-pdf-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/export/participant-pdf-export.service/participant-pdf-export.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Content } from 'pdfmake/interfaces';
 import { MeetingPdfExportService } from 'src/app/site/pages/meetings/services/export/meeting-pdf-export.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 
@@ -38,7 +39,7 @@ export class ParticipantPdfExportService {
      * Export a PDF document containing access information for participants
      */
     public exportAccessDocuments(...participants: ViewUser[]): void {
-        const doc: object[] = [];
+        const doc: Content[] = [];
         participants.forEach(participant => {
             doc.push(this.userPdfService.userAccessToDocDef(participant));
         });

--- a/client/src/app/site/pages/meetings/pages/participants/export/participant-pdf.service/participant-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/export/participant-pdf.service/participant-pdf.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Column, Content, ContentColumns, ContentTable, TableCell } from 'pdfmake/interfaces';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
 import { ViewUser } from 'src/app/site/pages/meetings/view-models/view-user';
 import { OrganizationSettingsService } from 'src/app/site/pages/organization/services/organization-settings.service';
@@ -35,7 +36,7 @@ export class ParticipantPdfService {
      *
      * @returns doc def for the user
      */
-    public userAccessToDocDef(user: ViewUser): object {
+    public userAccessToDocDef(user: ViewUser): Content {
         const userHeadline = [
             {
                 text: user.short_name,
@@ -57,7 +58,7 @@ export class ParticipantPdfService {
      * @param users An array of users
      * @returns pdfMake definitions for a table including name, structure level and groups for each user
      */
-    public createUserListDocDef(users: ViewUser[]): object {
+    public createUserListDocDef(users: ViewUser[]): Content {
         const title = {
             text: this.translate.instant(`List of participants`),
             style: `title`
@@ -71,7 +72,7 @@ export class ParticipantPdfService {
      * @param user
      * @returns
      */
-    private createAccessDataContent(user: ViewUser): object {
+    private createAccessDataContent(user: ViewUser): ContentColumns {
         return {
             columns: [this.createUserAccessContent(user)],
             margin: [0, 20]
@@ -85,8 +86,8 @@ export class ParticipantPdfService {
      * @param user
      * @returns pdfMake definitions
      */
-    private createUserAccessContent(user: ViewUser): object {
-        const columnOpenSlides: object[] = [
+    private createUserAccessContent(user: ViewUser): Column[] {
+        const columnOpenSlides: Column[] = [
             {
                 text: this.translate.instant(`OpenSlides access data`),
                 style: `userDataHeading`
@@ -142,7 +143,7 @@ export class ParticipantPdfService {
      *
      * @returns pdfMake definitions
      */
-    private createWelcomeText(): object {
+    private createWelcomeText(): Content {
         const users_pdf_welcometitle = this.meetingSettingsService.instant(`users_pdf_welcometitle`)!;
         const users_pdf_welcometext = this.meetingSettingsService.instant(`users_pdf_welcometext`)!;
         return [
@@ -163,8 +164,8 @@ export class ParticipantPdfService {
      * @param users: passed through to getListUsers
      * @returns a pdfMake table definition ready to be put into a page
      */
-    private createUserList(users: ViewUser[]): object {
-        const userTableBody: object[] = [
+    private createUserList(users: ViewUser[]): ContentTable {
+        const userTableBody: TableCell[][] = [
             [
                 {
                     text: `#`,
@@ -197,8 +198,8 @@ export class ParticipantPdfService {
      * @returns column definitions with odd and even entries styled differently,
      * short name, structure level and group name columns
      */
-    private getListUsers(users: ViewUser[]): object[] {
-        const result: any[] = [];
+    private getListUsers(users: ViewUser[]): Column[] {
+        const result: Column[] = [];
         let counter = 1;
         users.forEach(user => {
             const groupList = user.groups().map(grp => grp.name);

--- a/client/src/app/site/pages/meetings/pages/participants/modules/groups/components/group-list/group-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/modules/groups/components/group-list/group-list.component.ts
@@ -114,7 +114,6 @@ export class GroupListComponent extends BaseMeetingComponent implements OnInit, 
 
         const name = this.selectedGroup ? this.selectedGroup.name : ``;
         const external_id = this.selectedGroup?.external_id ?? ``;
-        const forbiddenNames = this.groups.filter(group => group.name !== name).map(group => group.name);
 
         this.groupForm = this.formBuilder.group({
             name: [

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
@@ -134,8 +134,6 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
     private _accountId: Id | null = null;
     private _suitableAccountList: Partial<User>[] = [];
 
-    private _currentUser: ViewUser | null = null;
-
     public constructor(
         componentServiceCollector: MeetingComponentServiceCollectorService,
         protected override translate: TranslateService,
@@ -158,7 +156,7 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
                 validators: [OneOfValidator.validation([`username`, `first_name`, `last_name`, `email`], `name`)]
             }
         );
-        this.createUserForm.valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+        this.createUserForm.valueChanges.pipe(distinctUntilChanged()).subscribe(() => {
             if (this._accountId) {
                 this.detailView?.enableSelfUpdate();
                 this.account = null;
@@ -246,8 +244,8 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
                     : undefined,
                 vote_delegations_from_ids: this.personalInfoFormValue.vote_delegations_from_ids
                     ? this.personalInfoFormValue.vote_delegations_from_ids
-                          .map(id => this.repo.getViewModel(id).getMeetingUser().id)
-                          .filter(id => !!id)
+                          .map((id: Id) => this.repo.getViewModel(id).getMeetingUser().id)
+                          .filter((id: Id | undefined) => !!id)
                     : []
             };
             if (this._accountId) {

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/fullscreen-projector/components/fullscreen-projector-main/fullscreen-projector-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/fullscreen-projector/components/fullscreen-projector-main/fullscreen-projector-main.component.ts
@@ -15,21 +15,19 @@ export class FullscreenProjectorMainComponent extends BaseModelRequestHandlerCom
         super();
     }
 
-    protected override onParamsChanged(params: any, oldParams?: any): void {
-        this.openslidesRouter.currentParamMap.subscribe(params => {
-            if (params[`id`]) {
-                this.sequentialNumberMappingService
-                    .getIdBySequentialNumber({
-                        collection: ViewProjector.COLLECTION,
-                        meetingId: params[`meetingId`],
-                        sequentialNumber: +params[`id`]
-                    })
-                    .then(id => {
-                        if (id) {
-                            this.subscribeTo(getProjectorSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-                        }
-                    });
-            }
-        });
+    protected override onParamsChanged(params: any, _oldParams?: any): void {
+        if (params[`id`]) {
+            this.sequentialNumberMappingService
+                .getIdBySequentialNumber({
+                    collection: ViewProjector.COLLECTION,
+                    meetingId: params[`meetingId`],
+                    sequentialNumber: +params[`id`]
+                })
+                .then(id => {
+                    if (id) {
+                        this.subscribeTo(getProjectorSubscriptionConfig(id), { hideWhenMeetingChanged: true });
+                    }
+                });
+        }
     }
 }

--- a/client/src/app/site/pages/meetings/services/active-meeting.service.ts
+++ b/client/src/app/site/pages/meetings/services/active-meeting.service.ts
@@ -56,7 +56,7 @@ export class ActiveMeetingService {
     ) {
         this.activeMeetingIdService.meetingIdObservable.subscribe(id => {
             if (id !== undefined) {
-                this.setupModelSubscription(id);
+                this.setupModelSubscription();
             }
         });
         this.lifecycle.openslidesBooted.subscribe();
@@ -74,7 +74,7 @@ export class ActiveMeetingService {
         return null;
     }
 
-    private async setupModelSubscription(id: number | null): Promise<void> {
+    private async setupModelSubscription(): Promise<void> {
         if (!!this.meetingId) {
             await this.refreshAutoupdateSubscription();
             this.refreshRepoSubscription();

--- a/client/src/app/site/pages/meetings/services/export/meeting-pdf-export.service.ts
+++ b/client/src/app/site/pages/meetings/services/export/meeting-pdf-export.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Content, PageSize, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { FontPlace } from 'src/app/domain/models/mediafiles/mediafile.constants';
 import {
     PdfDocumentService,
@@ -15,7 +16,7 @@ import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/mee
 import { MeetingExportModule } from './meeting-export.module';
 
 interface MeetingDownloadLandscapeConfig {
-    docDefinition: object;
+    docDefinition: Content;
     filename: string;
     metadata?: object;
 }
@@ -73,7 +74,7 @@ export class MeetingPdfExportService {
         this.pdfExportService.downloadLandscape({ ...config, ...this.createDownloadConfig() });
     }
 
-    public downloadWaitableDoc(filename: string, buildDocFn: () => Promise<object>): void {
+    public downloadWaitableDoc(filename: string, buildDocFn: () => Promise<TDocumentDefinitions>): void {
         const config = this.createDownloadConfig();
         this.pdfExportService.downloadWaitableDoc(
             filename,
@@ -159,13 +160,13 @@ export class MeetingPdfExportService {
         fontSize: number;
         loadFonts: () => PdfFontDescription;
         createVfs: () => Promise<PdfVirtualFileSystem>;
-        pageSize: string;
+        pageSize: PageSize;
     } {
         return {
             fontSize: this.fontSize!,
             loadFonts: () => this.getFonts(),
             createVfs: () => this.createVirtualFileSystem(),
-            pageSize: this.meetingSettingsService.instant(`export_pdf_pagesize`) ?? `A4`
+            pageSize: <PageSize>this.meetingSettingsService.instant(`export_pdf_pagesize`) ?? `A4`
         };
     }
 }

--- a/client/src/app/site/pages/meetings/view-models/base-projectable-model.ts
+++ b/client/src/app/site/pages/meetings/view-models/base-projectable-model.ts
@@ -11,7 +11,7 @@ import { ProjectionBuildDescriptor } from './projection-build-descriptor';
  */
 export abstract class BaseProjectableViewModel<M extends BaseModel = any> extends BaseViewModel<M> {
     public getProjectionBuildDescriptor(
-        meetingSettingsService?: MeetingSettingsService
+        _meetingSettingsService?: MeetingSettingsService
     ): ProjectionBuildDescriptor | null {
         return {
             content_object_id: this.fqid,
@@ -25,8 +25,8 @@ export abstract class BaseProjectableViewModel<M extends BaseModel = any> extend
     /**
      * @returns the projector title used for managing projector elements.
      */
-    public getProjectorTitle(projection: Projection): ProjectorTitle {
+    public getProjectorTitle(_projection: Projection): ProjectorTitle {
         return { title: this.getTitle() };
     }
 }
-export interface BaseProjectableViewModel<M extends BaseModel = any> extends Projectable {}
+export interface BaseProjectableViewModel extends Projectable {}

--- a/client/src/app/site/pages/organization/pages/mediafiles/modules/organization-mediafile-list/components/organization-mediafile-list/organization-mediafile-list.component.ts
+++ b/client/src/app/site/pages/organization/pages/mediafiles/modules/organization-mediafile-list/components/organization-mediafile-list/organization-mediafile-list.component.ts
@@ -60,7 +60,7 @@ export class OrganizationMediafileListComponent
     }
 
     public get shouldShowFileMenuFn(): (file: ViewMediafile) => boolean {
-        return file => this.showFileMenu(file);
+        return () => this.showFileMenu();
     }
 
     /**
@@ -76,7 +76,7 @@ export class OrganizationMediafileListComponent
     public fileEditForm: UntypedFormGroup | null = null;
 
     public isUsedAsLogoFn = (file: ViewMediafile) => this.isUsedAs(file);
-    public isUsedAsFontFn = (file: ViewMediafile) => false;
+    public isUsedAsFontFn = (_file: ViewMediafile) => false;
 
     private folderSubscription: Subscription | null = null;
     private directorySubscription: Subscription | null = null;
@@ -178,10 +178,9 @@ export class OrganizationMediafileListComponent
 
     /**
      * Determine if the given file has any extra option to show.
-     * @param file the file to check
      * @returns wether the extra menu should be accessible
      */
-    public showFileMenu(file: ViewMediafile): boolean {
+    public showFileMenu(): boolean {
         return this.canEdit;
     }
 

--- a/client/src/app/site/pages/organization/services/organization-controller.service.ts
+++ b/client/src/app/site/pages/organization/services/organization-controller.service.ts
@@ -17,7 +17,7 @@ export class OrganizationControllerService extends BaseController<ViewOrganizati
         super(repositoryServiceCollector, Organization, repo);
     }
 
-    public getTitle = (viewModel: ViewOrganization) => ``;
+    public getTitle = (_viewModel: ViewOrganization) => ``;
 
     public update(update: Partial<Organization>): Promise<void> {
         return this.repo.update(update);

--- a/client/src/app/site/services/operator.service.ts
+++ b/client/src/app/site/services/operator.service.ts
@@ -303,7 +303,7 @@ export class OperatorService {
         });
         this.DS.getChangeObservable(Group)
             .pipe(debounceTime(50))
-            .subscribe(changes => {
+            .subscribe(() => {
                 if (!this._groupsLoaded) {
                     console.log(`operator: group permissions loaded`);
                     this._groupsLoaded = true;

--- a/client/src/app/ui/base/base-form-control.ts
+++ b/client/src/app/ui/base/base-form-control.ts
@@ -26,6 +26,10 @@ export abstract class BaseFormControlComponent<T> implements ControlValueAccesso
         this.stateChanges.next();
     }
 
+    public get value(): T | null {
+        return this.contentForm.value;
+    }
+
     @Input()
     public set disabled(disable: boolean) {
         this._disabled = coerceBooleanProperty(disable);
@@ -39,10 +43,6 @@ export abstract class BaseFormControlComponent<T> implements ControlValueAccesso
 
     public get disabled(): boolean {
         return this._disabled;
-    }
-
-    public get value(): T | null {
-        return this.contentForm.value;
     }
 
     public get id(): number {
@@ -92,9 +92,9 @@ export abstract class BaseFormControlComponent<T> implements ControlValueAccesso
         this.disabled = isDisabled;
     }
 
-    protected _onChange = (value: T | null) => {};
+    protected _onChange: (_v: T | null) => void = () => {};
 
-    protected _onTouched = (value: T | null) => {};
+    protected _onTouched: (_v: T | null) => void = () => {};
 
     protected abstract createForm(): UntypedFormControl | UntypedFormGroup;
 

--- a/client/src/app/ui/base/import-service.ts
+++ b/client/src/app/ui/base/import-service.ts
@@ -42,7 +42,7 @@ export interface ImportService<M extends Identifiable> {
     downloadCsvExample(): void;
 }
 
-export interface BackendImportService<M extends Identifiable> {
+export interface BackendImportService {
     readonly rawFileObservable: Observable<File | null>;
     readonly encodings: ValueLabelCombination[];
     readonly columnSeparators: ValueLabelCombination[];

--- a/client/src/app/ui/modules/datepicker/components/base-datepicker/base-datepicker.component.ts
+++ b/client/src/app/ui/modules/datepicker/components/base-datepicker/base-datepicker.component.ts
@@ -47,7 +47,7 @@ export abstract class BaseDatepickerComponent extends BaseFormFieldControlCompon
             });
     }
 
-    public onContainerClick(event: MouseEvent): void {}
+    public onContainerClick(_event: MouseEvent): void {}
 
     protected initializeForm(): void {}
 }

--- a/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.spec.ts
+++ b/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.spec.ts
@@ -1,11 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Identifiable } from 'src/app/domain/interfaces';
 
 import { BackendImportListComponent } from './backend-import-list.component';
 
 xdescribe(`ViaBackendImportListComponent`, () => {
-    let component: BackendImportListComponent<Identifiable>;
-    let fixture: ComponentFixture<BackendImportListComponent<Identifiable>>;
+    let component: BackendImportListComponent;
+    let fixture: ComponentFixture<BackendImportListComponent>;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({

--- a/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
+++ b/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
@@ -19,7 +19,6 @@ import { MatTab, MatTabChangeEvent } from '@angular/material/tabs';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
 import { delay, firstValueFrom, map, Observable, of } from 'rxjs';
-import { Identifiable } from 'src/app/domain/interfaces';
 import { infoDialogSettings } from 'src/app/infrastructure/utils/dialog-settings';
 import { ValueLabelCombination } from 'src/app/infrastructure/utils/import/import-utils';
 import { BackendImportService } from 'src/app/ui/base/import-service';
@@ -54,7 +53,7 @@ export enum BackendImportPhase {
     styleUrls: [`./backend-import-list.component.scss`],
     encapsulation: ViewEncapsulation.None
 })
-export class BackendImportListComponent<M extends Identifiable> implements OnInit, OnDestroy {
+export class BackendImportListComponent implements OnInit, OnDestroy {
     public readonly END_POSITION = END_POSITION;
     public readonly START_POSITION = START_POSITION;
 
@@ -80,15 +79,15 @@ export class BackendImportListComponent<M extends Identifiable> implements OnIni
     public additionalInfo = ``;
 
     @Input()
-    public set importer(importer: BackendImportService<M>) {
+    public set importer(importer: BackendImportService) {
         this._importer = importer;
     }
 
-    public get importer(): BackendImportService<M> {
+    public get importer(): BackendImportService {
         return this._importer;
     }
 
-    private _importer!: BackendImportService<M>;
+    private _importer!: BackendImportService;
 
     /**
      * Defines all necessary and optional fields, that a .csv-file can contain.

--- a/client/src/app/ui/modules/openslides-date-adapter/openslides-date-adapter.ts
+++ b/client/src/app/ui/modules/openslides-date-adapter/openslides-date-adapter.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { MAT_DATE_LOCALE } from '@angular/material/core';
 import { DateFnsAdapter } from '@angular/material-date-fns-adapter';
-import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
+import { TranslateService } from '@ngx-translate/core';
 import { langToTimeLocale } from 'src/app/infrastructure/utils';
 
 /**
@@ -15,7 +15,7 @@ export class OpenSlidesDateAdapter extends DateFnsAdapter {
         // subscribe to language changes to change localisation of dates accordingly
         // DateAdapter seems not to be a singleton so we do that in this subclass instead of app.component
         this.updateLocaleByName(translate.currentLang);
-        translate.onLangChange.subscribe((e: LangChangeEvent) => {
+        translate.onLangChange.subscribe(() => {
             this.updateLocaleByName(translate.currentLang);
         });
     }

--- a/client/src/app/ui/modules/openslides-overlay/components/overlay/overlay.component.ts
+++ b/client/src/app/ui/modules/openslides-overlay/components/overlay/overlay.component.ts
@@ -5,6 +5,7 @@ import {
     HostListener,
     Input,
     Output,
+    TemplateRef,
     Type,
     ViewChild,
     ViewContainerRef
@@ -54,9 +55,9 @@ export class OverlayComponent {
     /**
      * Attaches to the backdrop overlay a custom template.
      *
-     * @param templateRef The reference to attach.
+     * @param _templateRef The reference to attach.
      */
-    public attachTemplate<T>(templateRef: any): void {}
+    public attachTemplate<T>(_templateRef: TemplateRef<T>): void {}
 
     /**
      * Attaches to the backdrop overlay a custom component.

--- a/client/src/app/ui/modules/openslides-overlay/definitions/overlay-instance.ts
+++ b/client/src/app/ui/modules/openslides-overlay/definitions/overlay-instance.ts
@@ -32,7 +32,7 @@ export class OverlayInstance<T = any> {
         }
     }
 
-    public attachTemplate(templateRef: TemplateRef<T>): void {}
+    public attachTemplate(_templateRef: TemplateRef<T>): void {}
 
     public attachComponent(component: Type<T>): void {
         const instance = this._overlayComponent.attachComponent(component);

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -152,7 +152,7 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     public ngOnInit(): void {
         this.manageService.currentScrollingTableComponent = this;
         this.subscriptions.push(
-            this.manageService.cellDefinitionsObservable.subscribe(def => {
+            this.manageService.cellDefinitionsObservable.subscribe(() => {
                 this.cd.markForCheck();
             })
         );

--- a/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
+++ b/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.ts
@@ -105,7 +105,7 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
      * Allows for the definition of additional strings that should be checked against the search value for a given item
      */
     @Input()
-    public getAdditionallySearchedValuesFn: (item: Selectable) => string[] = item => [];
+    public getAdditionallySearchedValuesFn: (item: Selectable) => string[] = () => [];
 
     @Input()
     public set sortFn(fn: false | ((valueA: Selectable, valueB: Selectable) => number)) {
@@ -114,6 +114,10 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
         } else {
             this._sortFn = this._defaultSortFn;
         }
+    }
+
+    public get sortFn(): false | ((valueA: Selectable, valueB: Selectable) => number) {
+        return this._sortFn;
     }
 
     @Input()
@@ -142,10 +146,6 @@ export abstract class BaseSearchSelectorComponent extends BaseFormFieldControlCo
 
     public get maxHeight(): string {
         return 112 + this.panelHeight + `px`;
-    }
-
-    public get sortFn(): false | ((valueA: Selectable, valueB: Selectable) => number) {
-        return this._sortFn;
     }
 
     private _defaultSortFn = (a: Selectable, b: Selectable) =>

--- a/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.ts
+++ b/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.ts
@@ -66,7 +66,7 @@ export class LocalizedDateRangePipe extends FormatPipe implements PipeTransform 
             case `cs#PP`:
                 return this.formatDMYPP;
             default:
-                return (startString, startArray, endString, endArray) =>
+                return (startString, _startArray, endString, _endArray) =>
                     this.defaultTransformInterval(startString, endString);
         }
     }

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -76,7 +76,7 @@ function openConnection(
 ): void {
     function getRequestCategory(
         description: string,
-        _request: Object
+        _request: unknown
     ): 'required' | 'requiredMeeting' | 'other' | 'sequentialnumbermapping' {
         const required = [`theme_list:subscription`, `operator:subscription`, `organization:subscription`];
         if (required.indexOf(description) !== -1) {

--- a/client/tsconfig.worker.json
+++ b/client/tsconfig.worker.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/worker",
+    "skipLibCheck": true,
     "lib": [
       "es2018",
       "webworker"


### PR DESCRIPTION
resolves #2733 

This PR also adds types to the pdf related services. Note that I had to change some things there as the pdf services used some functionality which was not supported by the pdfmake documentation and therefore removed. For that reason the pdf exports should be tested before merging this. 

Also a error in [fullscreen-projector-main.component.ts](https://github.com/OpenSlides/openslides-client/pull/2754/files#diff-40e4055aa3c9699fd107046fe769ae85884df1e44eb545c137fe8c351210293d) was fixed where an observable was opened by itself again. 