### PR TITLE
Fix autoupdate errors with ok status

### DIFF
--- a/client/src/app/worker/http/http-stream.ts
+++ b/client/src/app/worker/http/http-stream.ts
@@ -146,7 +146,11 @@ export abstract class HttpStream {
             this._receivedDataResolver = undefined;
         }
 
-        if (data instanceof ErrorDescription || isCommunicationError(data) || isCommunicationErrorWrapper(data)) {
+        if (
+            data instanceof ErrorDescription ||
+            isCommunicationError(this.parse(data)) ||
+            isCommunicationErrorWrapper(this.parse(data))
+        ) {
             this.handleError(data);
         } else {
             data = this.parse(data);


### PR DESCRIPTION
Error objects are currently not parsed correctly when autoupdate is responding with an ok http status code resulting in a reconnect loop.