### PR TITLE
Fix reload cancel causing issues

### DIFF
--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call/call.component.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call/call.component.ts
@@ -120,7 +120,7 @@ export class CallComponent extends BaseMeetingComponent implements OnInit, After
 
     // closing the tab should also try to stop jitsi.
     // this will usually not be caught by ngOnDestroy
-    @HostListener(`window:beforeunload`)
+    @HostListener(`window:unload`)
     public beforeunload(): void {
         this.rtcService.stopJitsi();
     }

--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/stream/stream.component.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/stream/stream.component.ts
@@ -79,7 +79,7 @@ export class StreamComponent extends BaseMeetingComponent implements AfterViewIn
 
     // closing the tab should also try to stop jitsi.
     // this will usually not be caught by ngOnDestroy
-    @HostListener(`window:beforeunload`)
+    @HostListener(`window:unload`)
     public async beforeunload(): Promise<void> {
         this.beforeViewCloses();
     }

--- a/client/src/app/site/services/autoupdate/autoupdate.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate.service.ts
@@ -107,7 +107,7 @@ export class AutoupdateService {
             })
         );
 
-        window.addEventListener(`beforeunload`, () => {
+        window.addEventListener(`unload`, () => {
             for (const id of Object.keys(this._activeRequestObjects)) {
                 const streamId = Number(id);
                 const { modelSubscription } = this._activeRequestObjects[streamId];


### PR DESCRIPTION
resolves #2962 

This fixes also some other places where a canceled reload might cause problems. While these events should not be used as of https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event to detect a page getting closed this will improve the current situation. 

In the future we might want to change this especially for the polling connection handling. 
The problems this could cause are documented here: https://github.com/OpenSlides/openslides-client/issues/2962#issuecomment-1828283669