### PR TITLE
Remove default structure level the from account detail view

### DIFF
--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail/account-detail.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail/account-detail.component.html
@@ -37,17 +37,6 @@
     <ng-template #editView let-form="form">
         <h2>{{ 'Organization specific information' | translate }}</h2>
         <div [formGroup]="form">
-            <!-- Default Strucuture Level -->
-            <mat-form-field
-                class="distance"
-                [ngClass]="{
-                    form37: true
-                }"
-            >
-                <mat-label>{{ 'Default structure level' | translate }}</mat-label>
-                <input type="text" matInput formControlName="default_structure_level" />
-            </mat-form-field>
-
             <!-- Default Vote weight -->
             <!-- TODO Input type should be number with limited decimal spaces -->
             <mat-form-field class="form16 force-min-with">
@@ -100,11 +89,6 @@
 
     <ng-template #showView let-user="user">
         <h2>{{ 'Organization specific information' | translate }}</h2>
-        <!-- Structure level -->
-        <div *ngIf="user.default_structure_level">
-            <h4>{{ 'Default structure level' | translate }}</h4>
-            <span>{{ user.default_structure_level }}</span>
-        </div>
 
         <div *ngIf="user.default_vote_weight || user.default_vote_weight === 0">
             <h4>{{ 'Default vote weight' | translate }}</h4>


### PR DESCRIPTION
Resolve #3316 

I looked into the code and didn't find a reason, not to exclude this. The control is already gone and there are no other
ref.