### PR TITLE
Add eslint rules

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -66,6 +66,8 @@ module.exports = {
                 '@typescript-eslint/no-this-alias': ['error'],
                 '@typescript-eslint/adjacent-overload-signatures': ['error'],
                 '@typescript-eslint/ban-types': ['error'],
+                '@typescript-eslint/explicit-member-accessibility': ['error'],
+                '@typescript-eslint/explicit-function-return-type': ['warn'],
 
                 'jsdoc/require-example': ['off'],
                 'jsdoc/newline-after-description': ['off'],
@@ -85,6 +87,8 @@ module.exports = {
             files: ['*.spec.ts'],
             rules: {
                 'no-restricted-globals': ['error', 'fdescribe', 'fit'],
+                '@typescript-eslint/explicit-member-accessibility': ['off'],
+                '@typescript-eslint/explicit-function-return-type': ['off'],
             }
         },
         {

--- a/client/src/app/domain/models/meetings/meeting.ts
+++ b/client/src/app/domain/models/meetings/meeting.ts
@@ -179,17 +179,17 @@ export class Settings {
     public assignment_poll_default_backend!: PollBackendDurationType;
 
     //topic poll
-    topic_poll_default_group_ids: Id[]; // (group/used_as_poll_default_id)[];
+    public topic_poll_default_group_ids: Id[]; // (group/used_as_poll_default_id)[];
 
     //default poll
-    poll_ballot_paper_selection: BallotPaperSelection;
-    poll_ballot_paper_number: number;
-    poll_sort_poll_result_by_votes: boolean;
-    poll_default_type: PollType;
-    poll_default_method: PollMethod;
-    poll_default_onehundred_percent_base: PollPercentBase;
-    poll_default_group_ids: Id[]; // (group/used_as_poll_default_id)[];
-    poll_default_backend: PollBackendDurationType;
+    public poll_ballot_paper_selection: BallotPaperSelection;
+    public poll_ballot_paper_number: number;
+    public poll_sort_poll_result_by_votes: boolean;
+    public poll_default_type: PollType;
+    public poll_default_method: PollMethod;
+    public poll_default_onehundred_percent_base: PollPercentBase;
+    public poll_default_group_ids: Id[]; // (group/used_as_poll_default_id)[];
+    public poll_default_backend: PollBackendDurationType;
 
     //SSO
     public external_id!: string;

--- a/client/src/app/gateways/action-worker-watch/action-worker-watch.service.ts
+++ b/client/src/app/gateways/action-worker-watch/action-worker-watch.service.ts
@@ -108,7 +108,7 @@ export class ActionWorkerWatchService {
      * Should only be used if the option to manage the handling of these specific action workers is done in a separate component.
      * @param actionName the (backend) name of the action for which there shouldn't be a dialog.
      */
-    public disableWaitDialog(actionName: string) {
+    public disableWaitDialog(actionName: string): void {
         if (!this._noDialogActionNames.find(name => name === actionName)) {
             this._noDialogActionNames.push(actionName);
         }
@@ -117,7 +117,7 @@ export class ActionWorkerWatchService {
     /**
      * May be used to reverse the effects of enableWaitDialog.
      */
-    public enableWaitDialog(actionName: string) {
+    public enableWaitDialog(actionName: string): void {
         const index = this._noDialogActionNames.findIndex(name => name === actionName);
         if (!(index === -1)) {
             this._noDialogActionNames.splice(index, 1);
@@ -163,7 +163,7 @@ export class ActionWorkerWatchService {
     /**
      * Deletes all workers from _toBeDeleted that have been in there for more than 10 seconds.
      */
-    private cleanup() {
+    private cleanup(): void {
         const toDelete = this._toBeDeleted
             .filter(date => (Date.now() - date.timestamp) / 1000 > 10)
             .map(date => date.workerId);

--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
@@ -372,7 +372,7 @@ export class HtmlToPdfService {
      * Takes a list of paragraphs and the data from which to calculate the next paragraph and appends the child node.
      * Can be overwritten by subclasses for more specific functionality.
      */
-    protected addChildNodeIntoParagraphs(paragraph: any[], data: ChildNodeParagraphPayload) {
+    protected addChildNodeIntoParagraphs(paragraph: any[], data: ChildNodeParagraphPayload): void {
         const parsedElement = this.parseElement(data.child, data.styles);
         paragraph.push(parsedElement);
     }

--- a/client/src/app/gateways/export/progress-snack-bar/services/progress-snack-bar.service.ts
+++ b/client/src/app/gateways/export/progress-snack-bar/services/progress-snack-bar.service.ts
@@ -12,7 +12,7 @@ import { ProgressSnackBarServiceModule } from './progress-snack-bar-service.modu
     providedIn: ProgressSnackBarServiceModule
 })
 export class ProgressSnackBarService {
-    constructor(private matSnackBar: MatSnackBar) {}
+    public constructor(private matSnackBar: MatSnackBar) {}
 
     public async open(config?: MatSnackBarConfig): Promise<MatSnackBarRef<ProgressSnackBarComponent>> {
         const module = await import(`../progress-snack-bar.module`).then(m => m.ProgressSnackBarModule);

--- a/client/src/app/gateways/presenter/get-active-users-amount-presenter.service.ts
+++ b/client/src/app/gateways/presenter/get-active-users-amount-presenter.service.ts
@@ -11,7 +11,7 @@ interface GetActiveUsersPresenterResult {
     providedIn: `root`
 })
 export class GetActiveUsersAmountPresenterService {
-    constructor(private presenter: PresenterService) {}
+    public constructor(private presenter: PresenterService) {}
 
     public async call(): Promise<number> {
         const response = await this.presenter.call<GetActiveUsersPresenterResult>(Presenter.GET_ACTIVE_USER_AMOUNT, {});

--- a/client/src/app/gateways/repositories/action-worker/action-worker-repository.service.ts
+++ b/client/src/app/gateways/repositories/action-worker/action-worker-repository.service.ts
@@ -9,7 +9,7 @@ import { ViewActionWorker } from './view-action-worker';
     providedIn: `root`
 })
 export class ActionWorkerRepositoryService extends BaseRepository<ViewActionWorker, ActionWorker> {
-    constructor(repositoryServiceCollector: RepositoryServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryServiceCollectorService) {
         super(repositoryServiceCollector, ActionWorker);
     }
 

--- a/client/src/app/gateways/repositories/assignments/assignment-candidate-repository.service/assignment-candidate-repository.service.ts
+++ b/client/src/app/gateways/repositories/assignments/assignment-candidate-repository.service/assignment-candidate-repository.service.ts
@@ -17,7 +17,7 @@ export class AssignmentCandidateRepositoryService extends BaseMeetingRelatedRepo
     ViewAssignmentCandidate,
     AssignmentCandidate
 > {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, AssignmentCandidate);
     }
 

--- a/client/src/app/gateways/repositories/assignments/assignment-repository.service/assignment-repository.service.ts
+++ b/client/src/app/gateways/repositories/assignments/assignment-repository.service/assignment-repository.service.ts
@@ -18,7 +18,7 @@ export class AssignmentRepositoryService extends BaseAgendaItemAndListOfSpeakers
     ViewAssignment,
     Assignment
 > {
-    constructor(
+    public constructor(
         repositoryServiceCollector: RepositoryMeetingServiceCollectorService,
         agendaItemRepo: AgendaItemRepositoryService
     ) {

--- a/client/src/app/gateways/repositories/chat/chat-group-repository.service/chat-group-repository.service.ts
+++ b/client/src/app/gateways/repositories/chat/chat-group-repository.service/chat-group-repository.service.ts
@@ -12,7 +12,7 @@ import { ChatGroupAction } from './chat-group.action';
     providedIn: `root`
 })
 export class ChatGroupRepositoryService extends BaseMeetingRelatedRepository<ViewChatGroup, ChatGroup> {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, ChatGroup);
     }
 

--- a/client/src/app/gateways/repositories/motions/motion-block-repository.service/motion-block-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-block-repository.service/motion-block-repository.service.ts
@@ -15,7 +15,7 @@ export class MotionBlockRepositoryService extends BaseAgendaItemAndListOfSpeaker
     ViewMotionBlock,
     MotionBlock
 > {
-    constructor(
+    public constructor(
         repositoryServiceCollector: RepositoryMeetingServiceCollectorService,
         agendaItemRepo: AgendaItemRepositoryService
     ) {

--- a/client/src/app/gateways/repositories/motions/motion-category-repository.service/motion-category-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-category-repository.service/motion-category-repository.service.ts
@@ -14,7 +14,7 @@ import { MotionCategoryAction } from './motion-category.action';
     providedIn: `root`
 })
 export class MotionCategoryRepositoryService extends BaseMeetingRelatedRepository<ViewMotionCategory, MotionCategory> {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionCategory);
     }
 

--- a/client/src/app/gateways/repositories/motions/motion-change-recommendation-repository.service/motion-change-recommendation-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-change-recommendation-repository.service/motion-change-recommendation-repository.service.ts
@@ -14,7 +14,7 @@ export class MotionChangeRecommendationRepositoryService extends BaseMeetingRela
     ViewMotionChangeRecommendation,
     MotionChangeRecommendation
 > {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionChangeRecommendation);
     }
 

--- a/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-repository.service.ts
@@ -11,7 +11,7 @@ import { MotionCommentAction } from './motion-comment.action';
     providedIn: `root`
 })
 export class MotionCommentRepositoryService extends BaseMeetingRelatedRepository<ViewMotionComment, MotionComment> {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionComment);
     }
 

--- a/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-section-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-comments/motion-comment-section-repository.service.ts
@@ -14,7 +14,7 @@ export class MotionCommentSectionRepositoryService extends BaseMeetingRelatedRep
     ViewMotionCommentSection,
     MotionCommentSection
 > {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionCommentSection);
 
         this.viewModelSortFn = (a: ViewMotionCommentSection, b: ViewMotionCommentSection) => {

--- a/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-repository.service/motion-repository.service.ts
@@ -31,7 +31,7 @@ export class MotionRepositoryService extends BaseAgendaItemAndListOfSpeakersCont
      */
     protected sortProperty: SortProperty = `number`;
 
-    constructor(
+    public constructor(
         repositoryServiceCollector: RepositoryMeetingServiceCollectorService,
         agendaItemRepo: AgendaItemRepositoryService,
         private treeService: TreeService

--- a/client/src/app/gateways/repositories/motions/motion-state-repository.service/motion-state-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-state-repository.service/motion-state-repository.service.ts
@@ -12,7 +12,7 @@ import { MotionStateAction } from './motion-state.action';
     providedIn: `root`
 })
 export class MotionStateRepositoryService extends BaseMeetingRelatedRepository<ViewMotionState, MotionState> {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionState);
     }
 

--- a/client/src/app/gateways/repositories/motions/motion-statute-paragraph-repository.serivce/motion-statute-paragraph-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-statute-paragraph-repository.serivce/motion-statute-paragraph-repository.service.ts
@@ -15,7 +15,7 @@ export class MotionStatuteParagraphRepositoryService extends BaseMeetingRelatedR
     ViewMotionStatuteParagraph,
     MotionStatuteParagraph
 > {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionStatuteParagraph);
     }
 

--- a/client/src/app/gateways/repositories/motions/motion-workflow-repository.service/motion-workflow-repository.service.ts
+++ b/client/src/app/gateways/repositories/motions/motion-workflow-repository.service/motion-workflow-repository.service.ts
@@ -13,7 +13,7 @@ import { MotionWorkflowAction } from './motion-workflow.action';
     providedIn: `root`
 })
 export class MotionWorkflowRepositoryService extends BaseMeetingRelatedRepository<ViewMotionWorkflow, MotionWorkflow> {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, MotionWorkflow);
     }
 

--- a/client/src/app/gateways/repositories/point-of-order-category/point-of-order-category-repository.service.ts
+++ b/client/src/app/gateways/repositories/point-of-order-category/point-of-order-category-repository.service.ts
@@ -18,7 +18,7 @@ export class PointOfOrderCategoryRepositoryService
     extends BaseMeetingRelatedRepository<ViewPointOfOrderCategory, PointOfOrderCategory>
     implements CanPerformListUpdates<PointOfOrderCategory, void | Identifiable>
 {
-    constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
+    public constructor(repositoryServiceCollector: RepositoryMeetingServiceCollectorService) {
         super(repositoryServiceCollector, PointOfOrderCategory);
     }
 

--- a/client/src/app/gateways/repositories/repository-service-collector.service.ts
+++ b/client/src/app/gateways/repositories/repository-service-collector.service.ts
@@ -14,7 +14,7 @@ import { ActionService } from '../actions';
 export class RepositoryServiceCollectorService {
     public collectionToKeyUpdatesObservableMap: { [collection: string]: BehaviorSubject<string[]> } = {};
 
-    constructor(
+    public constructor(
         public DS: DataStoreService,
         public actionService: ActionService,
         public collectionMapperService: CollectionMapperService,

--- a/client/src/app/infrastructure/utils/import/import-process.ts
+++ b/client/src/app/infrastructure/utils/import/import-process.ts
@@ -29,7 +29,7 @@ export class ImportProcess<ModelsToCreate> {
 
     private _importFailCounter = 0;
 
-    public constructor(readonly config: ImportProcessConfig<ModelsToCreate>) {
+    public constructor(config: ImportProcessConfig<ModelsToCreate>) {
         this._afterImportChunkFn = config.afterImportChunkFn ?? VoidFn;
         this._importFn = config.importFn;
         this._chunkSize = config.chunkSize;

--- a/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
+++ b/client/src/app/infrastructure/utils/import/json-import-file-utils.ts
@@ -10,7 +10,7 @@ export const WRONG_JSON_IMPORT_FORMAT_ERROR_MSG = _(`Import data needs to have t
     providedIn: `root`
 })
 export class UploadFileJsonProcessorService {
-    constructor(private snackbar: MatSnackBar, private translate: TranslateService) {}
+    public constructor(private snackbar: MatSnackBar, private translate: TranslateService) {}
 
     public async getUploadFileJson<ExpectType>(file: FileData): Promise<ExpectType> {
         const json = await new Promise<ExpectType>(resolve => {

--- a/client/src/app/infrastructure/utils/import/static-after-import-handler.ts
+++ b/client/src/app/infrastructure/utils/import/static-after-import-handler.ts
@@ -9,9 +9,9 @@ export class StaticAfterImportHandler<ToCreate = any, ToImport = any> extends Ba
     ToImport
 > {
     public constructor(
-        readonly config: StaticAfterImportConfig<ToCreate, ToImport>,
-        override readonly idProperty: keyof ToCreate,
-        override readonly translateFn: (value: string) => string
+        config: StaticAfterImportConfig<ToCreate, ToImport>,
+        idProperty: keyof ToCreate,
+        translateFn: (value: string) => string
     ) {
         super({ idProperty, ...config, translateFn });
     }

--- a/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
+++ b/client/src/app/openslides-main-module/components/openslides-main/openslides-main.component.ts
@@ -28,7 +28,7 @@ const CURRENT_LANGUAGE_STORAGE_KEY = `currentLanguage`;
 export class OpenSlidesMainComponent implements OnInit {
     private onInitDone = new Deferred();
 
-    title = `OpenSlides`;
+    public title = `OpenSlides`;
 
     public constructor(
         _viewContainer: ViewContainerRef,

--- a/client/src/app/openslides-main-module/services/shared-worker.service.ts
+++ b/client/src/app/openslides-main-module/services/shared-worker.service.ts
@@ -50,7 +50,7 @@ export class SharedWorkerService {
     private healthCheckSubscription: Subscription;
     private messageEventSubscription: Subscription;
 
-    constructor(private zone: NgZone) {
+    public constructor(private zone: NgZone) {
         this.connectWorker(true);
     }
 

--- a/client/src/app/site/modules/chip-select/components/chip-select-chip/chip-select-chip.component.ts
+++ b/client/src/app/site/modules/chip-select/components/chip-select-chip/chip-select-chip.component.ts
@@ -6,5 +6,5 @@ import { Component, TemplateRef, ViewChild } from '@angular/core';
     styleUrls: [`./chip-select-chip.component.scss`]
 })
 export class ChipSelectChipComponent {
-    @ViewChild(TemplateRef) template: TemplateRef<any>;
+    @ViewChild(TemplateRef) public template: TemplateRef<any>;
 }

--- a/client/src/app/site/modules/chip-select/components/chip-select/chip-select.component.ts
+++ b/client/src/app/site/modules/chip-select/components/chip-select/chip-select.component.ts
@@ -8,7 +8,7 @@ import { ChipSelectChipComponent } from '../chip-select-chip/chip-select-chip.co
     styleUrls: [`./chip-select.component.scss`]
 })
 export class ChipSelectComponent implements AfterContentInit {
-    constructor() {}
+    public constructor() {}
 
     @Input()
     public chipClass: string | null;
@@ -16,11 +16,11 @@ export class ChipSelectComponent implements AfterContentInit {
     @Input()
     public canOpen: boolean;
 
-    @ContentChildren(ChipSelectChipComponent) inputChips: QueryList<ChipSelectChipComponent>;
+    @ContentChildren(ChipSelectChipComponent) public inputChips: QueryList<ChipSelectChipComponent>;
 
     public chips: ChipSelectChipComponent[] = [];
 
-    ngAfterContentInit(): void {
+    public ngAfterContentInit(): void {
         this.chips = this.inputChips.toArray();
         this.inputChips.changes.subscribe((chips: ChipSelectChipComponent[]) => {
             this.chips = chips;

--- a/client/src/app/site/modules/global-headbar/components/global-search/global-search.component.ts
+++ b/client/src/app/site/modules/global-headbar/components/global-search/global-search.component.ts
@@ -96,7 +96,7 @@ export class GlobalSearchComponent implements OnDestroy {
         });
     }
 
-    ngOnDestroy(): void {
+    public ngOnDestroy(): void {
         this.filterChangeSubscription.unsubscribe();
         this.viewportSubscription.unsubscribe();
     }

--- a/client/src/app/site/modules/info/components/info-actions/info-actions.component.ts
+++ b/client/src/app/site/modules/info/components/info-actions/info-actions.component.ts
@@ -11,7 +11,7 @@ import { LifecycleService } from 'src/app/site/services/lifecycle.service';
     styleUrls: [`./info-actions.component.scss`]
 })
 export class InfoActionsComponent extends BaseComponent {
-    constructor(
+    public constructor(
         private lifecycleService: LifecycleService,
         private snackbar: MatSnackBar,
         private presenter: CheckDatabasePresenterService,

--- a/client/src/app/site/modules/site-wrapper/services/banner.service.ts
+++ b/client/src/app/site/modules/site-wrapper/services/banner.service.ts
@@ -3,14 +3,14 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { Constructable } from 'src/app/domain/interfaces/constructable';
 
 export class BannerDefinition {
-    type?: string;
-    class?: string;
-    icon?: string;
-    text?: string;
-    subText?: string;
-    link?: string;
-    largerOnMobileView?: boolean;
-    component?: Constructable;
+    public type?: string;
+    public class?: string;
+    public icon?: string;
+    public text?: string;
+    public subText?: string;
+    public link?: string;
+    public largerOnMobileView?: boolean;
+    public component?: Constructable;
 }
 
 @Injectable({

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/speaking-times/speaking-times.component.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/speaking-times/speaking-times.component.ts
@@ -85,7 +85,7 @@ export class SpeakingTimesComponent implements OnDestroy {
         }
     }
 
-    constructor(
+    public constructor(
         private durationService: DurationService,
         private speakingTimesRepo: StructureLevelListOfSpeakersRepositoryService,
         private speakerRepo: SpeakerRepositoryService,
@@ -102,7 +102,7 @@ export class SpeakingTimesComponent implements OnDestroy {
         });
     }
 
-    ngOnDestroy(): void {
+    public ngOnDestroy(): void {
         for (const speakingTimeId of this.subscriptions.keys()) {
             this.subscriptions.get(speakingTimeId).unsubscribe();
         }

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/directives/list-of-speakers-content-title.directive.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/directives/list-of-speakers-content-title.directive.ts
@@ -4,5 +4,5 @@ import { Directive } from '@angular/core';
     selector: `[osListOfSpeakersContentTitle]`
 })
 export class ListOfSpeakersContentTitleDirective {
-    constructor() {}
+    public constructor() {}
 }

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/agenda-content-object-form/services/agenda-content-object-form.service.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/agenda-content-object-form/services/agenda-content-object-form.service.ts
@@ -7,7 +7,10 @@ import { ViewAgendaItem } from '../../../../pages/agenda';
 
 @Injectable()
 export class AgendaContentObjectFormService {
-    constructor(private repo: AgendaItemRepositoryService, private activeMeetingIdService: ActiveMeetingIdService) {}
+    public constructor(
+        private repo: AgendaItemRepositoryService,
+        private activeMeetingIdService: ActiveMeetingIdService
+    ) {}
 
     public getViewModelListObservable(): Observable<ViewAgendaItem[]> {
         return this.repo.getViewModelListObservable();

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.ts
@@ -25,7 +25,7 @@ export class ProjectableTitleComponent {
         map(_ => this.isBeingProjected())
     );
 
-    constructor(private projectorService: ProjectorControllerService, private cd: ChangeDetectorRef) {}
+    public constructor(private projectorService: ProjectorControllerService, private cd: ChangeDetectorRef) {}
 
     public isBeingProjected(): boolean {
         if (!this.model) {

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projectable-list/services/projectable-list.service.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projectable-list/services/projectable-list.service.ts
@@ -5,7 +5,7 @@ import { isProjectable, Projectable, ProjectionBuildDescriptor } from 'src/app/s
 
 @Injectable()
 export class ProjectableListService {
-    constructor(
+    public constructor(
         private activeMeetingService: ActiveMeetingService,
         private meetingSettingsService: MeetingSettingsService
     ) {}

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/components/projection-dialog/projection-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/components/projection-dialog/projection-dialog.component.ts
@@ -92,12 +92,12 @@ export class ProjectionDialogComponent implements OnInit, OnDestroy {
         );
     }
 
-    ngOnDestroy(): void {
+    public ngOnDestroy(): void {
         this.modelRequestService.closeSubscription(this._projectorSubscription);
         this._subscriptions.forEach(s => s.unsubscribe());
     }
 
-    ngOnInit(): void {
+    public ngOnInit(): void {
         this._projectorSubscription = PROJECTOR_LIST_MINIMAL_SUBSCRIPTION + `_${Date.now()}`;
         this.modelRequestService.subscribeTo({
             ...getProjectorListMinimalSubscriptionConfig(this.activeMeetingService.meetingId),

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/services/projection-dialog.service.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/services/projection-dialog.service.ts
@@ -13,7 +13,7 @@ import { ProjectionDialogModule } from '../projection-dialog.module';
 
 @Injectable({ providedIn: ProjectionDialogModule })
 export class ProjectionDialogService {
-    constructor(private dialog: MatDialog, private projectorRepo: ProjectorControllerService) {}
+    public constructor(private dialog: MatDialog, private projectorRepo: ProjectorControllerService) {}
 
     /**
      * Opens the projection dialog for the given projectable. After the user's choice,

--- a/client/src/app/site/pages/meetings/modules/poll/components/entitled-users-table/entitled-users-table.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/entitled-users-table/entitled-users-table.component.ts
@@ -45,7 +45,10 @@ export class EntitledUsersTableComponent {
     public readonly permission = Permission;
 
     public filterPropsEntitledUsersTable = [`user.full_name`, `vote_delegated_to.full_name`, `voted_verbose`];
-    constructor(private controller: ParticipantControllerService, public filter: EntitledUsersListFilterService) {}
+    public constructor(
+        private controller: ParticipantControllerService,
+        public filter: EntitledUsersListFilterService
+    ) {}
 
     private getNameFromEntry(entry: EntitledUsersTableEntry): string {
         return (entry.user ?? this.controller.getViewModel(entry.user_id))?.getShortName();

--- a/client/src/app/site/pages/meetings/modules/poll/services/poll-controller.service/poll-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/poll-controller.service/poll-controller.service.ts
@@ -13,7 +13,7 @@ import { ViewPoll } from '../../../../pages/polls';
 
 @Injectable({ providedIn: `root` })
 export class PollControllerService extends BaseMeetingControllerService<ViewPoll, Poll> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: PollRepositoryService,
         protected voteRepo: VoteRepositoryService

--- a/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/vote-controller.service/vote-controller.service.ts
@@ -13,7 +13,7 @@ import { ViewPoll, ViewVote } from '../../../../pages/polls';
     providedIn: `root`
 })
 export class VoteControllerService extends BaseMeetingControllerService<ViewVote, Vote> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: VoteRepositoryService,
         private operator: OperatorService

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/services/speaker-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/services/speaker-controller.service.ts
@@ -18,7 +18,7 @@ import { ViewListOfSpeakers, ViewSpeaker } from '../view-models';
     providedIn: `root`
 })
 export class SpeakerControllerService extends BaseMeetingControllerService<ViewSpeaker, Speaker> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: SpeakerRepositoryService,
         protected userRepo: UserControllerService

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-dialog/topic-poll-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-dialog/topic-poll-dialog.component.ts
@@ -25,7 +25,7 @@ let uniqueId = 0;
 export class TextOptionSelectable implements Selectable {
     public readonly id = ++uniqueId;
 
-    constructor(private readonly text: string) {}
+    public constructor(private readonly text: string) {}
 
     public getTitle(): string {
         return this.text;
@@ -42,8 +42,8 @@ export class TextOptionSelectable implements Selectable {
     styleUrls: [`./topic-poll-dialog.component.scss`]
 })
 export class TopicPollDialogComponent extends BasePollDialogComponent implements AfterViewInit {
-    @ViewChild(`scrollframe`, { static: false }) scrollFrame: ElementRef;
-    @ViewChildren(`item`) itemElements: QueryList<any>;
+    @ViewChild(`scrollframe`, { static: false }) public scrollFrame: ElementRef;
+    @ViewChildren(`item`) public itemElements: QueryList<any>;
 
     private scrollContainer: any;
     private isNearBottom = true;
@@ -80,12 +80,15 @@ export class TopicPollDialogComponent extends BasePollDialogComponent implements
         return super.formsValid;
     }
 
-    constructor(public topicPollService: TopicPollService, @Inject(MAT_DIALOG_DATA) pollData: ViewPoll<ViewTopic>) {
+    public constructor(
+        public topicPollService: TopicPollService,
+        @Inject(MAT_DIALOG_DATA) pollData: ViewPoll<ViewTopic>
+    ) {
         super(pollData);
         this.optionTypeText = true;
     }
 
-    ngAfterViewInit() {
+    public ngAfterViewInit() {
         if (this.scrollFrame) {
             this.scrollContainer = this.scrollFrame.nativeElement;
             this.itemElements.changes.subscribe(_ => this.onItemElementsChanged());

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/services/topic-export.service/topic-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/services/topic-export.service/topic-export.service.ts
@@ -17,7 +17,7 @@ interface TopicExport {
     providedIn: TopicImportServiceModule
 })
 export class TopicExportService {
-    constructor(private csvExportService: CsvExportForBackendService, private translate: TranslateService) {}
+    public constructor(private csvExportService: CsvExportForBackendService, private translate: TranslateService) {}
 
     public downloadCsvImportExample(): void {
         const rows: TopicExport[] = [

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/services/topic-controller.service/topic-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/services/topic-controller.service/topic-controller.service.ts
@@ -12,7 +12,7 @@ import { ViewTopic } from '../../view-models';
     providedIn: `root`
 })
 export class TopicControllerService extends BaseMeetingControllerService<ViewTopic, Topic> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: TopicRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-export.service/agenda-item-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-export.service/agenda-item-export.service.ts
@@ -21,7 +21,7 @@ interface AgendaTreePdfEntry {
     providedIn: AgendaItemListServiceModule
 })
 export class AgendaItemExportService {
-    constructor(
+    public constructor(
         private translate: TranslateService,
         private csvExportService: MeetingCsvExportForBackendService,
         private pdfExportService: MeetingPdfExportService,

--- a/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-multiselect.service/agenda-item-multiselect.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-item-list/services/agenda-item-multiselect.service/agenda-item-multiselect.service.ts
@@ -16,7 +16,7 @@ import { AgendaItemListServiceModule } from '../agenda-item-list-service.module'
 export class AgendaItemMultiselectService {
     private messageForSpinner = this.translate.instant(`Agenda items are in process. Please wait ...`);
 
-    constructor(
+    public constructor(
         private choiceService: ChoiceService,
         private spinnerService: SpinnerService,
         public repo: AgendaItemControllerService,

--- a/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-sort/components/agenda-sort/agenda-sort.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-sort/components/agenda-sort/agenda-sort.component.ts
@@ -26,7 +26,7 @@ export class AgendaSortComponent extends BaseSortTreeViewComponent<ViewAgendaIte
      */
     public itemsObservable: Observable<ViewAgendaItem[]>;
 
-    @ViewChild(`visibilities`) visibilitiesEl: MatSelectionList;
+    @ViewChild(`visibilities`) public visibilitiesEl: MatSelectionList;
 
     /**
      * These are the available options for filtering the nodes.

--- a/client/src/app/site/pages/meetings/pages/agenda/services/agenda-item-controller.service/agenda-item-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/services/agenda-item-controller.service/agenda-item-controller.service.ts
@@ -17,7 +17,7 @@ import { AgendaItemCommonServiceModule } from '../agenda-item-common-service.mod
     providedIn: AgendaItemCommonServiceModule
 })
 export class AgendaItemControllerService extends BaseMeetingControllerService<ViewAgendaItem, AgendaItem> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: AgendaItemRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/services/assignment-candidate-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/services/assignment-candidate-controller.service.ts
@@ -15,7 +15,7 @@ export class AssignmentCandidateControllerService extends BaseMeetingControllerS
     ViewAssignmentCandidate,
     AssignmentCandidate
 > {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: AssignmentCandidateRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-list/services/assignment-sort-list.service.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-list/services/assignment-sort-list.service.ts
@@ -28,7 +28,7 @@ export class AssignmentSortListService extends BaseSortListService<ViewAssignmen
         { property: `id`, label: `Creation date` }
     ];
 
-    constructor() {
+    public constructor() {
         super({
             sortProperty: `title`,
             sortAscending: true

--- a/client/src/app/site/pages/meetings/pages/assignments/services/assignment-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/services/assignment-controller.service.ts
@@ -10,7 +10,7 @@ import { AssignmentCommonServiceModule } from './assignment-common-service.modul
 
 @Injectable({ providedIn: AssignmentCommonServiceModule })
 export class AssignmentControllerService extends BaseMeetingControllerService<ViewAssignment, Assignment> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: AssignmentRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-detail-message-form/chat-group-detail-message-form.component.ts
+++ b/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-detail-message-form/chat-group-detail-message-form.component.ts
@@ -36,7 +36,7 @@ export class ChatGroupDetailMessageFormComponent {
 
     private _currentMessage: ViewChatMessage | null = null;
 
-    constructor(fb: UntypedFormBuilder) {
+    public constructor(fb: UntypedFormBuilder) {
         this.messageForm = fb.control(``, [Validators.maxLength(CHAT_MESSAGE_MAX_LENGTH)]);
     }
 

--- a/client/src/app/site/pages/meetings/pages/chat/services/chat-group-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/chat/services/chat-group-controller.service.ts
@@ -11,7 +11,7 @@ import { ViewChatGroup } from '../view-models';
     providedIn: `root`
 })
 export class ChatGroupControllerService extends BaseMeetingControllerService<ViewChatGroup, ChatGroup> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: ChatGroupRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/chat/services/chat-message-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/chat/services/chat-message-controller.service.ts
@@ -11,7 +11,7 @@ import { ViewChatMessage } from '../view-models';
     providedIn: `root`
 })
 export class ChatMessageControllerService extends BaseMeetingControllerService<ViewChatMessage, ChatMessage> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: ChatMessageRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/interaction/services/broadcast.service.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/services/broadcast.service.ts
@@ -28,7 +28,7 @@ export class BroadcastService {
     private broadcastChannel: BroadcastChannel;
     private onMessage = new Subject<any>();
 
-    constructor() {
+    public constructor() {
         this.broadcastChannel = new BroadcastChannel(BroadcastChannelName);
         this.broadcastChannel.onmessage = message => this.onMessage.next(message.data);
     }

--- a/client/src/app/site/pages/meetings/pages/interaction/services/interaction-receive.service.ts
+++ b/client/src/app/site/pages/meetings/pages/interaction/services/interaction-receive.service.ts
@@ -84,7 +84,7 @@ export class InteractionReceiveService {
 
     private _kickObservable = this.notifyService.getMessageObservable<kickMessage>(KickMessage);
 
-    constructor(private notifyService: NotifyService, private activeMeetingService: ActiveMeetingService) {}
+    public constructor(private notifyService: NotifyService, private activeMeetingService: ActiveMeetingService) {}
 
     public startListening(lazyServices: InteractionReceiveSetupServices): void {
         if (!!this._inviteSubscription) {

--- a/client/src/app/site/pages/meetings/pages/mediafiles/services/mediafile-common.service.ts
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/services/mediafile-common.service.ts
@@ -18,7 +18,7 @@ export class MediafileCommonService {
         return this.meetingIdService.meetingId!;
     }
 
-    constructor(
+    public constructor(
         private meetingIdService: ActiveMeetingIdService,
         private router: Router,
         private repo: MediafileControllerService,

--- a/client/src/app/site/pages/meetings/pages/mediafiles/services/mediafile-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/services/mediafile-controller.service.ts
@@ -14,7 +14,7 @@ import { MediafileCommonServiceModule } from './mediafile-common-service.module'
 
 @Injectable({ providedIn: MediafileCommonServiceModule })
 export class MediafileControllerService extends BaseController<ViewMediafile, Mediafile> {
-    constructor(
+    public constructor(
         protected override controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MediafileRepositoryService,
         private operator: OperatorService

--- a/client/src/app/site/pages/meetings/pages/motions/modules/categories/services/motion-category-controller.service/motion-category-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/categories/services/motion-category-controller.service/motion-category-controller.service.ts
@@ -18,7 +18,7 @@ import { ViewMotionCategory } from '../../view-models';
 export class MotionCategoryControllerService extends BaseMeetingControllerService<ViewMotionCategory, MotionCategory> {
     private readonly _currentCategoriesSubject = new BehaviorSubject<ViewMotionCategory[]>([]);
 
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MotionCategoryRepositoryService,
         private treeService: TreeService

--- a/client/src/app/site/pages/meetings/pages/motions/modules/comments/services/motion-comment-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/comments/services/motion-comment-controller.service.ts
@@ -11,7 +11,7 @@ import { ViewMotionComment } from '../view-models';
     providedIn: `root`
 })
 export class MotionCommentControllerService extends BaseMeetingControllerService<ViewMotionComment, MotionComment> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MotionCommentRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/motions/modules/comments/services/motion-comment-section-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/comments/services/motion-comment-section-controller.service.ts
@@ -14,7 +14,7 @@ export class MotionCommentSectionControllerService extends BaseMeetingController
     ViewMotionCommentSection,
     MotionCommentSection
 > {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MotionCommentSectionRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/services/motion-poll-controller.service/motion-poll-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/services/motion-poll-controller.service/motion-poll-controller.service.ts
@@ -10,7 +10,7 @@ import { MotionPollServiceModule } from '../motion-poll-service.module';
     providedIn: MotionPollServiceModule
 })
 export class MotionPollControllerService {
-    constructor(private repo: PollRepositoryService) {}
+    public constructor(private repo: PollRepositoryService) {}
 
     public getViewModelList(): ViewPoll[] {
         return this.repo.getViewModelList().filter(poll => poll.pollClassType === PollClassType.Motion);

--- a/client/src/app/site/pages/meetings/pages/motions/modules/states/services/motion-state-controller.service/motion-state-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/states/services/motion-state-controller.service/motion-state-controller.service.ts
@@ -13,7 +13,7 @@ import { ViewMotionState } from '../../view-models';
     providedIn: `root`
 })
 export class MotionStateControllerService extends BaseMeetingControllerService<ViewMotionState, MotionState> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MotionStateRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/motions/modules/statute-paragraphs/services/motion-statute-paragraph-controller.service/motion-statute-paragraph-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/statute-paragraphs/services/motion-statute-paragraph-controller.service/motion-statute-paragraph-controller.service.ts
@@ -14,7 +14,7 @@ export class MotionStatuteParagraphControllerService extends BaseMeetingControll
     ViewMotionStatuteParagraph,
     MotionStatuteParagraph
 > {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MotionStatuteParagraphRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/motions/modules/tags/services/tag-controller.service/tag-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/tags/services/tag-controller.service/tag-controller.service.ts
@@ -11,7 +11,7 @@ import { ViewTag } from '../../view-models';
     providedIn: `root`
 })
 export class TagControllerService extends BaseMeetingControllerService<ViewTag, Tag> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: TagRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/motions/modules/workflows/services/motion-workflow-controller.service/motion-workflow-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/workflows/services/motion-workflow-controller.service/motion-workflow-controller.service.ts
@@ -15,7 +15,7 @@ import { ViewMotionWorkflow } from '../../view-models';
     providedIn: `root`
 })
 export class MotionWorkflowControllerService extends BaseMeetingControllerService<ViewMotionWorkflow, MotionWorkflow> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: MotionWorkflowRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/modules/motion-list-info-dialog/components/motion-list-info-dialog/motion-list-info-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/modules/motion-list-info-dialog/components/motion-list-info-dialog/motion-list-info-dialog.component.ts
@@ -40,7 +40,7 @@ export class MotionListInfoDialogComponent {
     public readonly selectedMotion: ViewMotion;
 
     public constructor(
-        @Inject(MAT_DIALOG_DATA) readonly config: MotionListInfoDialogConfig,
+        @Inject(MAT_DIALOG_DATA) public readonly config: MotionListInfoDialogConfig,
         repo: MotionControllerService,
         private categoryRepo: MotionCategoryControllerService,
         private blockRepo: MotionBlockControllerService,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/services/workflow-export.service/workflow-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/services/workflow-export.service/workflow-export.service.ts
@@ -12,7 +12,7 @@ import { MotionWorkflowServiceModule } from '../motion-workflow-service.module';
     providedIn: MotionWorkflowServiceModule
 })
 export class WorkflowExportService {
-    constructor(private translate: TranslateService, private stateRepo: MotionStateControllerService) {}
+    public constructor(private translate: TranslateService, private stateRepo: MotionStateControllerService) {}
 
     public exportWorkflows(...workflows: ViewMotionWorkflow[]): void {
         const workflowKeysToCopy: (keyof MotionWorkflow)[] = [`name`];

--- a/client/src/app/site/pages/meetings/pages/motions/services/list/amendment-list-sort.service/amendment-list-sort.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/list/amendment-list-sort.service/amendment-list-sort.service.ts
@@ -26,7 +26,7 @@ export class AmendmentListSortService extends MotionListBaseSortService {
         }
     ];
 
-    constructor() {
+    public constructor() {
         super({
             sortProperty: `parentAndLineNumber`,
             sortAscending: true

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/modules/participant-list-info-dialog/components/participant-list-info-dialog/participant-list-info-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/modules/participant-list-info-dialog/components/participant-list-info-dialog/participant-list-info-dialog.component.ts
@@ -46,7 +46,7 @@ export class ParticipantListInfoDialogComponent extends BaseUiComponent implemen
     private _currentUser: ViewUser | null = null;
     private _voteDelegationEnabled = false;
 
-    constructor(
+    public constructor(
         @Inject(MAT_DIALOG_DATA) public readonly infoDialog: InfoDialog,
         private participantRepo: ParticipantControllerService,
         private groupRepo: GroupControllerService,

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/services/projection-controller.service/projection-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/services/projection-controller.service/projection-controller.service.ts
@@ -10,7 +10,7 @@ import { ProjectorDetailServiceModule } from '../projector-detail-service.module
 
 @Injectable({ providedIn: ProjectorDetailServiceModule })
 export class ProjectionControllerService extends BaseMeetingControllerService<ViewProjection, Projection> {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: ProjectionRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/services/projector-countdown-controller.service/projector-countdown-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/services/projector-countdown-controller.service/projector-countdown-controller.service.ts
@@ -13,7 +13,7 @@ export class ProjectorCountdownControllerService extends BaseMeetingControllerSe
     ViewProjectorCountdown,
     ProjectorCountdown
 > {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: ProjectorCountdownRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/services/projector-message-controller.service/projector-message-controller.service.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/services/projector-message-controller.service/projector-message-controller.service.ts
@@ -13,7 +13,7 @@ export class ProjectorMessageControllerService extends BaseMeetingControllerServ
     ViewProjectorMessage,
     ProjectorMessage
 > {
-    constructor(
+    public constructor(
         controllerServiceCollector: MeetingControllerServiceCollectorService,
         protected override repo: ProjectorMessageRepositoryService
     ) {

--- a/client/src/app/site/pages/meetings/services/export/meeting-pdf-export.service.ts
+++ b/client/src/app/site/pages/meetings/services/export/meeting-pdf-export.service.ts
@@ -53,7 +53,7 @@ export class MeetingPdfExportService {
         return mmToPoints(this.meetingSettingsService.instant(`export_pdf_page_margin_bottom`)!);
     }
 
-    constructor(
+    public constructor(
         private pdfExportService: PdfDocumentService,
         private meetingSettingsService: MeetingSettingsService,
         private httpService: HttpService,

--- a/client/src/app/site/pages/meetings/services/meeting-component-service-collector.service.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-component-service-collector.service.ts
@@ -34,7 +34,7 @@ export class MeetingComponentServiceCollectorService {
         return this.componentServiceCollector.router;
     }
 
-    constructor(
+    public constructor(
         private componentServiceCollector: ComponentServiceCollectorService,
         public activeMeetingIdService: ActiveMeetingIdService,
         public activeMeetingService: ActiveMeetingService,

--- a/client/src/app/site/pages/meetings/services/meeting-controller-service-collector.service.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-controller-service-collector.service.ts
@@ -30,7 +30,7 @@ export class MeetingControllerServiceCollectorService {
         return this.controllerServiceCollector.viewModelStoreService;
     }
 
-    constructor(
+    public constructor(
         private controllerServiceCollector: ControllerServiceCollectorService,
         public activeMeetingIdService: ActiveMeetingIdService,
         public activeMeetingService: ActiveMeetingService,

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-list/services/account-list-search/account-list-search.service.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-list/services/account-list-search/account-list-search.service.ts
@@ -8,7 +8,7 @@ import { AccountListServiceModule } from '../account-list-service.module';
     providedIn: AccountListServiceModule
 })
 export class AccountListSearchService extends ListSearchService<ViewUser> {
-    constructor() {
+    public constructor() {
         super([`short_name`, `username`, `email`, `saml_id`], []);
     }
 }

--- a/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
+++ b/client/src/app/site/services/autoupdate/autoupdate-communication.service.ts
@@ -42,7 +42,7 @@ export class AutoupdateCommunicationService {
     private tryReconnectOpen = false;
     private subscriptionsWithData = new Set<string>();
 
-    constructor(
+    public constructor(
         private authTokenService: AuthTokenService,
         private authService: AuthService,
         private sharedWorker: SharedWorkerService,

--- a/client/src/app/site/services/communication-manager.service/stream-handler.ts
+++ b/client/src/app/site/services/communication-manager.service/stream-handler.ts
@@ -15,7 +15,7 @@ export class StreamHandler<T> {
 
     public constructor(
         private readonly buildStreamFn: () => HttpStream<T>,
-        readonly config: {
+        config: {
             afterOpenedFn?: AfterEventFn;
             afterClosedFn?: AfterEventFn;
         } = {}

--- a/client/src/app/site/services/component-service-collector.service.ts
+++ b/client/src/app/site/services/component-service-collector.service.ts
@@ -10,7 +10,7 @@ import { ModelRequestService } from './model-request.service';
     providedIn: `root`
 })
 export class ComponentServiceCollectorService {
-    constructor(
+    public constructor(
         public router: Router,
         public titleService: Title,
         public matSnackBar: MatSnackBar,

--- a/client/src/app/ui/directives/trim-on-paste/trim-on-paste.directive.ts
+++ b/client/src/app/ui/directives/trim-on-paste/trim-on-paste.directive.ts
@@ -4,9 +4,9 @@ import { Directive, ElementRef, HostListener } from '@angular/core';
     selector: `[osTrimOnPaste]`
 })
 export class TrimOnPasteDirective {
-    constructor(private el: ElementRef) {}
+    public constructor(private el: ElementRef) {}
 
-    @HostListener(`paste`, [`$event`]) onPaste(event: ClipboardEvent) {
+    @HostListener(`paste`, [`$event`]) public onPaste(event: ClipboardEvent): void {
         const clipboardData = event.clipboardData;
         let paste = clipboardData?.getData(`text`);
         if (paste !== paste.trim()) {

--- a/client/src/app/ui/modules/comma-separated-listing/components/comma-separated-listing/comma-separated-listing.component.ts
+++ b/client/src/app/ui/modules/comma-separated-listing/components/comma-separated-listing/comma-separated-listing.component.ts
@@ -19,7 +19,7 @@ export class CommaSeparatedListingComponent<T = unknown> {
     /**
      * If it is bigger than 0, the listing will be ellipsed after showElementsAmount elements.
      */
-    @Input() showElementsAmount = 0;
+    @Input() public showElementsAmount = 0;
 
     public get ellipsed(): boolean {
         return this.showElementsAmount > 0 && this.showElementsAmount < this.list.length;
@@ -29,5 +29,5 @@ export class CommaSeparatedListingComponent<T = unknown> {
         return this.ellipsed ? this.list.slice(0, this.showElementsAmount) : this.list;
     }
 
-    constructor() {}
+    public constructor() {}
 }

--- a/client/src/app/ui/modules/datepicker/components/base-datepicker/base-datepicker.component.ts
+++ b/client/src/app/ui/modules/datepicker/components/base-datepicker/base-datepicker.component.ts
@@ -6,7 +6,7 @@ import { BaseFormFieldControlComponent } from 'src/app/ui/base/base-form-field-c
 
 @Directive()
 export abstract class BaseDatepickerComponent extends BaseFormFieldControlComponent<any> {
-    @ViewChild(`picker`) picker: MatDateRangePicker<Date> | MatDatepicker<Date>;
+    @ViewChild(`picker`) public picker: MatDateRangePicker<Date> | MatDatepicker<Date>;
 
     public readonly controlType = `os-datepicker`;
 
@@ -25,7 +25,7 @@ export abstract class BaseDatepickerComponent extends BaseFormFieldControlCompon
     @Input()
     public showUpdateSuccessIcon = false;
 
-    constructor(element: ElementRef<HTMLElement>, @Optional() @Self() ngControl: NgControl) {
+    public constructor(element: ElementRef<HTMLElement>, @Optional() @Self() ngControl: NgControl) {
         super(ngControl);
 
         this.fm

--- a/client/src/app/ui/modules/datepicker/components/datepicker/datepicker.component.ts
+++ b/client/src/app/ui/modules/datepicker/components/datepicker/datepicker.component.ts
@@ -19,7 +19,7 @@ export class DatepickerComponent extends BaseDatepickerComponent {
 
     public override contentForm: UntypedFormControl;
 
-    constructor(element: ElementRef<HTMLElement>, @Optional() @Self() ngControl: NgControl) {
+    public constructor(element: ElementRef<HTMLElement>, @Optional() @Self() ngControl: NgControl) {
         super(element, ngControl);
     }
 

--- a/client/src/app/ui/modules/datepicker/components/daterangepicker/daterangepicker.component.ts
+++ b/client/src/app/ui/modules/datepicker/components/daterangepicker/daterangepicker.component.ts
@@ -22,7 +22,7 @@ export class DaterangepickerComponent extends BaseDatepickerComponent {
 
     private currentValue: any;
 
-    constructor(element: ElementRef<HTMLElement>, @Optional() @Self() ngControl: NgControl) {
+    public constructor(element: ElementRef<HTMLElement>, @Optional() @Self() ngControl: NgControl) {
         super(element, ngControl);
     }
 

--- a/client/src/app/ui/modules/expandable-content-wrapper/components/expandable-content-wrapper/expandable-content-wrapper.component.ts
+++ b/client/src/app/ui/modules/expandable-content-wrapper/components/expandable-content-wrapper/expandable-content-wrapper.component.ts
@@ -47,7 +47,7 @@ export class ExpandableContentWrapperComponent {
 
     public showCollapsed: boolean;
 
-    constructor(private cd: ChangeDetectorRef) {
+    public constructor(private cd: ChangeDetectorRef) {
         this.update();
     }
 

--- a/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.ts
+++ b/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.ts
@@ -46,7 +46,7 @@ export class FileUploadComponent {
     @ContentChild(TemplateRef, { static: true })
     public additionalContent: TemplateRef<any> | null = null;
 
-    @ViewChild(`fileInput`) fileInput: ElementRef;
+    @ViewChild(`fileInput`) public fileInput: ElementRef;
 
     /**
      * Determine if uploading should happen parallel or synchronously.

--- a/client/src/app/ui/modules/head-bar/components/head-bar/head-bar.component.ts
+++ b/client/src/app/ui/modules/head-bar/components/head-bar/head-bar.component.ts
@@ -115,7 +115,7 @@ export class HeadBarComponent implements OnInit, AfterViewInit {
         return this._isSaveButtonEnabled;
     }
 
-    @ViewChild(`headbarContent`) headbarContent: TemplateRef<unknown>;
+    @ViewChild(`headbarContent`) public headbarContent: TemplateRef<unknown>;
 
     /**
      * Determine multiSelect mode: changed interactions and head bar

--- a/client/src/app/ui/modules/import-list/directives/import-list-first-tab.directive.ts
+++ b/client/src/app/ui/modules/import-list/directives/import-list-first-tab.directive.ts
@@ -4,5 +4,5 @@ import { Directive } from '@angular/core';
     selector: `[osImportListFirstTab]`
 })
 export class ImportListFirstTabDirective {
-    constructor() {}
+    public constructor() {}
 }

--- a/client/src/app/ui/modules/import-list/directives/import-list-last-tab.directive.ts
+++ b/client/src/app/ui/modules/import-list/directives/import-list-last-tab.directive.ts
@@ -4,5 +4,5 @@ import { Directive } from '@angular/core';
     selector: `[osImportListLastTab]`
 })
 export class ImportListLastTabDirective {
-    constructor() {}
+    public constructor() {}
 }

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.ts
@@ -43,7 +43,7 @@ export class ScrollingTableComponent<T extends Partial<Mutable<Identifiable>>>
     @ViewChild(CdkVirtualScrollViewport)
     public scrollViewport: CdkVirtualScrollViewport | undefined;
 
-    @ViewChild(`cdkContainer`) cdkContainer: ElementRef;
+    @ViewChild(`cdkContainer`) public cdkContainer: ElementRef;
 
     @Input()
     public tableHeight: string | undefined = undefined;

--- a/client/src/app/ui/modules/search-selector/directives/search-selector-not-found-template.directive.ts
+++ b/client/src/app/ui/modules/search-selector/directives/search-selector-not-found-template.directive.ts
@@ -4,5 +4,5 @@ import { Directive } from '@angular/core';
     selector: `[osSearchSelectorNotFoundTemplate]`
 })
 export class SearchSelectorNotFoundTemplateDirective {
-    constructor() {}
+    public constructor() {}
 }

--- a/client/src/app/ui/modules/sidenav/modules/easter-egg/modules/chess-dialog/services/chess-challenge.service.ts
+++ b/client/src/app/ui/modules/sidenav/modules/easter-egg/modules/chess-dialog/services/chess-challenge.service.ts
@@ -12,7 +12,7 @@ import { ChessDialogModule } from '../chess-dialog.module';
     providedIn: ChessDialogModule
 })
 export class ChessChallengeService {
-    constructor(
+    public constructor(
         private notifyService: NotifyService,
         private op: OperatorService,
         private dialog: MatDialog,

--- a/client/src/app/ui/pipes/entries/entries.pipe.ts
+++ b/client/src/app/ui/pipes/entries/entries.pipe.ts
@@ -15,7 +15,7 @@ export class EntriesPipe implements PipeTransform {
 
     public constructor(private readonly differs: KeyValueDiffers) {}
 
-    transform<K, V>(
+    public transform<K, V>(
         instance: IterableMap<K, V> | any,
         compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number
     ): Array<KeyValue<K, V>> {

--- a/client/src/app/worker/autoupdate/autoupdate-stream-pool.ts
+++ b/client/src/app/worker/autoupdate/autoupdate-stream-pool.ts
@@ -38,7 +38,7 @@ export class AutoupdateStreamPool {
         return this.streams.filter(stream => stream.active);
     }
 
-    constructor(private endpoint: AutoupdateSetEndpointParams) {
+    public constructor(private endpoint: AutoupdateSetEndpointParams) {
         this.updateAuthentication();
     }
 

--- a/client/src/app/worker/autoupdate/autoupdate-stream.ts
+++ b/client/src/app/worker/autoupdate/autoupdate-stream.ts
@@ -45,7 +45,7 @@ export class AutoupdateStream {
         return this.failedCounter;
     }
 
-    constructor(
+    public constructor(
         private _subscriptions: AutoupdateSubscription[],
         public queryParams: URLSearchParams,
         private endpoint: AutoupdateSetEndpointParams,

--- a/client/src/app/worker/autoupdate/autoupdate-subscription.ts
+++ b/client/src/app/worker/autoupdate/autoupdate-subscription.ts
@@ -13,7 +13,7 @@ export class AutoupdateSubscription {
         return this._request;
     }
 
-    constructor(
+    public constructor(
         public id: number,
         public url: string,
         public requestHash: string,

--- a/client/tests/integration/page-objects/components/list-component.ts
+++ b/client/tests/integration/page-objects/components/list-component.ts
@@ -4,7 +4,7 @@ export class ListComponent {
     readonly page: Page;
     readonly osList: Locator;
 
-    constructor(page: Page, osList?: Locator) {
+    public constructor(page: Page, osList?: Locator) {
         this.page = page;
         this.osList = osList || page.locator('os-list').first();
     }

--- a/client/tests/integration/page-objects/meeting/home/detail.ts
+++ b/client/tests/integration/page-objects/meeting/home/detail.ts
@@ -6,7 +6,7 @@ export class MeetingHomePage {
     public readonly welcomeText: Locator;
     public readonly editButton: Locator;
 
-    constructor(page: Page) {
+    public constructor(page: Page) {
         this.page = page;
         this.frontPageTitle = page.locator(`mat-sidenav-content`).locator(`.app-content > h1`);
         this.welcomeText = page.locator(`mat-sidenav-content`).locator(`.app-content > div`);

--- a/client/tests/integration/page-objects/meeting/home/edit.ts
+++ b/client/tests/integration/page-objects/meeting/home/edit.ts
@@ -8,7 +8,7 @@ export class MeetingHomeEditPage {
     public readonly saveButton: Locator;
     public readonly closeButton: Locator;
 
-    constructor(page: Page) {
+    public constructor(page: Page) {
         this.page = page;
         this.frontPageTitleInput = page.locator(`[formcontrolname=welcome_title]`);
         this.welcomeTextTinyMce = page.locator(`.tox-tinymce`);

--- a/client/tests/integration/page-objects/meeting/motion/detail.ts
+++ b/client/tests/integration/page-objects/meeting/motion/detail.ts
@@ -3,7 +3,7 @@ import { Page } from '@playwright/test';
 export class MeetingMotionDetailPage {
     private readonly page: Page;
 
-    constructor(page: Page) {
+    public constructor(page: Page) {
         this.page = page;
     }
 


### PR DESCRIPTION
resolves #3426 

Explicit return type is currently only added as warning because it would need a lot of manual intervention to fix all of the already existing issues. 