### PR TITLE
Fix autoupdate handleError error type check

### DIFF
--- a/client/src/app/gateways/http-stream/http-stream.service.ts
+++ b/client/src/app/gateways/http-stream/http-stream.service.ts
@@ -25,7 +25,7 @@ interface RequestOptions {
     paramsFn?: HttpParamsGetter;
 }
 
-enum PossibleStreamError {
+export enum PossibleStreamError {
     AUTH = `auth`
 }
 
@@ -93,7 +93,7 @@ export class HttpStreamService {
     }
 
     private shouldReconnect({ error }: ShouldReconnectContext): boolean | Promise<boolean> {
-        if (error.error?.type === PossibleStreamError.AUTH) {
+        if (error.error?.type === PossibleStreamError.AUTH || error?.type === PossibleStreamError.AUTH) {
             this.authService.logout();
             return false;
         }

--- a/client/src/app/gateways/http-stream/http-stream.ts
+++ b/client/src/app/gateways/http-stream/http-stream.ts
@@ -328,7 +328,6 @@ export class HttpStream<T> {
     }
 
     private async handleStreamError(error: unknown): Promise<void> {
-        console.log(error);
         if (error instanceof HttpErrorResponse) {
             try {
                 error = this.parseCommunicationError(error.error as any, error);

--- a/client/src/app/gateways/http-stream/http-stream.ts
+++ b/client/src/app/gateways/http-stream/http-stream.ts
@@ -9,6 +9,7 @@ import * as fzstd from 'fzstd';
 import { firstValueFrom, Observable, Subscription } from 'rxjs';
 
 import { EndpointConfiguration } from './endpoint-configuration';
+import { PossibleStreamError } from './http-stream.service';
 import {
     CommunicationError,
     CommunicationErrorWrapper,
@@ -327,10 +328,10 @@ export class HttpStream<T> {
     }
 
     private async handleStreamError(error: unknown): Promise<void> {
+        console.log(error);
         if (error instanceof HttpErrorResponse) {
-            error = error.error;
             try {
-                error = this.parseCommunicationError(error as any);
+                error = this.parseCommunicationError(error.error as any, error);
             } catch (e) {}
         }
         this.handleError(error);
@@ -402,7 +403,7 @@ export class HttpStream<T> {
         }
     }
 
-    private parseCommunicationError(text: string): CommunicationError {
+    private parseCommunicationError(text: string, error?: HttpErrorResponse): CommunicationError {
         try {
             const errorBody = JSON.parse(text) as CommunicationError | CommunicationErrorWrapper;
             if (isCommunicationError(errorBody)) {
@@ -410,6 +411,9 @@ export class HttpStream<T> {
             }
             if (isCommunicationErrorWrapper(errorBody)) {
                 return errorBody.error;
+            }
+            if (error.status === 401) {
+                return { msg: `Unauthorized`, type: PossibleStreamError.AUTH };
             }
         } catch (e) {
             return {

--- a/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
@@ -245,7 +245,9 @@ export class AutoupdateCommunicationService {
     }
 
     private handleReceiveError(data: AutoupdateReceiveError): void {
-        if (data.content.data?.terminate) {
+        if (data.content.data?.reason === `Logout`) {
+            this.authService.logout();
+        } else if (data.content.data?.terminate) {
             this.tryReconnectOpen = true;
             this.matSnackBar
                 .open(

--- a/client/src/app/site/services/operator.service.ts
+++ b/client/src/app/site/services/operator.service.ts
@@ -450,7 +450,7 @@ export class OperatorService {
                 );
                 this._currentOperatorDataSubscription = await this.autoupdateService.subscribe(
                     await this.modelRequestBuilder.build(operatorRequest),
-                    `operator_${this.operatorId || 0}:subscription`
+                    `operator:subscription`
                 );
             })();
         }

--- a/client/src/app/site/services/operator.service.ts
+++ b/client/src/app/site/services/operator.service.ts
@@ -450,7 +450,7 @@ export class OperatorService {
                 );
                 this._currentOperatorDataSubscription = await this.autoupdateService.subscribe(
                     await this.modelRequestBuilder.build(operatorRequest),
-                    `operator:subscription`
+                    `operator_${this.operatorId || 0}:subscription`
                 );
             })();
         }

--- a/client/src/app/worker/autoupdate/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate/autoupdate-stream-pool.ts
@@ -361,7 +361,7 @@ export class AutoupdateStreamPool {
             await this.waitUntilEndpointHealthy();
         }
 
-        if (stream.failedConnects <= POOL_CONFIG.RETRY_AMOUNT && error?.reason !== ErrorType.CLIENT) {
+        if (stream.failedConnects <= POOL_CONFIG.RETRY_AMOUNT && error?.type !== ErrorType.CLIENT) {
             if (error?.error.content?.type === `auth`) {
                 await this.updateAuthentication();
             }

--- a/client/src/app/worker/autoupdate/autoupdate-subscription.ts
+++ b/client/src/app/worker/autoupdate/autoupdate-subscription.ts
@@ -33,12 +33,13 @@ export class AutoupdateSubscription {
      *
      * @param port The MessagePort the id should be send to
      */
-    public publishSubscriptionId(port: MessagePort): void {
+    public publishSubscriptionId(port: MessagePort, requestHash?: string): void {
         port.postMessage({
             sender: `autoupdate`,
             action: `set-streamid`,
             content: {
-                requestHash: this.requestHash,
+                description: this.description,
+                requestHash: requestHash || this.requestHash,
                 streamId: this.id
             }
         } as AutoupdateSetStreamId);
@@ -88,9 +89,9 @@ export class AutoupdateSubscription {
      *
      * @param port The port to be registered
      */
-    public addPort(port: MessagePort): void {
+    public addPort(port: MessagePort, requestHash?: string): void {
         this.ports.push(port);
-        this.publishSubscriptionId(port);
+        this.publishSubscriptionId(port, requestHash);
         this.resendTo(port);
 
         this.stream?.notifySubscriptionUsed(this);

--- a/client/src/app/worker/sw-autoupdate.ts
+++ b/client/src/app/worker/sw-autoupdate.ts
@@ -98,7 +98,7 @@ function openConnection(
     for (const queue of Object.keys(subscriptionQueues)) {
         const fulfillingSubscription = subscriptionQueues[queue].find(s => s.fulfills(queryParams, request));
         if (fulfillingSubscription) {
-            fulfillingSubscription.addPort(ctx);
+            fulfillingSubscription.addPort(ctx, requestHash);
             return;
         }
     }
@@ -112,10 +112,10 @@ function openConnection(
             autoupdatePool.addSubscription(subscription, existingSubscription.stream);
             subscription.resendTo(ctx);
         } else {
-            existingSubscription.addPort(ctx);
+            existingSubscription.addPort(ctx, requestHash);
         }
 
-        if (!existingSubscription.stream.active) {
+        if (!existingSubscription.stream?.active) {
             autoupdatePool.reconnect(existingSubscription.stream, false);
         }
         return;


### PR DESCRIPTION
Client errors are currently not correctly handled by the shared worker. This could result in unexpected behavior when the autoupdate reports an client error. 

resolves #3071