### PR TITLE
Fix participant-create-wizard

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
@@ -283,7 +283,7 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
 
     private async checkScope(): Promise<void> {
         if (this._accountId) {
-            this._isUserInScope = await this.userService.isUserInSameScope(this._accountId);
+            this._isUserInScope = await this.userService.hasScopeManagePerms(this._accountId);
             if (this._isUserInScope && this.account?.id !== this._accountId) {
                 this.account = new User(
                     (await this.modelRequestService.fetch(getParticipantDetailSubscription(this._accountId)))[`user`][

--- a/client/src/app/site/services/operator.service.ts
+++ b/client/src/app/site/services/operator.service.ts
@@ -15,6 +15,7 @@ import { Deferred } from '../../infrastructure/utils/promises';
 import { GroupControllerService } from '../pages/meetings/pages/participants';
 import { ActiveMeetingService } from '../pages/meetings/services/active-meeting.service';
 import { NoActiveMeetingError } from '../pages/meetings/services/active-meeting-id.service';
+import { MeetingControllerService } from '../pages/meetings/services/meeting-controller.service';
 import { ViewMeeting } from '../pages/meetings/view-models/view-meeting';
 import { AuthService } from './auth.service';
 import { AutoupdateService, ModelSubscription } from './autoupdate';
@@ -213,7 +214,8 @@ export class OperatorService {
         private userRepo: UserRepositoryService,
         private groupRepo: GroupControllerService,
         private autoupdateService: AutoupdateService,
-        private modelRequestBuilder: ModelRequestBuilderService
+        private modelRequestBuilder: ModelRequestBuilderService,
+        private meetingRepo: MeetingControllerService
     ) {
         this.setNotReady();
         // General environment in which the operator moves
@@ -501,6 +503,36 @@ export class OperatorService {
             result = true;
         } else {
             result = checkPerms.some(permission => this._permissions?.includes(permission));
+        }
+        return result;
+    }
+
+    /**
+     * Checks, if the operator has at least one of the given permissions for the given meetingId.
+     * @param checkPerms The permissions to check, if at least one matches.
+     */
+    public hasPermsInMeeting(meetingId: number, ...checkPerms: Permission[]): boolean {
+        if (meetingId === this.activeMeetingId) {
+            return this.hasPerms(...checkPerms);
+        }
+        if (!this._ready) {
+            // console.warn(`has perms: Operator is not ready!`);
+            return false;
+        }
+        if (this.isSuperAdmin) {
+            return true;
+        }
+        const groups = this.user.groups(meetingId);
+        let result: boolean;
+        if (!groups || !groups.length) {
+            result = false;
+        } else if (
+            this.isAuthenticated &&
+            groups.find(group => group.id === this.meetingRepo.getViewModel(meetingId)?.admin_group_id)
+        ) {
+            result = true;
+        } else {
+            result = checkPerms.some(permission => groups.some(group => group.hasPermission(permission)));
         }
         return result;
     }

--- a/client/src/app/site/services/operator.service.ts
+++ b/client/src/app/site/services/operator.service.ts
@@ -496,15 +496,12 @@ export class OperatorService {
             return true;
         }
 
-        let result: boolean;
         if (!this._groupIds) {
-            result = false;
+            return false;
         } else if (this.isAuthenticated && this._groupIds.find(id => id === this.adminGroupId)) {
-            result = true;
-        } else {
-            result = checkPerms.some(permission => this._permissions?.includes(permission));
+            return true;
         }
-        return result;
+        return checkPerms.some(permission => this._permissions?.includes(permission));
     }
 
     /**
@@ -523,18 +520,15 @@ export class OperatorService {
             return true;
         }
         const groups = this.user.groups(meetingId);
-        let result: boolean;
         if (!groups || !groups.length) {
-            result = false;
+            return false;
         } else if (
             this.isAuthenticated &&
             groups.find(group => group.id === this.meetingRepo.getViewModel(meetingId)?.admin_group_id)
         ) {
-            result = true;
-        } else {
-            result = checkPerms.some(permission => groups.some(group => group.hasPermission(permission)));
+            return true;
         }
-        return result;
+        return checkPerms.some(permission => groups.some(group => group.hasPermission(permission)));
     }
 
     /**

--- a/client/src/app/site/services/user.service.ts
+++ b/client/src/app/site/services/user.service.ts
@@ -88,7 +88,10 @@ export class UserService {
             .map(userId => parseInt(userId, 10))
             .some(userId => {
                 const toCompare = result[userId];
-                return this.presenter.compareScope(ownScope, toCompare) === -1;
+                return (
+                    this.presenter.compareScope(ownScope, toCompare) === -1 ||
+                    (ownScope.collection === toCompare.collection && ownScope.id !== toCompare.id)
+                );
             });
     }
 

--- a/client/src/app/site/services/user.service.ts
+++ b/client/src/app/site/services/user.service.ts
@@ -109,7 +109,7 @@ export class UserService {
             .map(userId => parseInt(userId, 10))
             .every(userId => {
                 const toCompare = result[userId];
-                let hasPerms = this.operator.hasOrganizationPermissions(OML.can_manage_users);
+                let hasPerms = this.operator.hasOrganizationPermissions(toCompare.user_oml || OML.can_manage_users);
                 if (!hasPerms && toCompare.collection === UserScope.COMMITTEE) {
                     hasPerms = hasPerms || this.operator.hasCommitteePermissions(toCompare.id, CML.can_manage);
                 }
@@ -117,8 +117,7 @@ export class UserService {
                     const committee_id = this.meetingRepo.getViewModel(toCompare.id)?.committee_id;
                     hasPerms =
                         hasPerms ||
-                        (this.activeMeetingService.meetingId === toCompare.id &&
-                            this.operator.hasPerms(Permission.userCanManage)) ||
+                        this.operator.hasPermsInMeeting(toCompare.id, Permission.userCanManage) ||
                         (committee_id && this.operator.hasCommitteePermissions(committee_id, CML.can_manage));
                 }
                 return hasPerms;


### PR DESCRIPTION
While trying to replicate #2787 (which I didn't manage to do at first) I instead found that the meeting-specific information form didn't appear for a meeting admin trying to add a user from another meeting.

I fixed that one.

Also fixes #2787