### PR TITLE
Update build-and-test-dev-image to use localprod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,3 @@ jobs:
 
       - name: Run karma tests
         run: make run-karma-tests
-
-  build-prod-image:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Build prod image
-        run: make build-prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: "./openslides-client"
+      - name: Copy example data
+        run: cp openslides-backend/global/data/example-data.json openslides-datastore-service/cli/
       - name: Start setup
+        working-directory: "./dev/localprod"
         run: |
-          cp openslides-backend/global/data/example-data.json openslides-datastore-service/cli/
-          cd dev/localprod/
           ./setup.sh
           sed -i '/x-default-environment/a \ \ DATASTORE_INITIAL_DATA_FILE: cli/example-data.json' docker-compose.yml
           docker-compose build --parallel
@@ -41,13 +42,8 @@ jobs:
           resource: https://localhost:8000
           timeout: 30000
       - name: Setup initial data
-        run: |
-          cd dev/localprod/
-          docker-compose  exec datastoreWriter python cli/create_initial_data.py
-      - name: Create initial data
-        run: |
-          cd dev/localprod/
-          ./openslides initial-data
+        working-directory: "./dev/localprod"
+        run: docker-compose  exec datastoreWriter python cli/create_initial_data.py
       - name: Start tests 
         working-directory: "./openslides-client"
         run: make run-playwright
@@ -59,9 +55,8 @@ jobs:
           retention-days: 7
       - name: Shut down setup
         if: always()
-        run: |
-          cd dev/localprod/
-          docker-compose down --volumes --remove-orphans
+        working-directory: "./dev/localprod"
+        run: docker-compose down --volumes --remove-orphans
 
   build-and-check-dev-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,27 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: "./openslides-client"
-      - name: Start dev setup
-        run: make run-dev ARGS="-d"
+      - name: Start setup
+        run: |
+          cp openslides-backend/global/data/example-data.json openslides-datastore-service/cli/
+          cd dev/localprod/
+          ./setup.sh
+          sed -i '/x-default-environment/a \ \ DATASTORE_INITIAL_DATA_FILE: cli/example-data.json' docker-compose.yml
+          docker-compose build --parallel
+          docker-compose up -d
       - name: Wait for dev setup
         uses: iFaxity/wait-on-action@v1.1.0
         with:
           resource: https://localhost:8000
-          timeout: 330000
+          timeout: 30000
+      - name: Setup initial data
+        run: |
+          cd dev/localprod/
+          docker-compose  exec datastoreWriter python cli/create_initial_data.py
+      - name: Create initial data
+        run: |
+          cd dev/localprod/
+          ./openslides initial-data
       - name: Start tests 
         working-directory: "./openslides-client"
         run: make run-playwright
@@ -43,9 +57,11 @@ jobs:
           name: playwright-report
           path: "./openslides-client/client/tests/playwright-report/"
           retention-days: 7
-      - name: Shut down dev setup
+      - name: Shut down setup
         if: always()
-        run: make stop-dev
+        run: |
+          cd dev/localprod/
+          docker-compose down --volumes --remove-orphans
 
   build-and-check-dev-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           timeout: 30000
       - name: Setup initial data
         working-directory: "./dev/localprod"
-        run: docker-compose  exec datastoreWriter python cli/create_initial_data.py
+        run: docker-compose exec -T datastoreWriter python cli/create_initial_data.py
       - name: Start tests 
         working-directory: "./openslides-client"
         run: make run-playwright

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ env:
   NG_CLI_ANALYTICS: ci
 
 jobs:
-  build-and-test-dev-image:    
+  build-and-test-prod-image:    
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +58,7 @@ jobs:
         working-directory: "./dev/localprod"
         run: docker-compose down --volumes --remove-orphans
 
-  build-and-check-dev-image:
+  build-and-test-dev-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -75,7 +75,7 @@ jobs:
       - name: Run karma tests
         run: make run-karma-tests
 
-  build-and-test-prod-image:
+  build-prod-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
+++ b/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
@@ -96,8 +96,13 @@ export class OpenSlidesMainComponent implements OnInit {
         );
         await this.onInitDone;
         try {
-            if (await this.updateService.checkForUpdate()) {
-                await this.updateService.applyUpdate();
+            if ((await navigator.serviceWorker?.getRegistrations())?.length) {
+                if (await this.updateService.checkForUpdate()) {
+                    await this.updateService.applyUpdate();
+                    return;
+                }
+            } else {
+                this.updateService.checkForUpdate();
             }
         } catch (_) {}
 

--- a/client/tests/Dockerfile.test
+++ b/client/tests/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.32.0-jammy
+FROM mcr.microsoft.com/playwright:v1.37.1-jammy
 
 WORKDIR /app
 COPY ./package.json .

--- a/client/tests/package-lock.json
+++ b/client/tests/package-lock.json
@@ -6,23 +6,23 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.32.0"
+        "@playwright/test": "^1.37.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.32.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
-      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
+      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.32.3"
+        "playwright-core": "1.37.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -49,28 +49,28 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.32.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
-      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "dev": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     }
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.32.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
-      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
+      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.32.3"
+        "playwright-core": "1.37.1"
       }
     },
     "@types/node": {
@@ -87,9 +87,9 @@
       "optional": true
     },
     "playwright-core": {
-      "version": "1.32.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
-      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "dev": true
     }
   }

--- a/client/tests/package.json
+++ b/client/tests/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {},
   "devDependencies": {
-    "@playwright/test": "^1.32.0"
+    "@playwright/test": "^1.37.1"
   }
 }

--- a/client/tests/playwright.config.ts
+++ b/client/tests/playwright.config.ts
@@ -40,6 +40,8 @@ const config: PlaywrightTestConfig = {
 
         ignoreHTTPSErrors: true,
 
+        serviceWorkers: 'block',
+
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry'
     },


### PR DESCRIPTION
This is an attempt to make the build-and-test-dev-image more reliable by using localprod which builds the client when building the images instead of when starting the setup which should prevent the timeout which currently occurs quite often. 

Also included is a performance improvement for initial loading when the service worker is not yet registered which was necessary to make the tests work. In that case waiting for the service worker to download a new application version is skipped as there is none installed. 