### PR TITLE
Fix import error handling and cleanup participant import icons

### DIFF
--- a/client/src/app/gateways/error-mapping/error-map-utils.ts
+++ b/client/src/app/gateways/error-mapping/error-map-utils.ts
@@ -54,6 +54,9 @@ const MeetingCreateErrorMap: ErrorMap = new ErrorMap([
  */
 const getActionErrorMap: (data: any) => ErrorMap | null = data => {
     const actionName = Array.isArray(data) && typeof data[0] === `object` ? data[0][`action`] : null;
+    if (typeof actionName === `string` && actionName.endsWith(`.import`)) {
+        return MatchAllErrorMap;
+    }
     switch (actionName) {
         case MeetingAction.CREATE:
             return MeetingCreateErrorMap;

--- a/client/src/app/gateways/error-mapping/error-map-utils.ts
+++ b/client/src/app/gateways/error-mapping/error-map-utils.ts
@@ -54,9 +54,6 @@ const MeetingCreateErrorMap: ErrorMap = new ErrorMap([
  */
 const getActionErrorMap: (data: any) => ErrorMap | null = data => {
     const actionName = Array.isArray(data) && typeof data[0] === `object` ? data[0][`action`] : null;
-    if (typeof actionName === `string` && actionName.endsWith(`.import`)) {
-        return MatchAllErrorMap;
-    }
     switch (actionName) {
         case MeetingAction.CREATE:
             return MeetingCreateErrorMap;
@@ -65,6 +62,9 @@ const getActionErrorMap: (data: any) => ErrorMap | null = data => {
         case UserAction.SET_PASSWORD_SELF:
             return MatchAllErrorMap;
         default:
+            if (typeof actionName === `string` && actionName.endsWith(`.import`)) {
+                return MatchAllErrorMap;
+            }
             return null;
     }
 };

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.html
@@ -20,24 +20,4 @@
             | translate
     }}"
     modelName="Participant"
->
-    <!-- <ng-template osImportListStatusTemplate let-row="row">
-        <div *ngIf="row.status === 'merge'">
-            <mat-icon matTooltip="{{ ('Participant' | translate) + ' ' + ('will be referenced' | translate) }}">
-                merge_type
-            </mat-icon>
-        </div>
-    </ng-template> -->
-
-    <!-- <div *osScrollingTableCell="'group_ids'; row as entry">
-        <div *osScrollingTableCellLabel>{{ 'Groups' | translate }}</div>
-        <os-comma-separated-listing [list]="entry.newEntry.group_ids">
-            <ng-template let-group>
-                <span>{{ group.name }}</span>
-                <span *ngIf="!group.id">
-                    <mat-icon color="accent">add</mat-icon>
-                </span>
-            </ng-template>
-        </os-comma-separated-listing>
-    </div> -->
-</os-backend-import-list>
+></os-backend-import-list>

--- a/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
+++ b/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
@@ -356,6 +356,8 @@ export class BackendImportListComponent implements OnInit, OnDestroy {
                 return this._state !== BackendImportPhase.FINISHED ? `merge` : `done`;
             case BackendImportState.Generated:
                 return `autorenew`;
+            case BackendImportState.Remove:
+                return `remove`;
             default:
                 return `block`; // fallback: Error
         }

--- a/client/src/app/ui/modules/import-list/definitions/backend-import-preview.ts
+++ b/client/src/app/ui/modules/import-list/definitions/backend-import-preview.ts
@@ -5,7 +5,8 @@ export enum BackendImportState {
     Warning = `warning`,
     New = `new`,
     Done = `done`,
-    Generated = `generated`
+    Generated = `generated`,
+    Remove = `remove`
     // could be expanded later
 }
 


### PR DESCRIPTION
In this PR I did the following:

1. Previously when the import failed with a non-preview-related error (i.e. a string error that doesn't update the preview with an explanation), a snackbar with the error would be shown, but the view would continue showing the preview in a context that implied the import to still be ongoing. -> Fixed that by making the view revert to a clean pre-import state
2. The participant import has a system where trying to change fields that the user has no right to edit will get the field payload removed. This is signified in the preview through a new field state `remove`. Until now that state had no associated icon, causing such fields to show the default icon `block`, which suggests that there is an error on that field, when really there isn't -> Made OpenSlides use the `remove` icon for fields with the `remove` state.