### PR TITLE
Add tests to openslides-status service

### DIFF
--- a/client/src/app/site/services/openslides-status.service.spec.ts
+++ b/client/src/app/site/services/openslides-status.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
+import { Deferred } from 'src/app/infrastructure/utils/promises';
 
 import { OpenSlidesStatusService } from './openslides-status.service';
 
-xdescribe(`OpenSlidesStatusService`, () => {
+describe(`OpenSlidesStatusService`, () => {
     let service: OpenSlidesStatusService;
 
     beforeEach(() => {
@@ -12,5 +13,21 @@ xdescribe(`OpenSlidesStatusService`, () => {
 
     it(`should be created`, () => {
         expect(service).toBeTruthy();
+    });
+
+    it(`check stable`, () => {
+        expect((service.stable as Deferred).wasResolved).toBe(false);
+    });
+
+    it(`observe isStable`, () => {
+        let actualValue: boolean | undefined;
+        service.isStableObservable.subscribe(value => {
+            actualValue = value;
+        });
+        expect(actualValue).toBe(false);
+        service.setStable();
+        expect(actualValue).toBe(true);
+        service.reset();
+        expect(actualValue).toBe(true);
     });
 });

--- a/client/src/app/site/services/openslides-status.service.spec.ts
+++ b/client/src/app/site/services/openslides-status.service.spec.ts
@@ -28,6 +28,13 @@ describe(`OpenSlidesStatusService`, () => {
         service.setStable();
         expect(actualValue).toBe(true);
         service.reset();
-        expect(actualValue).toBe(true);
+        expect(actualValue).toBe(false);
+    });
+
+    it(`reset should unresolve stable`, () => {
+        service.setStable();
+        expect((service.stable as Deferred).wasResolved).toBe(true);
+        service.reset();
+        expect((service.stable as Deferred).wasResolved).toBe(false);
     });
 });

--- a/client/src/app/site/services/openslides-status.service.spec.ts
+++ b/client/src/app/site/services/openslides-status.service.spec.ts
@@ -17,9 +17,11 @@ describe(`OpenSlidesStatusService`, () => {
 
     it(`check stable`, () => {
         expect((service.stable as Deferred).wasResolved).toBe(false);
+        service.setStable();
+        expect((service.stable as Deferred).wasResolved).toBe(true);
     });
 
-    it(`observe isStable`, () => {
+    it(`observe stableSubject`, () => {
         let actualValue: boolean | undefined;
         service.isStableObservable.subscribe(value => {
             actualValue = value;
@@ -27,14 +29,5 @@ describe(`OpenSlidesStatusService`, () => {
         expect(actualValue).toBe(false);
         service.setStable();
         expect(actualValue).toBe(true);
-        service.reset();
-        expect(actualValue).toBe(false);
-    });
-
-    it(`reset should unresolve stable`, () => {
-        service.setStable();
-        expect((service.stable as Deferred).wasResolved).toBe(true);
-        service.reset();
-        expect((service.stable as Deferred).wasResolved).toBe(false);
     });
 });

--- a/client/src/app/site/services/openslides-status.service.ts
+++ b/client/src/app/site/services/openslides-status.service.ts
@@ -21,9 +21,4 @@ export class OpenSlidesStatusService {
         this._stable.resolve();
         this._stableSubject.next(true);
     }
-
-    public reset(): void {
-        this._stable = new Deferred();
-        this._stableSubject.next(false);
-    }
 }

--- a/client/src/app/site/services/openslides-status.service.ts
+++ b/client/src/app/site/services/openslides-status.service.ts
@@ -24,5 +24,6 @@ export class OpenSlidesStatusService {
 
     public reset(): void {
         this._stable = new Deferred();
+        this._stableSubject.next(false);
     }
 }


### PR DESCRIPTION
I'm not sure, that the reset method is correct. It doesn't change the isStable to false.