### PR TITLE
Update service worker caching

### DIFF
--- a/client/ngsw-config.json
+++ b/client/ngsw-config.json
@@ -1,28 +1,32 @@
 {
     "$schema": "./node_modules/@angular/service-worker/config/schema.json",
     "index": "/index.html",
+    "version": 2,
     "assetGroups": [
         {
             "name": "app",
-            "installMode": "prefetch",
+            "installMode": "lazy",
             "resources": {
                 "files": [
                     "/favicon.ico",
                     "/index.html",
                     "/manifest.webmanifest",
                     "/*.css",
-                    "/*.js",
-                    "/fira-sans*",
-                    "/Material-Icons-Baseline.*"
+                    "/*.js"
                 ]
             }
         },
         {
             "name": "assets",
             "installMode": "lazy",
-            "updateMode": "prefetch",
+            "updateMode": "lazy",
             "resources": {
-                "files": ["/assets/**", "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"]
+                "files": [
+                    "/assets/**",
+                    "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)",
+                    "/fira-sans*",
+                    "/Material-Icons-Baseline.*"
+                ]
             }
         }
     ],

--- a/client/ngsw-config.json
+++ b/client/ngsw-config.json
@@ -5,12 +5,10 @@
     "assetGroups": [
         {
             "name": "app",
-            "installMode": "lazy",
+            "installMode": "prefetch",
             "resources": {
                 "files": [
-                    "/favicon.ico",
                     "/index.html",
-                    "/manifest.webmanifest",
                     "/*.css",
                     "/*.js"
                 ]
@@ -19,12 +17,13 @@
         {
             "name": "assets",
             "installMode": "lazy",
-            "updateMode": "lazy",
             "resources": {
                 "files": [
                     "/assets/**",
                     "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)",
                     "/fira-sans*",
+                    "/favicon.ico",
+                    "/manifest.webmanifest",
                     "/Material-Icons-Baseline.*"
                 ]
             }

--- a/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
+++ b/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
@@ -126,7 +126,6 @@ export class OpenSlidesMainComponent implements OnInit {
         this.router.initialNavigation();
         await this.onInitDone;
 
-        console.time();
         try {
             if (
                 (await navigator.serviceWorker?.getRegistrations())?.length &&
@@ -135,10 +134,7 @@ export class OpenSlidesMainComponent implements OnInit {
                     new Promise((_, reject) => setTimeout(() => reject(), 3000))
                 ]))
             ) {
-                console.timeEnd();
-                if (confirm()) {
-                    await this.updateService.applyUpdate();
-                }
+                await this.updateService.applyUpdate();
                 return;
             } else {
                 this.updateService.checkForUpdate();
@@ -146,7 +142,6 @@ export class OpenSlidesMainComponent implements OnInit {
         } catch (_) {
             this.updateService.checkForUpdate();
         }
-        console.timeEnd();
 
         setTimeout(() => {
             this.lifecycleService.appLoaded.next();

--- a/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
+++ b/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
@@ -126,6 +126,7 @@ export class OpenSlidesMainComponent implements OnInit {
         this.router.initialNavigation();
         await this.onInitDone;
 
+        console.time();
         try {
             if (
                 (await navigator.serviceWorker?.getRegistrations())?.length &&
@@ -134,7 +135,10 @@ export class OpenSlidesMainComponent implements OnInit {
                     new Promise((_, reject) => setTimeout(() => reject(), 3000))
                 ]))
             ) {
-                await this.updateService.applyUpdate();
+                console.timeEnd();
+                if (confirm()) {
+                    await this.updateService.applyUpdate();
+                }
                 return;
             } else {
                 this.updateService.checkForUpdate();
@@ -142,6 +146,7 @@ export class OpenSlidesMainComponent implements OnInit {
         } catch (_) {
             this.updateService.checkForUpdate();
         }
+        console.timeEnd();
 
         setTimeout(() => {
             this.lifecycleService.appLoaded.next();


### PR DESCRIPTION
With this PR all assets which are not required for a working application are moved into the assets caching group with lazy resource download. 
Also the prefetch mode for already downloaded assets is changed to lazy. 

Additionally the version is increased which can as of https://angular.io/guide/service-worker-config#version be done on api changes. It seems like this unregisters the service worker which could help that at the latest after a reload nothing is left inside the shared worker cache. 