### PR TITLE
Fix missing label in participant import

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.html
@@ -30,12 +30,14 @@
     </ng-template>
 
     <div *osScrollingTableCell="'group_ids'; row as entry">
-        <span *ngFor="let group of entry.newEntry.group_ids; let last = last">
-            <span>{{ group.name | translate }}</span>
-            <span *ngIf="!group.id">
-                <mat-icon color="accent">add</mat-icon>
-            </span>
-            <span *ngIf="!last">,</span>
-        </span>
+        <div *osScrollingTableCellLabel>{{ 'Groups' | translate }}</div>
+        <os-comma-separated-listing [list]="entry.newEntry.group_ids">
+            <ng-template let-group>
+                <span>{{ group.name }}</span>
+                <span *ngIf="!group.id">
+                    <mat-icon color="accent">add</mat-icon>
+                </span>
+            </ng-template>
+        </os-comma-separated-listing>
     </div>
 </os-import-list>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/participant-import.module.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/participant-import.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
+import { CommaSeparatedListingModule } from 'src/app/ui/modules/comma-separated-listing';
 import { HeadBarModule } from 'src/app/ui/modules/head-bar';
 import { ImportListModule } from 'src/app/ui/modules/import-list';
 
@@ -14,6 +15,7 @@ import { ParticipantImportServiceModule } from './services';
     declarations: [ParticipantImportListComponent],
     imports: [
         CommonModule,
+        CommaSeparatedListingModule,
         ParticipantImportRoutingModule,
         ParticipantImportServiceModule,
         ImportListModule,

--- a/client/src/app/ui/modules/comma-separated-listing/components/comma-separated-listing/comma-separated-listing.component.html
+++ b/client/src/app/ui/modules/comma-separated-listing/components/comma-separated-listing/comma-separated-listing.component.html
@@ -3,6 +3,6 @@
         <ng-template [ngTemplateOutlet]="templateRef" [ngTemplateOutletContext]="{ $implicit: item }"></ng-template>
     </span>
     <span *ngIf="!templateRef">{{ item }}</span>
-    <span *ngIf="!isLast">,&nbsp;</span>
+    <span *ngIf="!isLast">,&ensp;</span>
     <span *ngIf="isLast && ellipsed">…</span>
 </span>


### PR DESCRIPTION
- add missing "Groups" label
- use `CommaSeparatedListing` to add whitespaces between the group names
- revert https://github.com/OpenSlides/openslides-client/pull/2603/commits/ac4ba8fc8d4f0c16624fa8fddcef55e6d22e620d to use a breaking whitespace to add automatic line breaks betweens the group names, if necessary