### PR TITLE
Hide empty space if three dot menu is not shown

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
@@ -150,14 +150,21 @@
     </div>
 
     <!-- Menu -->
-    <div *osScrollingTableCell="'menu'; row as user; config: { width: 40 }" class="cell-slot fill">
+    <div
+        *osScrollingTableCell="
+            'menu';
+            row as user;
+            config: { width: 40 };
+            isHidden: !(canSeeItemMenu() || (viewport.isMobileSubject | async))
+        "
+        class="cell-slot"
+    >
         <button
             mat-icon-button
             [disabled]="isMultiSelect"
             [matMenuTriggerFor]="singleItemMenu"
             (click)="$event.stopPropagation()"
             [matMenuTriggerData]="{ user: user }"
-            *ngIf="canSeeSingleItemMenu(user) || (viewport.isMobileSubject | async)"
         >
             <mat-icon>more_vert</mat-icon>
         </button>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
@@ -155,7 +155,7 @@
             'menu';
             row as user;
             config: { width: 40 };
-            isHidden: !(canSeeItemMenu() || (viewport.isMobileSubject | async))
+            isHidden: !canSeeItemMenu() && viewport.isMobileSubject
         "
         class="cell-slot"
     >

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
@@ -458,8 +458,8 @@ export class ParticipantListComponent extends BaseMeetingListViewComponent<ViewU
         await this.repo.removeUsersFromMeeting([user]);
     }
 
-    public canSeeSingleItemMenu(user: ViewUser): boolean {
-        return this.operator.hasPerms(Permission.userCanUpdate) || this.canChangePassword(user);
+    public canSeeItemMenu(): boolean {
+        return this.operator.hasPerms(Permission.userCanUpdate);
     }
 
     /**

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.ts
@@ -200,11 +200,7 @@ export class ParticipantListComponent extends BaseMeetingListViewComponent<ViewU
     public canChangePassword(user: ViewUser): boolean {
         const userOML = user?.organization_management_level;
         const sufficientOML = userOML ? this.operator.hasOrganizationPermissions(userOML as OML) : true;
-        return (
-            !user?.saml_id &&
-            this.userService.isAllowed(`changePassword`, user.id === this.operator.user.id) &&
-            sufficientOML
-        );
+        return !user?.saml_id && this.userService.isAllowed(`changePassword`, false) && sufficientOML;
     }
 
     public isUserPresent(user: ViewUser): boolean {

--- a/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
+++ b/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
@@ -24,11 +24,11 @@ export class ScrollingTableCellDirective implements OnInit, OnDestroy, Scrolling
 
     @Input()
     public set osScrollingTableCellIsHidden(isHidden: boolean | Observable<boolean>) {
-        if (this.inputSubscription) {
-            this.inputSubscription.unsubscribe();
+        if (this.isHiddenSubscription) {
+            this.isHiddenSubscription.unsubscribe();
         }
         if (typeof isHidden == `boolean`) {
-            this.inputSubscription = null;
+            this.isHiddenSubscription = null;
             this._isHidden = isHidden;
         } else {
             isHidden.subscribe(isMobileView => {
@@ -92,7 +92,7 @@ export class ScrollingTableCellDirective implements OnInit, OnDestroy, Scrolling
     private _property = ``;
     private _labelString = ``;
     private _isDefault = false;
-    private inputSubscription: Subscription | null = null;
+    private isHiddenSubscription: Subscription | null = null;
 
     public constructor(
         public readonly template: TemplateRef<any>,
@@ -109,8 +109,8 @@ export class ScrollingTableCellDirective implements OnInit, OnDestroy, Scrolling
     }
 
     public ngOnDestroy(): void {
-        if (this.inputSubscription) {
-            this.inputSubscription.unsubscribe();
+        if (this.isHiddenSubscription) {
+            this.isHiddenSubscription.unsubscribe();
         }
     }
 

--- a/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
+++ b/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
@@ -1,5 +1,6 @@
 import { TemplatePortal } from '@angular/cdk/portal';
 import { Directive, Input, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { ScrollingTableManageService } from '../services';
 import { ScrollingTableCellDefConfig } from './scrolling-table-cell-config';
@@ -22,8 +23,14 @@ export class ScrollingTableCellDirective implements OnInit, ScrollingTableCellDe
     }
 
     @Input()
-    public set osScrollingTableCellIsHidden(isHidden: boolean) {
-        this._isHidden = isHidden;
+    public set osScrollingTableCellIsHidden(isHidden: boolean | Observable<boolean>) {
+        if (typeof isHidden == `boolean`) {
+            this._isHidden = isHidden;
+        } else {
+            isHidden.subscribe(isMobileView => {
+                this._isHidden = !isMobileView;
+            });
+        }
     }
 
     @Input()

--- a/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
+++ b/client/src/app/ui/modules/scrolling-table/directives/scrolling-table-cell.directive.ts
@@ -27,9 +27,11 @@ export class ScrollingTableCellDirective implements OnInit, ScrollingTableCellDe
         if (typeof isHidden == `boolean`) {
             this._isHidden = isHidden;
         } else {
-            isHidden.subscribe(isMobileView => {
-                this._isHidden = !isMobileView;
-            });
+            isHidden
+                .subscribe(isMobileView => {
+                    this._isHidden = !isMobileView;
+                })
+                .unsubscribe();
         }
     }
 


### PR DESCRIPTION
closes #3587 

I removed the check for the ownPage (and set it to false always) to hide the option to change own password at all at this specific place.
The previous behaviour seemed unintuitive. (Only account/organization admins got the option to change their own password at this place. these admins were not allowed to update participants in the meeting in question) 
Note: Users are still able to change their own password via the my profile dialog