### PR TITLE
Fix a problem with navigation back from structure level

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/structure-levels/components/structure-level-list/structure-level-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/structure-levels/components/structure-level-list/structure-level-list.component.html
@@ -6,7 +6,7 @@
 </os-head-bar>
 
 <os-list
-    [listObservable]="repo.getViewModelListObservable()"
+    [listObservableProvider]="repo"
     [(selectedRows)]="selectedRows"
     listStorageKey="structure_levels"
     [vScrollFixed]="60"

--- a/client/src/app/site/pages/meetings/pages/participants/participants-routing.module.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/participants-routing.module.ts
@@ -47,7 +47,8 @@ const routes: Routes = [
             {
                 path: `structure-levels`,
                 loadChildren: () =>
-                    import(`./pages/structure-levels/structure-level.module`).then(m => m.StructureLevelModule)
+                    import(`./pages/structure-levels/structure-level.module`).then(m => m.StructureLevelModule),
+                data: { meetingPermissions: [Permission.userCanManage] }
             },
             {
                 path: ``,


### PR DESCRIPTION
Fix a problem with the structure level list component.
It should be possible to use the arrow-right to go back to participants.
Also add perms to structure level