### PR TITLE
Imports: Make sure file can be re-added after import fails with error

### DIFF
--- a/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
+++ b/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.ts
@@ -252,6 +252,9 @@ export class BackendImportListComponent implements OnInit, OnDestroy {
         this._importer.clearAll();
         this._requiredFields = this.createRequiredFields();
         this._importer.currentImportPhaseObservable.subscribe(phase => {
+            if (phase === BackendImportPhase.LOADING_PREVIEW && this.fileInput) {
+                this.fileInput.nativeElement.value = ``;
+            }
             this._state = phase;
         });
         this._importer.previewsObservable.subscribe(previews => {
@@ -291,13 +294,6 @@ export class BackendImportListComponent implements OnInit, OnDestroy {
      */
     public onSelectFile(event: any): void {
         this._importer.onSelectFile(event);
-    }
-
-    /**
-     * Triggers the importer's import
-     */
-    public async doImport(): Promise<void> {
-        this._importer.doImport();
     }
 
     /**


### PR DESCRIPTION
Closes #3100 

The original method of reproduction should be fixed by now, I don't know how to reproduce it on the other imports.

I would suggest using a purposefully broken backend to test this.
Simply temporarily add the line `raise ActionException("random text")` at the top of the the `participant_import.py`'s `validate_entry` method, restart your dev environment, then try uploading a participant csv file in the participant import.