### PR TITLE
Fix numeric sorting

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/motions/modules/motion-slide/components/motion-slide/motion-slide.component.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/motions/modules/motion-slide/components/motion-slide/motion-slide.component.ts
@@ -211,7 +211,7 @@ export class MotionSlideComponent
 
         const paragraphNumbers = Object.keys(amendment.amendment_paragraphs)
             .map(x => +x)
-            .sort();
+            .sort((a, b) => a - b);
 
         return paragraphNumbers
             .map(paraNo => {
@@ -401,7 +401,7 @@ export class MotionSlideComponent
 
         const paragraphNumbers = Object.keys(motion.amendment_paragraphs)
             .map(x => +x)
-            .sort();
+            .sort((a, b) => a - b);
         const amendmentParagraphs: DiffLinesInParagraph[] = paragraphNumbers
             .map(paraNo =>
                 this.diff.getAmendmentParagraphsLines(

--- a/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
+++ b/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
@@ -237,7 +237,7 @@ export class SortingListComponent<T extends Selectable = Selectable> implements 
             const newMultiSelectedIndex = multiSelectedIndex
                 .map(index => this.currentItems.findIndex(item => item.id === this.sortedItems[index].id))
                 .filter(index => index !== -1)
-                .sort();
+                .sort((a, b) => a - b);
             let newCurrentIndex = Math.min(event.currentIndex, this.currentItems.length - 1);
             if (newPreviousIndex === -1) {
                 newPreviousIndex = newMultiSelectedIndex.length ? newMultiSelectedIndex[0] : undefined;

--- a/client/src/app/ui/modules/sorting/modules/sorting-tree/services/tree.service.ts
+++ b/client/src/app/ui/modules/sorting/modules/sorting-tree/services/tree.service.ts
@@ -301,7 +301,7 @@ export class TreeService {
         if (!deleteIds.length) {
             return tree;
         }
-        deleteIds = deleteIds.sort();
+        deleteIds = deleteIds.sort((a, b) => a - b);
         tree = tree.sort((a, b) =>
             a.position != null && b.position != null ? a.position - b.position : b != null ? -1 : 0
         );


### PR DESCRIPTION
Javascript sorts alphabetically by default, so whenever numeric values should be sorted, a cusotm compare function has to be supplied. This led to projection errors when displaying paragraph-based amendments. I also fixed two other places where I think the array should be sorted numerically - please check if this is indeed the case.

Also, the motion slide contains a lot of duplicated code, but that's a story for another time...