### PR TITLE
Fix countdowns over an hour

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.scss
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.scss
@@ -48,7 +48,7 @@
     }
 
     .countdown-wrapper {
-        width: 170px;
+        min-width: 170px;
         text-align: right !important;
         position: relative;
         height: 100%;

--- a/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.ts
@@ -116,10 +116,10 @@ export class CountdownTimeComponent implements OnDestroy {
         }
 
         const time = new Date(seconds * 1000);
-        const m = `0` + time.getMinutes();
+        const m = Math.floor(+time / 1000 / 60).toString();
         const s = `0` + time.getSeconds();
 
-        this.time = m.slice(-2) + `:` + s.slice(-2);
+        this.time = (m.length < 2 ? `0` : ``) + m + `:` + s.slice(-2);
 
         if (negative) {
             this.time = `-` + this.time;

--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/projector-countdown-slide/components/projector-countdown-slide.component.scss
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/projector-countdown-slide/components/projector-countdown-slide.component.scss
@@ -17,7 +17,7 @@
         margin: 80px 0px 10px 10px;
         padding: 10px 44px 10px 10px;
         min-height: 60px;
-        width: 230px;
+        min-width: 230px;
         font-size: 3.7em;
         font-weight: bold;
         text-align: right;


### PR DESCRIPTION
resolves #2852 

This still needs some discussion or info on how to display larger countdowns. With this PR only minutes are shown. Currently the padding to the left is too small with more than three digit long minutes. We might need to refactor the css part of the countdown to fix that. 