### PR TITLE
Fix mat-hint overlapping with following components

### DIFF
--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.html
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.html
@@ -1,7 +1,7 @@
 <div class="settings-field-wrapper">
     <div class="form-item" [style.marginLeft.px]="setting.indentation * INDENTATION_PIXEL_AMOUNT">
         <form class="settings-form-group" [formGroup]="form">
-            <mat-form-field *ngIf="!isExcludedType(setting.type!)">
+            <mat-form-field *ngIf="!isExcludedType(setting.type!)" subscriptSizing="dynamic">
                 <!-- Decides which input-type to take (i.e) date, select, input) -->
                 <ng-container [ngSwitch]="setting.type">
                     <ng-container *ngSwitchCase="'choice'">

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.scss
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.scss
@@ -6,13 +6,6 @@
         flex: 2;
     }
 
-    .mat-mdc-form-field {
-        /* TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-        .mat-form-field-subscript-wrapper {
-            position: static;
-        }
-    }
-
     /* Full width form fields */
     .mat-mdc-form-field {
         width: 100%;

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-view/participant-detail-view.component.html
@@ -183,7 +183,7 @@
 
             <div *ngIf="isAllowed('update')">
                 <!-- Comment -->
-                <mat-form-field class="form100 force-min-width">
+                <mat-form-field class="form100 force-min-width" subscriptSizing="dynamic">
                     <mat-label>{{ 'Comment' | translate }}</mat-label>
                     <input matInput formControlName="comment" />
                     <mat-hint>{{ 'Only for internal notes.' | translate }}</mat-hint>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
@@ -225,7 +225,7 @@
 
                             <div *ngIf="isAllowedFn('update')">
                                 <!-- Comment -->
-                                <mat-form-field class="form100 force-min-width">
+                                <mat-form-field class="form100 force-min-width" subscriptSizing="dynamic">
                                     <mat-label>{{ 'Comment' | translate }}</mat-label>
                                     <input matInput formControlName="comment" />
                                     <mat-hint>{{ 'Only for internal notes.' | translate }}</mat-hint>

--- a/client/src/app/site/pages/meetings/pages/projectors/components/projector-countdown-dialog/components/projector-countdown-dialog/projector-countdown-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/projectors/components/projector-countdown-dialog/components/projector-countdown-dialog/projector-countdown-dialog.component.html
@@ -17,7 +17,7 @@
         </mat-form-field>
 
         <!-- Time field -->
-        <mat-form-field>
+        <mat-form-field subscriptSizing="dynamic">
             <mat-label>{{ 'Time' | translate }}</mat-label>
             <input matInput formControlName="duration" required />
             <mat-hint translate>If the value is set to 0 the time counts up as stopwatch.</mat-hint>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
@@ -21,7 +21,7 @@
             </mat-form-field>
 
             <p class="has-hint">
-                <mat-form-field *ngIf="isCreateView">
+                <mat-form-field *ngIf="isCreateView" subscriptSizing="dynamic">
                     <mat-label>{{ 'Duplicate from' | translate }}</mat-label>
                     <os-list-search-selector
                         [inputListValues]="availableMeetingsObservable"

--- a/client/src/app/site/pages/organization/pages/settings/modules/settings-detail/components/organization-settings/organization-settings.component.html
+++ b/client/src/app/site/pages/organization/pages/settings/modules/settings-detail/components/organization-settings/organization-settings.component.html
@@ -75,7 +75,7 @@
                 <h2>{{ 'Superadmin settings' | translate }}</h2>
                 <!-- System url -->
                 <section>
-                    <mat-form-field>
+                    <mat-form-field subscriptSizing="dynamic">
                         <mat-label>{{ 'OpenSlides URL' | translate }}</mat-label>
                         <input matInput formControlName="url" />
                         <mat-hint>
@@ -102,7 +102,7 @@
                     </mat-checkbox>
                 </section>
                 <section>
-                    <mat-form-field>
+                    <mat-form-field subscriptSizing="dynamic">
                         <mat-label>{{ 'Limit of active meetings' | translate }}</mat-label>
                         <input
                             matInput
@@ -116,7 +116,7 @@
                     </mat-form-field>
                 </section>
                 <section>
-                    <mat-form-field>
+                    <mat-form-field subscriptSizing="dynamic">
                         <mat-label>{{ 'Limit of active accounts' | translate }}</mat-label>
                         <input
                             matInput
@@ -152,7 +152,7 @@
                 </section>
                 <!-- JSON source attribute -->
                 <section>
-                    <mat-form-field>
+                    <mat-form-field subscriptSizing="dynamic">
                         <mat-label>{{ 'Attribute mapping (JSON)' | translate }}</mat-label>
                         <textarea matInput formControlName="saml_attr_mapping" [rows]="ssoConfigRows"></textarea>
                         <mat-hint>


### PR DESCRIPTION
close #3514 

Originally it was anticipated that it's a single case in meetings > settings > participants. That was not the case as the bug was just not detected in other parts of the application.