### PR TITLE
Add identical motions

### DIFF
--- a/client/src/app/domain/models/motions/motion.ts
+++ b/client/src/app/domain/models/motions/motion.ts
@@ -66,6 +66,7 @@ export class Motion extends BaseModel<Motion> implements MotionFormattingReprese
     public derived_motion_ids!: Id[]; // motion/all_origin_ids;
     public all_derived_motion_ids!: Id[]; // (motion/origin_id)[];
     public all_origin_ids!: Id[]; // motion/all_derived_motion_ids;
+    public identical_motion_ids!: Id[]; // motion/identical_motion_ids;
     public state_id!: Id; // motion_state/motion_ids;
     public recommendation_id!: Id; // motion_state/motion_recommendation_ids;
     public state_extension_reference_ids!: Fqid[]; // (*/referenced_in_motion_state_extension_ids)[];

--- a/client/src/app/infrastructure/definitions/relations/relations.ts
+++ b/client/src/app/infrastructure/definitions/relations/relations.ts
@@ -707,9 +707,7 @@ export const RELATIONS: Relation[] = [
         MViewModel: ViewMotion,
         OViewModel: ViewMotion,
         MField: `origin`,
-        MIdField: `origin_id`,
-        OField: `derived_motions`,
-        OIdField: `derived_motion_ids`
+        OField: `derived_motions`
     }),
     ...makeM2O({
         MViewModel: ViewMotion,
@@ -721,9 +719,13 @@ export const RELATIONS: Relation[] = [
         AViewModel: ViewMotion,
         BViewModel: ViewMotion,
         AField: `all_origins`,
-        AIdField: `all_origin_ids`,
-        BField: `all_derived_motions`,
-        BIdField: `all_derived_motion_ids`
+        BField: `all_derived_motions`
+    }),
+    ...makeM2M({
+        AViewModel: ViewMotion,
+        BViewModel: ViewMotion,
+        AField: `identical_motions`,
+        BField: `identical_motions`
     }),
     ...makeM2O({
         MViewModel: ViewMotion,

--- a/client/src/app/site/pages/meetings/pages/motions/motions.subscription.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/motions.subscription.ts
@@ -206,6 +206,7 @@ export const getMotionDetailSubscriptionConfig: SubscriptionConfigGenerator = (.
             `all_origin_ids`,
             `origin_meeting_id`,
             `derived_motion_ids`,
+            `identical_motion_ids`,
             `amendment_ids`,
             `amendment_paragraphs`
         ]

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.html
@@ -253,6 +253,16 @@
     </div>
 </div>
 
+<!-- Identical motions -->
+<div *ngIf="motion?.identical_motions?.length">
+    <h4>{{ 'Identical motions' | translate }}</h4>
+    <ng-container *ngFor="let identicalMotion of motion?.identical_motions">
+        <a [routerLink]="['/', activeMeetingId, 'motions', identicalMotion.id]" [state]="{ back: 'true' }">
+            {{ identicalMotion.getTitle() }}
+        </a>
+    </ng-container>
+</div>
+
 <!-- Amendments -->
 <div *ngIf="amendments && amendments.length > 0">
     <h4>{{ 'Amendments' | translate }}</h4>

--- a/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
@@ -361,6 +361,7 @@ interface IMotionRelations extends HasPolls<ViewMotion> {
     derived_motions?: ViewMotion[];
     all_derived_motions?: ViewMotion[];
     all_origins?: ViewMotion[];
+    identical_motions?: ViewMotion[];
     state?: ViewMotionState;
     state_extension_references: (BaseViewModel & HasReferencedMotionsInExtension)[];
     recommendation?: ViewMotionState;


### PR DESCRIPTION
closes #3155 

needs https://github.com/OpenSlides/openslides-backend/pull/2146 & https://github.com/OpenSlides/openslides-autoupdate-service/pull/824

@rrenkert I just listed the identical motions in the detail view for now. If we want to do something with it like mark it more prominently or somehow notify the user, you'll have to specify what to do.