### PR TITLE
Add option to customize autopilot content

### DIFF
--- a/client/src/app/site/pages/meetings/pages/autopilot/autopilot-routing.module.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/autopilot-routing.module.ts
@@ -3,17 +3,12 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { AutopilotComponent } from './components/autopilot/autopilot.component';
 import { AutopilotMainComponent } from './components/autopilot-main/autopilot-main.component';
-import { AutopilotSettingsComponent } from './components/autopilot-settings/autopilot-settings.component';
 
 const routes: Routes = [
     {
         path: ``,
         component: AutopilotMainComponent,
         children: [{ path: ``, component: AutopilotComponent, pathMatch: `full` }]
-    },
-    {
-        path: `edit`,
-        component: AutopilotSettingsComponent
     }
 ];
 

--- a/client/src/app/site/pages/meetings/pages/autopilot/autopilot-routing.module.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/autopilot-routing.module.ts
@@ -3,12 +3,17 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { AutopilotComponent } from './components/autopilot/autopilot.component';
 import { AutopilotMainComponent } from './components/autopilot-main/autopilot-main.component';
+import { AutopilotSettingsComponent } from './components/autopilot-settings/autopilot-settings.component';
 
 const routes: Routes = [
     {
         path: ``,
         component: AutopilotMainComponent,
         children: [{ path: ``, component: AutopilotComponent, pathMatch: `full` }]
+    },
+    {
+        path: `edit`,
+        component: AutopilotSettingsComponent
     }
 ];
 

--- a/client/src/app/site/pages/meetings/pages/autopilot/autopilot.module.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/autopilot.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatBadgeModule } from '@angular/material/badge';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -51,6 +52,7 @@ import { PollCollectionComponent } from './components/poll-collection/poll-colle
         MatFormFieldModule,
         MatIconModule,
         MatDialogModule,
+        MatBadgeModule,
         ListOfSpeakersContentModule,
         HeadBarModule,
         CountdownTimeModule,

--- a/client/src/app/site/pages/meetings/pages/autopilot/autopilot.module.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/autopilot.module.ts
@@ -6,6 +6,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -28,10 +29,11 @@ import { InteractionServiceModule } from '../interaction/services/interaction-se
 import { AutopilotRoutingModule } from './autopilot-routing.module';
 import { AutopilotComponent } from './components/autopilot/autopilot.component';
 import { AutopilotMainComponent } from './components/autopilot-main/autopilot-main.component';
