### PR TITLE
Fix double click needed to remove filter

### DIFF
--- a/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.html
+++ b/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.html
@@ -11,7 +11,11 @@
     <!-- Current filters -->
     <div class="current-filters h-scroller" *ngIf="filterService">
         <div *ngFor="let filter of filterService.filterStack">
-            <button mat-stroked-button (click)="removeFilterFromStack(filter)">
+            <button
+                mat-stroked-button
+                (mouseup)="removeFilterFromStack(filter)"
+                (click)="removeFilterFromStack(filter)"
+            >
                 <os-icon-container icon="close" class="active-filter">
                     <span class="active-filter">
                         {{ filter.option.label | translate }}


### PR DESCRIPTION
resolves #2357 

I consider this a workaround. It seems when blurring focus of a checkbox from the filters a mousedown event is fired which prevents the click event on the filter from getting fired. I could not figure out why this happens. Especially why only on the participant list. 