### PR TITLE
Fix user edit for illegal legacy username

### DIFF
--- a/client/src/app/site/modules/user-components/components/user-detail-view/user-detail-view.component.ts
+++ b/client/src/app/site/modules/user-components/components/user-detail-view/user-detail-view.component.ts
@@ -314,7 +314,8 @@ export class UserDetailViewComponent extends BaseUiComponent implements OnInit, 
     private propagateValues(): void {
         setTimeout(() => {
             // setTimeout prevents 'ExpressionChangedAfterItHasBeenChecked'-error
-            this.changeEvent.emit(this.getChangedValues(this.personalInfoForm.value));
+            const changes = this.getChangedValues(this.personalInfoForm.value);
+            this.changeEvent.emit(changes);
             this.validEvent.emit(this.personalInfoForm.valid && (this.isNewUser || this._hasChanges));
             this.errorEvent.emit(this.personalInfoForm.errors);
         });
@@ -324,7 +325,7 @@ export class UserDetailViewComponent extends BaseUiComponent implements OnInit, 
         return (control: AbstractControl): ValidationErrors | null => {
             const value = control.value;
 
-            if (!value) {
+            if (!value || control.pristine) {
                 return null;
             }
 
@@ -346,6 +347,11 @@ export class UserDetailViewComponent extends BaseUiComponent implements OnInit, 
                     this.personalInfoForm.get(key).markAsTouched();
                 }
             });
+            for (const key of Object.keys(newData)) {
+                if (this.personalInfoForm.get(key).pristine) {
+                    delete newData[key];
+                }
+            }
             if (this.user.saml_id && newData[`default_password`]) {
                 delete newData[`default_password`];
             }

--- a/client/src/app/site/modules/user-components/components/user-detail-view/user-detail-view.component.ts
+++ b/client/src/app/site/modules/user-components/components/user-detail-view/user-detail-view.component.ts
@@ -325,7 +325,7 @@ export class UserDetailViewComponent extends BaseUiComponent implements OnInit, 
         return (control: AbstractControl): ValidationErrors | null => {
             const value = control.value;
 
-            if (!value || control.pristine) {
+            if (!value || (this.user?.id && control.pristine)) {
                 return null;
             }
 
@@ -347,9 +347,11 @@ export class UserDetailViewComponent extends BaseUiComponent implements OnInit, 
                     this.personalInfoForm.get(key).markAsTouched();
                 }
             });
-            for (const key of Object.keys(newData)) {
-                if (this.personalInfoForm.get(key).pristine) {
-                    delete newData[key];
+            if (this.user.id) {
+                for (const key of Object.keys(newData)) {
+                    if (this.personalInfoForm.get(key).pristine) {
+                        delete newData[key];
+                    }
                 }
             }
             if (this.user.saml_id && newData[`default_password`]) {


### PR DESCRIPTION
Closes #3250 

Should filter out most unchanged keys if it is an update, please check if this breaks _any_ field in account or participant edit.
Also check for create nothing should be changed.
Also check what happens if you edit a user, save, and then edit again.

This PR _should_ also make it possible to save even if a legacy username with empty spaces is left unchanged in the preview. Idk, I couldn't test it