### PR TITLE
Pause autoupdate connection on inactivitiy

### DIFF
--- a/client/src/app/site/services/window-visibility.service.ts
+++ b/client/src/app/site/services/window-visibility.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { debounceTime, filter, firstValueFrom, fromEvent, map, Observable } from 'rxjs';
+
+@Injectable({
+    providedIn: `root`
+})
+export class WindowVisibilityService {
+    public constructor() {}
+
+    public async waitUntilVisible(): Promise<void> {
+        if (document.visibilityState !== `visible`) {
+            await firstValueFrom(
+                fromEvent(document, `visibilitychange`).pipe(filter(() => document.visibilityState === `visible`))
+            );
+        }
+    }
+
+    public hiddenFor(ms: number): Observable<void> {
+        return fromEvent(document, `visibilitychange`).pipe(
+            debounceTime(ms),
+            filter(() => document.visibilityState === `hidden`),
+            map(() => {})
+        );
+    }
+}


### PR DESCRIPTION
resolves #2751 

Closes autoupdate connections after five minutes of a browser window or tab not visible to the user. 