### PR TITLE
Add moderator notes to topic detail

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.ts
@@ -44,6 +44,11 @@ export class ModerationNoteComponent extends BaseMeetingComponent implements OnI
         }
     }
 
+    @Input()
+    public set contentObject(contentObject: BaseViewModel) {
+        this._contentObject = contentObject;
+    }
+
     public get moderatorNotes(): Observable<string> {
         return this.agendaItemRepo
             .getViewModelObservable(this._contentObject?.getModel().agenda_item_id)

--- a/client/src/app/site/pages/meetings/pages/agenda/agenda.subscription.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/agenda.subscription.ts
@@ -109,7 +109,7 @@ export const getTopicDetailSubscriptionConfig: SubscriptionConfigGenerator = (..
                 idField: `list_of_speakers_id`,
                 ...listOfSpeakersSpeakerCountSubscription
             },
-            { idField: `agenda_item_id`, fieldset: [`item_number`, `content_object_id`] }
+            { idField: `agenda_item_id`, fieldset: [`item_number`, `content_object_id`, `moderator_notes`] }
         ]
     },
     subscriptionName: TOPIC_ITEM_SUBSCRIPTION

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll/topic-poll.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll/topic-poll.component.html
@@ -1,4 +1,4 @@
-<mat-card class="os-card" *ngIf="shouldShowPoll">
+<mat-card class="os-card" *ngIf="shouldShowPoll" [ngClass]="newCardWidth ? 'new-card-width' : ''">
     <div class="topic-poll-wrapper">
         <div>
             <!-- Title -->

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll/topic-poll.component.scss
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll/topic-poll.component.scss
@@ -30,3 +30,7 @@
         }
     }
 }
+
+.new-card-width {
+    max-width: 738px;
+}

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll/topic-poll.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll/topic-poll.component.ts
@@ -21,6 +21,13 @@ export class TopicPollComponent extends BasePollComponent<ViewTopic> implements 
         this.initializePoll(id);
     }
 
+    /**
+     * At the moment, we use a legacy card here. After using mdc card, we should rm the
+     * newCardWidth workaround.
+     */
+    @Input()
+    public newCardWidth = false;
+
     @Output()
     public readonly dialogOpened = new EventEmitter<void>();
 

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.html
@@ -36,7 +36,7 @@
     <mat-card
         *ngIf="(topic || editTopic) && (hasLoaded | async)"
         class="spacer-bottom-60"
-        [ngClass]="editTopic ? 'os-form-card' : 'os-card'"
+        [ngClass]="editTopic ? 'os-form-card' : 'os-card card-padding'"
     >
         <ng-container *ngIf="!editTopic && topic">
             <os-projectable-title [model]="topic" [getTitleFn]="getTitleFn"></os-projectable-title>
@@ -106,10 +106,11 @@
         </form>
     </mat-card>
 
+    <os-moderation-note [contentObject]="topic" *ngIf="!editTopic"></os-moderation-note>
     <div *ngIf="!editTopic" class="spacer-bottom-60">
         <ng-container *ngIf="topic && topic.poll_ids?.length">
             <ng-container *ngFor="let poll of topic.poll_ids | reverse; trackBy: trackById">
-                <os-topic-poll [pollId]="poll" (dialogOpened)="openDialog(poll)"></os-topic-poll>
+                <os-topic-poll [pollId]="poll" (dialogOpened)="openDialog(poll)" [newCardWidth]="true"></os-topic-poll>
             </ng-container>
         </ng-container>
         <div class="create-poll-button" *ngIf="topic && isEVotingEnabled">

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/topic-detail.module.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/topic-detail.module.ts
@@ -1,15 +1,16 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
 import { MatSelectModule } from '@angular/material/select';
 import { RouterModule } from '@angular/router';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
+import { ListOfSpeakersContentModule } from 'src/app/site/pages/meetings/modules/list-of-speakers-content/list-of-speakers-content.module';
 import { MeetingsComponentCollectorModule } from 'src/app/site/pages/meetings/modules/meetings-component-collector';
 import { AttachmentControlModule } from 'src/app/site/pages/meetings/modules/meetings-component-collector/attachment-control';
 import { DirectivesModule } from 'src/app/ui/directives';
@@ -47,7 +48,8 @@ import { TopicDetailRoutingModule } from './topic-detail-routing.module';
         MatListModule,
         MatFormFieldModule,
         TopicPollModule,
-        RouterModule
+        RouterModule,
+        ListOfSpeakersContentModule
     ]
 })
 export class TopicDetailModule {}


### PR DESCRIPTION
Part of #3447 

It adds the moderation notes to the topic detail view and tries to fix the styling.
It works in a context where mat-legacy-card and mat-card is used. 