### PR TITLE
Increase motion number column to prevent line break.

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
@@ -58,7 +58,7 @@
         [(selectedRows)]="selectedRows"
     >
         <!-- number -->
-        <div *osScrollingTableCell="'number'; row as motion; config: { width: 60 }" class="cell-slot fill">
+        <div *osScrollingTableCell="'number'; row as motion; config: { width: 73 }" class="cell-slot fill">
             <os-detail-view-navigator [model]="motion" *ngIf="!isMultiSelect"></os-detail-view-navigator>
             <div class="column-number innerTable">
                 {{ motion.number }}

--- a/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.scss
+++ b/client/src/app/ui/modules/scrolling-table/components/scrolling-table/scrolling-table.component.scss
@@ -10,7 +10,7 @@
         position: relative;
         flex: 1;
         padding-left: 12px;
-        padding-right: 12px;
+        padding-right: 6px;
         box-sizing: content-box;
         width: 100%;
         height: 100%;


### PR DESCRIPTION
resolves #3471 

Optimize column with for motion identifier (up to this kind of identifier "A 001 -Ä001"). Reduce 6px padding between columns.