### PR TITLE
Fix line numbers at change context remainder (#2970)

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
@@ -2038,7 +2038,7 @@ export class MotionDiffService {
         highlight?: number,
         lineRange?: LineRange
     ): string {
-        let maxLine = 0;
+        let maxLine = lineRange?.from || 0;
         changes.forEach((change: ViewUnifiedChange) => {
             if (change.getLineTo() > maxLine) {
                 maxLine = change.getLineTo();


### PR DESCRIPTION
This should fix the issue reported in https://github.com/OpenSlides/openslides-client/issues/2970 , resulting in the getTextRemainderAfterLastChange method to expect to always work on the full text, which is not the case in the changed-amendment-case.