### PR TITLE
Handle projection options visibility in speaking times

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/speaking-times/speaking-times.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/speaking-times/speaking-times.component.html
@@ -1,7 +1,7 @@
 <div class="action-title">
     <p class="subtitle-text" translate>Speaking times</p>
     <ng-container *osPerms="permission.projectorCanManage">
-        <button type="button" mat-icon-button [matMenuTriggerFor]="projectionMenu">
+        <button type="button" *ngIf="showProjectionMenu" mat-icon-button [matMenuTriggerFor]="projectionMenu">
             <mat-icon>more_horiz</mat-icon>
         </button>
     </ng-container>

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/speaking-times/speaking-times.component.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/speaking-times/speaking-times.component.ts
@@ -51,6 +51,9 @@ export class SpeakingTimesComponent implements OnDestroy {
     public hasSpokenFlag = false;
 
     @Input()
+    public showProjectionMenu = false;
+
+    @Input()
     public set currentSpeakingTimes(speakingTimes: Id[]) {
         const newSpeakingTimes = new Set(speakingTimes);
         const subscribedIds = new Set(this.subscriptions.keys());

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/components/list-of-speakers/list-of-speakers.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/components/list-of-speakers/list-of-speakers.component.html
@@ -51,6 +51,7 @@
             <mat-card-content>
                 <os-speaking-times
                     [currentSpeakingTimes]="viewListOfSpeakers.structure_level_list_of_speakers_ids"
+                    [showProjectionMenu]="true"
                 ></os-speaking-times>
             </mat-card-content>
         </mat-card>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -118,6 +118,7 @@
         <mat-card-content>
             <os-speaking-times
                 [currentSpeakingTimes]="listOfSpeakers.structure_level_list_of_speakers_ids"
+                [showProjectionMenu]="false"
             ></os-speaking-times>
         </mat-card-content>
     </mat-card>


### PR DESCRIPTION
Don't show projection options in autopilot.
Show projection options in los detail view.

Resolve #3295 

Replaces the pr #3300 