### PR TITLE
Update material tabs and slider to mdc

### DIFF
--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/assignment-polls.module.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/assignment-polls.module.ts
@@ -4,7 +4,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
-import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
+import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { MeetingsComponentCollectorModule } from 'src/app/site/pages/meetings/modules/meetings-component-collector';

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/motion-polls.module.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/motion-polls.module.ts
@@ -4,7 +4,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
-import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
+import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 import { MeetingsComponentCollectorModule } from 'src/app/site/pages/meetings/modules/meetings-component-collector';

--- a/client/src/app/site/pages/meetings/pages/projectors/components/projector-edit-dialog/components/projector-edit-dialog/projector-edit-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/projectors/components/projector-edit-dialog/components/projector-edit-dialog/projector-edit-dialog.component.html
@@ -52,13 +52,13 @@
             <div class="spacer-top-20 grid-form">
                 <mat-slider
                     class="grid-start"
-                    formControlName="width"
-                    [thumbLabel]="true"
+                    [discrete]="true"
                     [min]="minWidth"
                     [max]="maxResolution"
                     [step]="resolutionChangeStep"
-                    [value]="updateForm.value.width"
-                ></mat-slider>
+                >
+                    <input matSliderThumb formControlName="width" [value]="updateForm.value.width" />
+                </mat-slider>
                 <div class="grid-end">
                     <mat-form-field>
                         <input

--- a/client/src/app/site/pages/meetings/pages/projectors/components/projector-edit-dialog/projector-edit-dialog.module.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/components/projector-edit-dialog/projector-edit-dialog.module.ts
@@ -10,8 +10,8 @@ import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/materia
 import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
-import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { MatSliderModule } from '@angular/material/slider';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
 
 import { ProjectorModule } from '../../../../modules/projector/projector.module';

--- a/client/src/app/ui/modules/import-list/components/import-list/import-list.component.ts
+++ b/client/src/app/ui/modules/import-list/components/import-list/import-list.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { MatLegacySelectChange as MatSelectChange } from '@angular/material/legacy-select';
-import { MatLegacyTab as MatTab, MatLegacyTabChangeEvent as MatTabChangeEvent } from '@angular/material/legacy-tabs';
+import { MatTab, MatTabChangeEvent } from '@angular/material/tabs';
 import { marker as _ } from '@colsen1991/ngx-translate-extract-marker';
 import { auditTime, distinctUntilChanged, firstValueFrom, map, Observable, of } from 'rxjs';
 import { Identifiable } from 'src/app/domain/interfaces';

--- a/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
+++ b/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { MatLegacySelectChange as MatSelectChange } from '@angular/material/legacy-select';
-import { MatLegacyTab as MatTab, MatLegacyTabChangeEvent as MatTabChangeEvent } from '@angular/material/legacy-tabs';
+import { MatTab, MatTabChangeEvent } from '@angular/material/tabs';
 import { marker as _ } from '@colsen1991/ngx-translate-extract-marker';
 import { TranslateService } from '@ngx-translate/core';
 import { delay, firstValueFrom, map, Observable, of } from 'rxjs';

--- a/client/src/app/ui/modules/import-list/import-list.module.ts
+++ b/client/src/app/ui/modules/import-list/import-list.module.ts
@@ -8,7 +8,7 @@ import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-c
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
-import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
 import { ScrollingTableModule } from 'src/app/ui/modules/scrolling-table';
 

--- a/client/src/app/ui/modules/import-list/import-list.module.ts
+++ b/client/src/app/ui/modules/import-list/import-list.module.ts
@@ -8,8 +8,8 @@ import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-c
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { MatTabsModule } from '@angular/material/tabs';
 import { ScrollingTableModule } from 'src/app/ui/modules/scrolling-table';
 
 import { OpenSlidesTranslationModule } from '../../../site/modules/translations';

--- a/client/src/app/ui/modules/vertical-tab-group/components/vertical-tab-group/vertical-tab-group.component.ts
+++ b/client/src/app/ui/modules/vertical-tab-group/components/vertical-tab-group/vertical-tab-group.component.ts
@@ -9,7 +9,7 @@ import {
     QueryList,
     TemplateRef
 } from '@angular/core';
-import { MatLegacyTab as MatTab } from '@angular/material/legacy-tabs';
+import { MatTab } from '@angular/material/tabs';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { ViewPortService } from 'src/app/site/services/view-port.service';
 

--- a/client/src/app/ui/modules/vertical-tab-group/vertical-tab-group.module.ts
+++ b/client/src/app/ui/modules/vertical-tab-group/vertical-tab-group.module.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
-import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
+import { MatTabsModule } from '@angular/material/tabs';
 
 import { VerticalTabGroupComponent } from './components/vertical-tab-group/vertical-tab-group.component';
 import { VerticalTabGroupLabelHeaderDirective } from './directives/vertical-tab-group-label-header.directive';

--- a/client/src/assets/styles/tables.scss
+++ b/client/src/assets/styles/tables.scss
@@ -27,7 +27,9 @@
 }
 
 // most mat-lists are NGrid already. Group-List and Workflow-Detail still require these.
-.mat-table {
+// TODO(mdc-migration) Remove mat-table once migrated
+.mat-table,
+.mat-mdc-table {
     width: 100%;
 
     /** nide the anchor column from head row */

--- a/client/src/assets/styles/theme-styles.scss
+++ b/client/src/assets/styles/theme-styles.scss
@@ -9,12 +9,16 @@
 @import 'global-components-style.scss';
 
 .openslides-light-theme {
+    /*TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated */
     @include mat.all-legacy-component-themes($openslides-light-theme);
+    @include mat.all-component-themes($openslides-light-theme);
     @include os-component-themes($openslides-light-theme);
 }
 
 .openslides-dark-theme {
+    /*TODO(mdc-migration): Remove all-legacy-component-colors once all legacy components are migrated */
     @include mat.all-legacy-component-colors($openslides-dark-theme);
+    @include mat.all-component-colors($openslides-dark-theme);
     @include os-component-themes($openslides-dark-theme);
 }
 

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -7,11 +7,17 @@
 //  If you specify typography styles for the components you use elsewhere, you should delete this line.
 //  If you don't need the default component typographies but still want the hierarchy styles,
 //  you can delete this line and instead use:
-//    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());`
+//    `@include mat.legacy-typography-hierarchy(mat.define-typography-config());`
+/* TODO(mdc-migration): Remove all-legacy-component-typographies once all legacy components are migrated */
 @include mat.all-legacy-component-typographies(
     mat.define-legacy-typography-config($font-family: "OSFont, Fira Sans, Roboto, Arial, Helvetica, sans-serif")
 );
+@include mat.all-component-typographies(
+    mat.define-legacy-typography-config($font-family: "OSFont, Fira Sans, Roboto, Arial, Helvetica, sans-serif")
+);
+/* TODO(mdc-migration): Remove legacy-core once all legacy components are migrated */
 @include mat.legacy-core();
+@include mat.core();
 
 /** theming */
 @import './assets/styles/theme-styles.scss';


### PR DESCRIPTION
part of #2934 

There was a problem reported that there are conflicts with the legacy tabs component and the mdc tab component. For that reason I migrated the tab component usages. 
Tabs are used for example by the topic import page and on the chat page. 
Note that the tabs look slightly different now as described here https://material.angular.io/guide/mdc-migration#tabs. 

I also updated the `mat-slider` in the projector edit dialog. The new style is also a bit different but fits nicely IMHO. 