### PR TITLE
Fix shared worker subscription merging

### DIFF
--- a/client/src/app/site/services/communication-manager.service/communication-manager.service.ts
+++ b/client/src/app/site/services/communication-manager.service/communication-manager.service.ts
@@ -47,7 +47,7 @@ export class CommunicationManagerService {
         buildFn: (streamId: number) => HttpStream<T>,
         streamId?: Id
     ): { closeFn: CloseFn; id: number } {
-        const nextId = streamId || Math.floor(Math.random() * (900000 - 1) + 100000);
+        const nextId = streamId || Math.floor(Math.random() * (900000000 - 1) + 100000000);
         this._activeStreamHandlers[nextId] = new StreamHandler(() => buildFn(nextId), {
             afterOpenedFn: stream => this.printStreamInformation(stream, `OPENED`),
             afterClosedFn: stream => this.printStreamInformation(stream, `CLOSED`)

--- a/client/src/app/worker/autoupdate/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate/autoupdate-stream-pool.ts
@@ -152,6 +152,15 @@ export class AutoupdateStreamPool {
     }
 
     /**
+     * @param subscription Subscription to be managed by pool
+     */
+    public addSubscription(subscription: AutoupdateSubscription, stream: AutoupdateStream): void {
+        subscription.stream = stream;
+        stream.subscriptions.push(subscription);
+        this.subscriptions[subscription.id] = subscription;
+    }
+
+    /**
      * Searches a subscription that fulfills the given queryParams
      * and modelRequest
      *

--- a/client/src/app/worker/autoupdate/autoupdate-subscription.ts
+++ b/client/src/app/worker/autoupdate/autoupdate-subscription.ts
@@ -21,7 +21,7 @@ export class AutoupdateSubscription {
         public description: string,
         public ports: MessagePort[]
     ) {
-        this.id = this.id || Math.floor(Math.random() * (900000 - 1) + 100000);
+        this.id = this.id || Math.floor(Math.random() * (900000000 - 1) + 100000000);
 
         for (const port of ports) {
             this.publishSubscriptionId(port);

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -105,7 +105,16 @@ function openConnection(
 
     const existingSubscription = autoupdatePool.getMatchingSubscription(queryParams, request);
     if (existingSubscription) {
-        existingSubscription.addPort(ctx);
+        if (existingSubscription.description !== description) {
+            const subscription = new AutoupdateSubscription(streamId, queryParams, requestHash, request, description, [
+                ctx
+            ]);
+            autoupdatePool.addSubscription(subscription, existingSubscription.stream);
+            subscription.resendTo(ctx);
+        } else {
+            existingSubscription.addPort(ctx);
+        }
+
         if (!existingSubscription.stream.active) {
             autoupdatePool.reconnect(existingSubscription.stream, false);
         }


### PR DESCRIPTION
There is currently a problem which results in a loop trying to open a autoupdate connection when opening autoupdate subscriptions that can be fulfilled by another subscription with a non matching description that is already running. 