### PR TITLE
Hide moderation note if no agenda item assigned

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
@@ -2,7 +2,7 @@
 <mat-card
     class="spacer-bottom-60 card-padding"
     [ngClass]="isEditing ? 'os-form-card' : 'os-card'"
-    *ngIf="canSeeModerationNote && (canManageModerationNote || (moderatorNotes | async))"
+    *ngIf="agendaItem && canSeeModerationNote && (canManageModerationNote || (moderatorNotes | async))"
 >
     <!-- Title edit/save/cancle-->
     <div class="action-title">


### PR DESCRIPTION
Hides moderation note if content object is not assigned to an agenda item. 

resolves #3328 