### PR TITLE
Fix participant structure level not displayed in autopilot

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/participants.subscription.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/participants.subscription.ts
@@ -88,7 +88,8 @@ export const getParticipantMinimalSubscriptionConfig: SubscriptionConfigGenerato
                         idField: `user_id`,
                         fieldset: `participantListMinimal`,
                         additionalFields: [`is_present_in_meeting_ids`]
-                    }
+                    },
+                    { idField: `structure_level_ids`, fieldset: [`name`] }
                 ]
             }
         ]


### PR DESCRIPTION
Currently the structure levels are not displayed in the los participant selection if a structure level has not spoken yet. 