+import { AutopilotSettingsComponent } from './components/autopilot-settings/autopilot-settings.component';
 import { PollCollectionComponent } from './components/poll-collection/poll-collection.component';
 
 @NgModule({
-    declarations: [AutopilotMainComponent, AutopilotComponent, PollCollectionComponent],
+    declarations: [AutopilotMainComponent, AutopilotSettingsComponent, AutopilotComponent, PollCollectionComponent],
     imports: [
         CommonModule,
         RouterModule,
@@ -41,6 +43,7 @@ import { PollCollectionComponent } from './components/poll-collection/poll-colle
         ProjectorModule,
         DirectivesModule,
         MatCardModule,
+        MatCheckboxModule,
         MatProgressBarModule,
         MatTabsModule,
         MatTooltipModule,

--- a/client/src/app/site/pages/meetings/pages/autopilot/autopilot.module.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/autopilot.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -40,6 +40,7 @@ import { PollCollectionComponent } from './components/poll-collection/poll-colle
         AutopilotRoutingModule,
         PromptDialogModule,
         InteractionServiceModule,
+        FormsModule,
         ProjectorModule,
         DirectivesModule,
         MatCardModule,

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
@@ -1,9 +1,9 @@
-<h1 mat-dialog-title translate>Disabled content elements</h1>
+<h1 mat-dialog-title translate>Enabled content elements</h1>
 <div mat-dialog-content>
     <div *ngFor="let option of autopilotContentElements" class="option">
         <mat-checkbox
             (ngModelChange)="updateDisabled(option.key, $event)"
-            [ngModel]="disabledAutopilotContentElements[option.key]"
+            [ngModel]="!disabledAutopilotContentElements[option.key]"
         >
             {{ option.description | translate }}
         </mat-checkbox>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
@@ -11,7 +11,10 @@
         </h1>
 
         <div *ngFor="let option of autopilotContentElements" class="option">
-            <mat-checkbox [checked]="isDisabled(option.key)" (checked)="setDisabled(option.key, $event)">
+            <mat-checkbox
+                (ngModelChange)="updateDisabled(option.key, $event)"
+                [ngModel]="disabledAutopilotContentElements[option.key]"
+            >
                 {{ option.description | translate }}
             </mat-checkbox>
         </div>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
@@ -1,0 +1,19 @@
+<os-head-bar [nav]="false">
+    <div class="title-slot">
+        <h2>{{ 'Autopilot settings' | translate }}</h2>
+    </div>
+</os-head-bar>
+
+<mat-card class="spacer-bottom-60" class="os-card">
+    <mat-card-content>
+        <h1 class="subtitle-text">
+            {{ 'Disabled content elements' | translate }}
+        </h1>
+
+        <div *ngFor="let option of autopilotContentElements" class="option">
+            <mat-checkbox [checked]="isDisabled(option.key)" (checked)="setDisabled(option.key, $event)">
+                {{ option.description | translate }}
+            </mat-checkbox>
+        </div>
+    </mat-card-content>
+</mat-card>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
@@ -1,22 +1,15 @@
-<os-head-bar [nav]="false">
-    <div class="title-slot">
-        <h2>{{ 'Autopilot settings' | translate }}</h2>
+<h1 mat-dialog-title translate>Disabled content elements</h1>
+<div mat-dialog-content>
+    <div *ngFor="let option of autopilotContentElements" class="option">
+        <mat-checkbox
+            (ngModelChange)="updateDisabled(option.key, $event)"
+            [ngModel]="disabledAutopilotContentElements[option.key]"
+        >
+            {{ option.description | translate }}
+        </mat-checkbox>
     </div>
-</os-head-bar>
+</div>
 
-<mat-card class="spacer-bottom-60" class="os-card">
-    <mat-card-content>
-        <h1 class="subtitle-text">
-            {{ 'Disabled content elements' | translate }}
-        </h1>
-
-        <div *ngFor="let option of autopilotContentElements" class="option">
-            <mat-checkbox
-                (ngModelChange)="updateDisabled(option.key, $event)"
-                [ngModel]="disabledAutopilotContentElements[option.key]"
-            >
-                {{ option.description | translate }}
-            </mat-checkbox>
-        </div>
-    </mat-card-content>
-</mat-card>
+<div mat-dialog-actions>
+    <button mat-button (click)="close()" translate>Close</button>
+</div>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.html
@@ -8,6 +8,8 @@
             {{ option.description | translate }}
         </mat-checkbox>
     </div>
+
+    <small translate>This settings are only applied locally.</small>
 </div>
 
 <div mat-dialog-actions>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.spec.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AutopilotSettingsComponent } from './autopilot-settings.component';
+
+xdescribe(`AutopilotSettingsComponent`, () => {
+    let component: AutopilotSettingsComponent;
+    let fixture: ComponentFixture<AutopilotSettingsComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [AutopilotSettingsComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AutopilotSettingsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it(`should create`, () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
@@ -1,7 +1,10 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
 import { marker as _ } from '@colsen1991/ngx-translate-extract-marker';
+import { first } from 'rxjs';
 
 import { BaseMeetingComponent } from '../../../../base/base-meeting.component';
+import { AutopilotService } from '../../services/autopilot.service';
 
 @Component({
     selector: `os-autopilot-settings`,
@@ -22,12 +25,16 @@ export class AutopilotSettingsComponent extends BaseMeetingComponent implements 
 
     public disabledAutopilotContentElements: { [key: string]: boolean } = {};
 
-    public constructor(private cd: ChangeDetectorRef) {
+    public constructor(
+        private dialogRef: MatDialogRef<AutopilotSettingsComponent>,
+        private cd: ChangeDetectorRef,
+        private autopilotService: AutopilotService
+    ) {
         super();
     }
 
     public ngOnInit(): void {
-        this.storage.get<{ [key: string]: boolean }>(`autopilot-disabled`).then(keys => {
+        this.autopilotService.disabledContentElements.pipe(first()).subscribe(keys => {
             this.disabledAutopilotContentElements = Object.assign(
                 this.autopilotContentElements.mapToObject(el => ({ [el.key]: false })),
                 keys
@@ -41,8 +48,10 @@ export class AutopilotSettingsComponent extends BaseMeetingComponent implements 
     }
 
     public updateDisabled(key: string, status: boolean): void {
-        this.disabledAutopilotContentElements[key] = status;
-        this.cd.markForCheck();
-        this.storage.set(`autopilot-disabled`, this.disabledAutopilotContentElements);
+        this.autopilotService.updateContentElementVisibility(key, status);
+    }
+
+    public close(): void {
+        this.dialogRef.close();
     }
 }

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { marker as _ } from '@colsen1991/ngx-translate-extract-marker';
+
+import { BaseMeetingComponent } from '../../../../base/base-meeting.component';
+
+@Component({
+    selector: `os-autopilot-settings`,
+    templateUrl: `./autopilot-settings.component.html`,
+    styleUrls: [`./autopilot-settings.component.scss`],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AutopilotSettingsComponent extends BaseMeetingComponent implements OnInit {
+    public readonly autopilotContentElements: { key: string; description: string }[] = [
+        { key: `list-of-speakers`, description: _(`List of speakers`) },
+        { key: `moderation-note`, description: _(`Moderation note`) },
+        { key: `poll-result`, description: _(`Poll results`) },
+        { key: `poll-running`, description: _(`Running poll`) },
+        { key: `poll-votable`, description: _(`Votable Poll`) },
+        { key: `projector`, description: _(`Projector`) },
+        { key: `speaking-times`, description: _(`Speaking times`) }
+    ];
+
+    public disabledAutopilotContentElements: string[] = [];
+
+    public constructor() {
+        super();
+    }
+
+    public ngOnInit(): void {
+        this.storage
+            .get<string[]>(`autopilot-disabled`)
+            .then(keys => (this.disabledAutopilotContentElements = keys || []));
+    }
+
+    public isDisabled(key: string): boolean {
+        return this.disabledAutopilotContentElements.indexOf(key) !== -1;
+    }
+
+    public setDisabled(key: string, status: unknown): void {
+        console.log(key, status);
+    }
+}

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
@@ -44,11 +44,11 @@ export class AutopilotSettingsComponent extends BaseMeetingComponent implements 
     }
 
     public isDisabled(key: string): boolean {
-        return this.disabledAutopilotContentElements[key];
+        return this.disabledAutopilotContentElements[key] === true;
     }
 
     public updateDisabled(key: string, status: boolean): void {
-        this.autopilotService.updateContentElementVisibility(key, status);
+        this.autopilotService.updateContentElementVisibility(key, !status);
     }
 
     public close(): void {

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-settings/autopilot-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { marker as _ } from '@colsen1991/ngx-translate-extract-marker';
 
 import { BaseMeetingComponent } from '../../../../base/base-meeting.component';
@@ -11,32 +11,38 @@ import { BaseMeetingComponent } from '../../../../base/base-meeting.component';
 })
 export class AutopilotSettingsComponent extends BaseMeetingComponent implements OnInit {
     public readonly autopilotContentElements: { key: string; description: string }[] = [
+        { key: `title`, description: _(`Autopilot content title`) },
         { key: `list-of-speakers`, description: _(`List of speakers`) },
         { key: `moderation-note`, description: _(`Moderation note`) },
-        { key: `poll-result`, description: _(`Poll results`) },
+        { key: `poll-finished`, description: _(`Poll results`) },
         { key: `poll-running`, description: _(`Running poll`) },
-        { key: `poll-votable`, description: _(`Votable Poll`) },
         { key: `projector`, description: _(`Projector`) },
         { key: `speaking-times`, description: _(`Speaking times`) }
     ];
 
-    public disabledAutopilotContentElements: string[] = [];
+    public disabledAutopilotContentElements: { [key: string]: boolean } = {};
 
-    public constructor() {
+    public constructor(private cd: ChangeDetectorRef) {
         super();
     }
 
     public ngOnInit(): void {
-        this.storage
-            .get<string[]>(`autopilot-disabled`)
-            .then(keys => (this.disabledAutopilotContentElements = keys || []));
+        this.storage.get<{ [key: string]: boolean }>(`autopilot-disabled`).then(keys => {
+            this.disabledAutopilotContentElements = Object.assign(
+                this.autopilotContentElements.mapToObject(el => ({ [el.key]: false })),
+                keys
+            );
+            this.cd.markForCheck();
+        });
     }
 
     public isDisabled(key: string): boolean {
-        return this.disabledAutopilotContentElements.indexOf(key) !== -1;
+        return this.disabledAutopilotContentElements[key];
     }
 
-    public setDisabled(key: string, status: unknown): void {
-        console.log(key, status);
+    public updateDisabled(key: string, status: boolean): void {
+        this.disabledAutopilotContentElements[key] = status;
+        this.cd.markForCheck();
+        this.storage.set(`autopilot-disabled`, this.disabledAutopilotContentElements);
     }
 }

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -14,7 +14,7 @@
     <div class="col-wrapper">
         <div class="col-main">
             <!-- Title Card -->
-            <mat-card class="os-card" *ngIf="!!title">
+            <mat-card class="os-card" *ngIf="!!title && disabledContentElements['title'] !== true">
                 <mat-card-content>
                     <a [routerLink]="viewModelUrl || null" [target]="lowerProjectionTarget" [state]="{ back: 'true' }">
                         <h1 class="line-and-icon">
@@ -28,7 +28,7 @@
             <os-list-of-speakers-content
                 *osPerms="
                     [permission.listOfSpeakersCanSee, permission.listOfSpeakersCanBeSpeaker];
-                    and: !!listOfSpeakers
+                    and: !!listOfSpeakers && disabledContentElements['list-of-speakers'] !== true
                 "
                 [listOfSpeakers]="listOfSpeakers!"
                 (canReaddLastSpeakerEvent)="canReaddLastSpeaker = $event"
@@ -86,24 +86,37 @@
             </os-list-of-speakers-content>
 
             <ng-container *osPerms="permission.listOfSpeakersCanSee">
-                <div *ngIf="structureLevelCountdownEnabled && listOfSpeakers && (showRightCol | async) === false">
+                <div
+                    *ngIf="
+                        structureLevelCountdownEnabled &&
+                        listOfSpeakers &&
+                        (showRightCol | async) === false &&
+                        disabledContentElements['speaking-times'] !== true
+                    "
+                >
                     <ng-container [ngTemplateOutlet]="speakingTimes"></ng-container>
                 </div>
             </ng-container>
 
             <!-- Moderator Note-->
-            <div *ngIf="hasCurrentProjection">
+            <div *ngIf="hasCurrentProjection && disabledContentElements['moderation-note'] !== true">
                 <os-moderation-note [listOfSpeakers]="listOfSpeakers"></os-moderation-note>
             </div>
 
             <!-- Poll-Collection -->
             <os-poll-collection
-                *ngIf="showPollCollection"
+                *ngIf="
+                    showPollCollection &&
+                    (disabledContentElements['poll-finished'] !== true ||
+                        disabledContentElements['poll-running'] !== true)
+                "
+                [onlyRunning]="disabledContentElements['poll-finished'] === true"
+                [onlyFinished]="disabledContentElements['poll-running'] === true"
                 [currentProjection]="projectedViewModel"
             ></os-poll-collection>
 
             <!-- Projector -->
-            <mat-card class="os-card spacer-bottom-60">
+            <mat-card *ngIf="disabledContentElements['projector'] !== true" class="os-card spacer-bottom-60">
                 <mat-card-content>
                     <a [routerLink]="projectorUrl" [target]="projectionTarget" [state]="{ back: 'true' }">
                         <p class="subtitle-text">{{ projectorTitle | translate }}</p>
@@ -119,7 +132,15 @@
         </div>
 
         <ng-container *osPerms="permission.listOfSpeakersCanSee">
-            <div *ngIf="structureLevelCountdownEnabled && listOfSpeakers && showRightCol | async" class="col-right">
+            <div
+                *ngIf="
+                    disabledContentElements['speaking-times'] !== true &&
+                        structureLevelCountdownEnabled &&
+                        listOfSpeakers &&
+                        showRightCol | async
+                "
+                class="col-right"
+            >
                 <ng-container [ngTemplateOutlet]="speakingTimes"></ng-container>
             </div>
         </ng-container>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -2,6 +2,13 @@
     <div class="title-slot">
         <h2>{{ 'Autopilot' | translate }}</h2>
     </div>
+
+    <!-- Menu -->
+    <ng-container class="menu-slot">
+        <a type="button" routerLink="edit" mat-icon-button [matTooltip]="'Customize autopilot' | translate">
+            <mat-icon>settings</mat-icon>
+        </a>
+    </ng-container>
 </os-head-bar>
 <div class="content-container">
     <div class="col-wrapper">

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -11,7 +11,14 @@
             [matTooltip]="'Customize autopilot' | translate"
             (click)="customizeAutopilot()"
         >
-            <mat-icon>settings</mat-icon>
+            <mat-icon
+                [matBadge]="numDisabledElements"
+                [matBadgeHidden]="numDisabledElements < 1"
+                matBadgeSize="small"
+                matBadgeColor="warn"
+            >
+                settings
+            </mat-icon>
         </button>
     </ng-container>
 </os-head-bar>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -5,9 +5,14 @@
 
     <!-- Menu -->
     <ng-container class="menu-slot">
-        <a type="button" routerLink="edit" mat-icon-button [matTooltip]="'Customize autopilot' | translate">
+        <button
+            type="button"
+            mat-icon-button
+            [matTooltip]="'Customize autopilot' | translate"
+            (click)="customizeAutopilot()"
+        >
             <mat-icon>settings</mat-icon>
-        </a>
+        </button>
     </ng-container>
 </os-head-bar>
 <div class="content-container">

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -110,8 +110,8 @@
                     (disabledContentElements['poll-finished'] !== true ||
                         disabledContentElements['poll-running'] !== true)
                 "
-                [onlyRunning]="disabledContentElements['poll-finished'] === true"
-                [onlyFinished]="disabledContentElements['poll-running'] === true"
+                [disableRunning]="disabledContentElements['poll-running'] === true"
+                [disableFinished]="disabledContentElements['poll-finished'] === true"
                 [currentProjection]="projectedViewModel"
             ></os-poll-collection>
 

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
@@ -114,7 +114,7 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
         super();
 
         this.storage.get<{ [key: string]: boolean }>(`autopilot-disabled`).then(keys => {
-            this.disabledContentElements = keys;
+            this.disabledContentElements = keys || {};
         });
 
         this.subscriptions.push(

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
@@ -1,5 +1,6 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject } from 'rxjs';
 import { HasProjectorTitle } from 'src/app/domain/interfaces';
@@ -15,6 +16,8 @@ import { ListOfSpeakersControllerService } from '../../../agenda/modules/list-of
 import { HasPolls } from '../../../polls';
 import { ViewProjection, ViewProjector } from '../../../projectors';
 import { ProjectorControllerService } from '../../../projectors/services/projector-controller.service';
+import { AutopilotService } from '../../services/autopilot.service';
+import { AutopilotSettingsComponent } from '../autopilot-settings/autopilot-settings.component';
 
 @Component({
     selector: `os-autopilot`,
@@ -106,18 +109,19 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
     public constructor(
         protected override translate: TranslateService,
         private operator: OperatorService,
+        private autopilotService: AutopilotService,
         projectorRepo: ProjectorControllerService,
         closService: CurrentListOfSpeakersService,
         private listOfSpeakersRepo: ListOfSpeakersControllerService,
-        breakpoint: BreakpointObserver
+        breakpoint: BreakpointObserver,
+        private dialog: MatDialog
     ) {
         super();
 
-        this.storage.get<{ [key: string]: boolean }>(`autopilot-disabled`).then(keys => {
-            this.disabledContentElements = keys || {};
-        });
-
         this.subscriptions.push(
+            this.autopilotService.disabledContentElements.subscribe(keys => {
+                this.disabledContentElements = keys || {};
+            }),
             projectorRepo.getReferenceProjectorObservable().subscribe(refProjector => {
                 if (refProjector) {
                     this.projector = refProjector;
@@ -155,5 +159,9 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
 
     public get hasCurrentProjection(): boolean {
         return !!this._currentProjection;
+    }
+
+    public customizeAutopilot(): void {
+        this.dialog.open(AutopilotSettingsComponent);
     }
 }

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
@@ -97,6 +97,8 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
 
     public structureLevelCountdownEnabled = false;
 
+    public disabledContentElements: { [key: string]: boolean } = {};
+
     public showRightCol: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
     private _currentProjection: ViewProjection | null = null;
@@ -110,6 +112,10 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
         breakpoint: BreakpointObserver
     ) {
         super();
+
+        this.storage.get<{ [key: string]: boolean }>(`autopilot-disabled`).then(keys => {
+            this.disabledContentElements = keys;
+        });
 
         this.subscriptions.push(
             projectorRepo.getReferenceProjectorObservable().subscribe(refProjector => {

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
@@ -98,6 +98,10 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
         }
     }
 
+    public get numDisabledElements(): number {
+        return Object.values(this.disabledContentElements).filter(v => v).length;
+    }
+
     public structureLevelCountdownEnabled = false;
 
     public disabledContentElements: { [key: string]: boolean } = {};

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.html
@@ -1,11 +1,13 @@
-<ng-container
-    *ngFor="let poll of polls; trackBy: identifyPoll"
-    [ngTemplateOutlet]="pollArea"
-    [ngTemplateOutletContext]="{ poll: poll, last: false }"
-></ng-container>
+<ng-container *ngIf="!onlyFinished">
+    <ng-container
+        *ngFor="let poll of polls; trackBy: identifyPoll"
+        [ngTemplateOutlet]="pollArea"
+        [ngTemplateOutletContext]="{ poll: poll, last: false }"
+    ></ng-container>
+</ng-container>
 
 <ng-container
-    *ngIf="lastPublishedPoll && !hasProjectedModelOpenPolls"
+    *ngIf="lastPublishedPoll && !hasProjectedModelOpenPolls && !onlyRunning"
     [ngTemplateOutlet]="pollArea"
     [ngTemplateOutletContext]="{ poll: lastPublishedPoll, last: true }"
 ></ng-container>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="!onlyFinished">
+<ng-container *ngIf="!disableRunning">
     <ng-container
         *ngFor="let poll of polls; trackBy: identifyPoll"
         [ngTemplateOutlet]="pollArea"
@@ -7,7 +7,7 @@
 </ng-container>
 
 <ng-container
-    *ngIf="lastPublishedPoll && !hasProjectedModelOpenPolls && !onlyRunning"
+    *ngIf="lastPublishedPoll && !hasProjectedModelOpenPolls && !disableFinished"
     [ngTemplateOutlet]="pollArea"
     [ngTemplateOutletContext]="{ poll: lastPublishedPoll, last: true }"
 ></ng-container>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
@@ -28,6 +28,12 @@ export class PollCollectionComponent<C extends PollContentObject> extends BaseCo
     private _currentProjection: (Partial<HasPolls<C>> & { readonly fqid: string }) | null = null;
 
     @Input()
+    public onlyRunning = false;
+
+    @Input()
+    public onlyFinished = false;
+
+    @Input()
     public set currentProjection(viewModel: (Partial<HasPolls<C>> & { readonly fqid: string }) | null) {
         this._currentProjection = viewModel;
         this.updateLastPublished();

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
@@ -28,10 +28,10 @@ export class PollCollectionComponent<C extends PollContentObject> extends BaseCo
     private _currentProjection: (Partial<HasPolls<C>> & { readonly fqid: string }) | null = null;
 
     @Input()
-    public onlyRunning = false;
+    public disableRunning = false;
 
     @Input()
-    public onlyFinished = false;
+    public disableFinished = false;
 
     @Input()
     public set currentProjection(viewModel: (Partial<HasPolls<C>> & { readonly fqid: string }) | null) {

--- a/client/src/app/site/pages/meetings/pages/autopilot/services/autopilot.service.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/services/autopilot.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { StorageService } from 'src/app/gateways/storage.service';
+
+@Injectable({ providedIn: `root` })
+export class AutopilotService {
+    private disabledContentElementsSubject = new BehaviorSubject<{ [key: string]: boolean }>({});
+
+    public get disabledContentElements(): Observable<{ [key: string]: boolean }> {
+        return this.disabledContentElementsSubject;
+    }
+
+    public constructor(private storage: StorageService) {
+        this.storage.get<{ [key: string]: boolean }>(`autopilot-disabled`).then(keys => {
+            this.disabledContentElementsSubject.next(keys);
+        });
+    }
+
+    public async updateContentElementVisibility(key: string, status: boolean): Promise<void> {
+        const disabledContentElements = this.disabledContentElementsSubject.getValue();
+        disabledContentElements[key] = status;
+        this.disabledContentElementsSubject.next(disabledContentElements);
+        await this.storage.set(`autopilot-disabled`, disabledContentElements);
+    }
+}

--- a/client/src/app/site/pages/meetings/pages/autopilot/services/autopilot.service.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/services/autopilot.service.ts
@@ -12,12 +12,12 @@ export class AutopilotService {
 
     public constructor(private storage: StorageService) {
         this.storage.get<{ [key: string]: boolean }>(`autopilot-disabled`).then(keys => {
-            this.disabledContentElementsSubject.next(keys);
+            this.disabledContentElementsSubject.next(keys || {});
         });
     }
 
     public async updateContentElementVisibility(key: string, status: boolean): Promise<void> {
-        const disabledContentElements = this.disabledContentElementsSubject.getValue();
+        const disabledContentElements = this.disabledContentElementsSubject.getValue() || {};
         disabledContentElements[key] = status;
         this.disabledContentElementsSubject.next(disabledContentElements);
         await this.storage.set(`autopilot-disabled`, disabledContentElements);


### PR DESCRIPTION
resolves #3430 

This also fixes a race condition in `base-repository.service.ts` where if one registered an sortList and directly unregisters it an exception is thrown causing content to not being displayed. 