### PR TITLE
Add a use color checkbox in structure level

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/structure-levels/components/structure-level-list/structure-level-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/structure-levels/components/structure-level-list/structure-level-list.component.html
@@ -78,6 +78,9 @@
                 </mat-error>
             </mat-form-field>
             <!-- Colour -->
+            <mat-checkbox formControlName="color_check" (change)="onColorCheckChanged()">
+                {{ 'Use color' | translate }}
+            </mat-checkbox>
             <mat-form-field class="os-dialog-large">
                 <mat-label>{{ 'Color' | translate }}</mat-label>
                 <input formControlName="color" type="color" matInput />

--- a/client/src/app/site/pages/meetings/pages/participants/pages/structure-levels/components/structure-level-list/structure-level-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/structure-levels/components/structure-level-list/structure-level-list.component.ts
@@ -58,6 +58,7 @@ export class StructureLevelListComponent extends BaseMeetingListViewComponent<Vi
         super.setTitle(`Structure Levels`);
         this.structureLevelForm = this.formBuilder.group({
             name: [``, Validators.required],
+            color_check: false,
             color: [``, Validators.pattern(/^#[0-9a-fA-F]{6}$/)]
         });
     }
@@ -68,12 +69,15 @@ export class StructureLevelListComponent extends BaseMeetingListViewComponent<Vi
     public openStructureLevelDialog(structureLevel: ViewStructureLevel | null = null): void {
         this.currentStructureLevel = structureLevel;
         this.reset();
-        this.structureLevelForm
-            .get(`name`)!
-            .setValue(this.currentStructureLevel ? this.currentStructureLevel.name : ``);
+        this.structureLevelForm.get(`name`)!.setValue(structureLevel ? structureLevel.name : ``);
+        if (structureLevel && !!structureLevel.color) {
+            this.structureLevelForm.get(`color_check`).setValue(true);
+        } else {
+            this.structureLevelForm.get(`color`).disable();
+        }
         this.structureLevelForm
             .get(`color`)!
-            .setValue(this.currentStructureLevel ? this.currentStructureLevel.color : `#000000`);
+            .setValue(structureLevel && !!structureLevel.color ? structureLevel.color : `#000000`);
         this.dialogRef = this.dialog.open(this.structureLevelDialog!, infoDialogSettings);
         this.dialogRef.afterClosed().subscribe(res => {
             if (res) {
@@ -110,6 +114,19 @@ export class StructureLevelListComponent extends BaseMeetingListViewComponent<Vi
     }
 
     /**
+     * if color_check is not set, disable color.
+     * if color_check is set, enable color.
+     */
+
+    public onColorCheckChanged(): void {
+        if (this.structureLevelForm.get(`color_check`).value) {
+            this.structureLevelForm.get(`color`).enable();
+        } else {
+            this.structureLevelForm.get(`color`).disable();
+        }
+    }
+
+    /**
      * Submit the form and create or update a structure level.
      */
     private save(): void {
@@ -126,7 +143,11 @@ export class StructureLevelListComponent extends BaseMeetingListViewComponent<Vi
 
     private updateStructureLevel(): void {
         if (this.currentStructureLevel) {
-            this.repo.update(this.structureLevelForm.value, this.currentStructureLevel.id).catch(this.raiseError);
+            const data = this.structureLevelForm.value;
+            if (!data.color) {
+                data.color = null;
+            }
+            this.repo.update(data, this.currentStructureLevel.id).catch(this.raiseError);
         }
     }
 


### PR DESCRIPTION
Add a "use color" checkbox to the structure level dialog.
S.o. wants to have structure levels without a color and I talked to @Elblinator about this "feature". We want this click adventure for the customers.