### PR TITLE
Improve meeting change subscription handling

### DIFF
--- a/client/src/app/site/pages/meetings/base/base-meeting-model-request-handler.component.ts
+++ b/client/src/app/site/pages/meetings/base/base-meeting-model-request-handler.component.ts
@@ -1,0 +1,21 @@
+import { Directive } from '@angular/core';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
+import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+
+@Directive()
+export abstract class BaseMeetingModelRequestHandler extends BaseModelRequestHandlerComponent {
+    protected abstract getSubscriptions(meetingId: Id): SubscriptionConfig<any>[];
+
+    protected override onShouldCreateModelRequests(_params: any, id: number | null): void {
+        if (id) {
+            this.subscribeTo(this.getSubscriptions(id), { hideWhenMeetingChanged: true });
+        }
+    }
+
+    protected override onNextMeetingId(id: number | null): void {
+        if (id) {
+            this.updateSubscribeTo(this.getSubscriptions(id), { hideWhenMeetingChanged: true });
+        }
+    }
+}

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/agenda-content-object-form/components/agenda-content-object-form/agenda-content-object-form.component.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/agenda-content-object-form/components/agenda-content-object-form/agenda-content-object-form.component.ts
@@ -2,8 +2,9 @@ import { AfterViewInit, Component, Input, OnDestroy } from '@angular/core';
 import { AbstractControl, UntypedFormGroup } from '@angular/forms';
 import { BehaviorSubject, map, Observable, Subscription } from 'rxjs';
 import { Permission } from 'src/app/domain/definitions/permission';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
 import { ItemTypeChoices } from 'src/app/domain/models/agenda/agenda-item';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { BaseMeetingModelRequestHandler } from 'src/app/site/pages/meetings/base/base-meeting-model-request-handler.component';
 import { ViewAgendaItem } from 'src/app/site/pages/meetings/pages/agenda';
 import { getAgendaListMinimalSubscriptionConfig } from 'src/app/site/pages/meetings/pages/agenda/agenda.subscription';
 import { MeetingSettingsService } from 'src/app/site/pages/meetings/services/meeting-settings.service';
@@ -16,7 +17,7 @@ import { AgendaContentObjectFormService } from '../../services/agenda-content-ob
     styleUrls: [`./agenda-content-object-form.component.scss`]
 })
 export class AgendaContentObjectFormComponent
-    extends BaseModelRequestHandlerComponent
+    extends BaseMeetingModelRequestHandler
     implements AfterViewInit, OnDestroy
 {
     @Input()
@@ -92,10 +93,8 @@ export class AgendaContentObjectFormComponent
         super.ngOnDestroy();
     }
 
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getAgendaListMinimalSubscriptionConfig(id), { hideWhenDestroyed: true });
-        }
+    protected getSubscriptions(meetingId: number): SubscriptionConfig<any>[] {
+        return [getAgendaListMinimalSubscriptionConfig(meetingId)];
     }
 
     private setupSubscription(): void {

--- a/client/src/app/site/pages/meetings/pages/agenda/components/agenda-main/agenda-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/components/agenda-main/agenda-main.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
+import { BaseMeetingModelRequestHandler } from 'src/app/site/pages/meetings/base/base-meeting-model-request-handler.component';
 
 import { getAgendaListSubscriptionConfig } from '../../agenda.subscription';
 
@@ -8,10 +10,8 @@ import { getAgendaListSubscriptionConfig } from '../../agenda.subscription';
     templateUrl: `./agenda-main.component.html`,
     styleUrls: [`./agenda-main.component.scss`]
 })
-export class AgendaMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getAgendaListSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-        }
+export class AgendaMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getAgendaListSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/components/list-of-speakers-main/list-of-speakers-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/components/list-of-speakers-main/list-of-speakers-main.component.ts
@@ -20,24 +20,30 @@ export class ListOfSpeakersMainComponent extends BaseModelRequestHandlerComponen
 
     protected override onParamsChanged(params: any, oldParams: any): void {
         if (params[`id`] !== oldParams[`id`] || params[`meetingId`] !== oldParams[`meetingId`]) {
-            this.sequentialNumberMapping
-                .getIdBySequentialNumber({
-                    collection: ListOfSpeakers.COLLECTION,
-                    meetingId: params[`meetingId`],
-                    sequentialNumber: +params[`id`]
-                })
-                .then(id => {
-                    if (id && this._currentLOSId !== id) {
-                        this._currentLOSId = id;
-                        this.loadLOSDetail();
-                    }
-                });
+            this.loadLOSDetail(+params[`id`], +params[`meetingId`]);
         }
     }
 
-    private loadLOSDetail(): void {
-        this.updateSubscribeTo(getListOfSpeakersDetailSubscriptionConfig(this._currentLOSId), {
-            hideWhenDestroyed: true
-        });
+    protected override onShouldCreateModelRequests(params: any, meetingId: Id): void {
+        if (params[`id`] && meetingId) {
+            this.loadLOSDetail(+params[`id`], meetingId);
+        }
+    }
+
+    private loadLOSDetail(id: Id, meetingId: Id): void {
+        this.sequentialNumberMapping
+            .getIdBySequentialNumber({
+                collection: ListOfSpeakers.COLLECTION,
+                meetingId: meetingId,
+                sequentialNumber: id
+            })
+            .then(id => {
+                if (id && this._currentLOSId !== id) {
+                    this._currentLOSId = id;
+                    this.updateSubscribeTo(getListOfSpeakersDetailSubscriptionConfig(this._currentLOSId), {
+                        hideWhenDestroyed: true
+                    });
+                }
+            });
     }
 }

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail-main/topic-detail-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail-main/topic-detail-main.component.ts
@@ -22,27 +22,44 @@ export class TopicDetailMainComponent extends BaseModelRequestHandlerComponent {
         super();
     }
 
-    protected override onParamsChanged(params: any, oldParams: any): void {
-        if (params[`id`] !== oldParams[`id`] || params[`meetingId`] !== oldParams[`meetingId`]) {
-            this.sequentialNumberMapping
-                .getIdBySequentialNumber({
-                    collection: Topic.COLLECTION,
-                    meetingId: params[`meetingId`],
-                    sequentialNumber: +params[`id`]
-                })
-                .then(id => {
-                    if (id && this._currentTopicId !== id) {
-                        this._currentTopicId = id;
-                        this.loadTopicDetail();
-                    } else if (!id && params[`meetingId`]) {
-                        this.loadTopicList(+params[`meetingId`]);
-                    }
-                });
+    protected override onShouldCreateModelRequests(params: any, meetingId: any): void {
+        if (meetingId) {
+            if (+params[`id`]) {
+                this.loadTopicDetail(+params[`id`], +params[`meetingId`]);
+            } else {
+                this.loadTopicList(+params[`meetingId`]);
+            }
         }
     }
 
-    private loadTopicDetail(): void {
-        this.updateSubscribeTo(getTopicDetailSubscriptionConfig(this._currentTopicId), { hideWhenDestroyed: true });
+    protected override onParamsChanged(params: any, oldParams: any): void {
+        if (
+            params[`id`] !== oldParams[`id`] ||
+            (+params[`meetingId`] && params[`meetingId`] !== oldParams[`meetingId`])
+        ) {
+            if (+params[`id`]) {
+                this.loadTopicDetail(+params[`id`], +params[`meetingId`]);
+            } else {
+                this.loadTopicList(+params[`meetingId`]);
+            }
+        }
+    }
+
+    private loadTopicDetail(sNr: Id, meetingId: Id): void {
+        this.sequentialNumberMapping
+            .getIdBySequentialNumber({
+                collection: Topic.COLLECTION,
+                meetingId,
+                sequentialNumber: sNr
+            })
+            .then(id => {
+                if (id && this._currentTopicId !== id) {
+                    this._currentTopicId = id;
+                    this.updateSubscribeTo(getTopicDetailSubscriptionConfig(this._currentTopicId), {
+                        hideWhenDestroyed: true
+                    });
+                }
+            });
     }
 
     private async loadTopicList(meetingId: number): Promise<void> {

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/components/topic-import-main/topic-import-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/components/topic-import-main/topic-import-main.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
+import { BaseMeetingModelRequestHandler } from 'src/app/site/pages/meetings/base/base-meeting-model-request-handler.component';
 
 import { getAgendaListSubscriptionConfig } from '../../../../../../agenda.subscription';
 
@@ -8,10 +10,8 @@ import { getAgendaListSubscriptionConfig } from '../../../../../../agenda.subscr
     templateUrl: `./topic-import-main.component.html`,
     styleUrls: [`./topic-import-main.component.scss`]
 })
-export class TopicImportMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getAgendaListSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-        }
+export class TopicImportMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getAgendaListSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/assignments/components/assignment-main/assignment-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/components/assignment-main/assignment-main.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
 
+import { BaseMeetingModelRequestHandler } from '../../../../base/base-meeting-model-request-handler.component';
 import { getAssignmentSubscriptionConfig } from '../../assignments.subscription';
 
 @Component({
@@ -8,10 +10,8 @@ import { getAssignmentSubscriptionConfig } from '../../assignments.subscription'
     templateUrl: `./assignment-main.component.html`,
     styleUrls: [`./assignment-main.component.scss`]
 })
-export class AssignmentMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getAssignmentSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-        }
+export class AssignmentMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getAssignmentSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-main/assignment-poll-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-main/assignment-poll-main.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Id } from 'src/app/domain/definitions/key-types';
 import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
 import { SequentialNumberMappingService } from 'src/app/site/pages/meetings/services/sequential-number-mapping.service';
 
@@ -16,8 +17,27 @@ export class AssignmentPollMainComponent extends BaseModelRequestHandlerComponen
         super();
     }
 
+    protected override onShouldCreateModelRequests(params: any, meetingId: Id): void {
+        if (params[`id`]) {
+            this.sequentialNumberMappingService
+                .getIdBySequentialNumber({
+                    collection: ViewPoll.COLLECTION,
+                    meetingId,
+                    sequentialNumber: +params[`id`]
+                })
+                .then(id => {
+                    if (id) {
+                        this.subscribeTo(getPollDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
+                        this.subscribeTo(getParticipantMinimalSubscriptionConfig(+params[`meetingId`]), {
+                            hideWhenDestroyed: true
+                        });
+                    }
+                });
+        }
+    }
+
     protected override onParamsChanged(params: any, oldParams: any): void {
-        if (params[`id`] && params[`id`] !== oldParams[`id`]) {
+        if ((params[`id`] && params[`id`] !== oldParams[`id`]) || params[`meetingId`] !== oldParams[`meetingId`]) {
             this.sequentialNumberMappingService
                 .getIdBySequentialNumber({
                     collection: ViewPoll.COLLECTION,
@@ -26,8 +46,8 @@ export class AssignmentPollMainComponent extends BaseModelRequestHandlerComponen
                 })
                 .then(id => {
                     if (id) {
-                        this.subscribeTo(getPollDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
-                        this.subscribeTo(getParticipantMinimalSubscriptionConfig(+params[`meetingId`]), {
+                        this.updateSubscribeTo(getPollDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
+                        this.updateSubscribeTo(getParticipantMinimalSubscriptionConfig(+params[`meetingId`]), {
                             hideWhenDestroyed: true
                         });
                     }

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-main/autopilot-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot-main/autopilot-main.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { distinctUntilChanged, map } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
 import { ProjectorRepositoryService } from 'src/app/gateways/repositories/projectors/projector-repository.service';
 import { collectionFromFqid } from 'src/app/infrastructure/utils/transform-functions';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { BaseMeetingModelRequestHandler } from 'src/app/site/pages/meetings/base/base-meeting-model-request-handler.component';
 import { CollectionMapperService } from 'src/app/site/services/collection-mapper.service';
 
 import {
@@ -17,7 +18,7 @@ import {
     templateUrl: `./autopilot-main.component.html`,
     styleUrls: [`./autopilot-main.component.scss`]
 })
-export class AutopilotMainComponent extends BaseModelRequestHandlerComponent {
+export class AutopilotMainComponent extends BaseMeetingModelRequestHandler {
     private currentSubscriptions: Id[] = [];
 
     public constructor(
@@ -83,11 +84,7 @@ export class AutopilotMainComponent extends BaseModelRequestHandlerComponent {
         );
     }
 
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getAutopilotSubscriptionConfig(id), {
-                hideWhenMeetingChanged: true
-            });
-        }
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getAutopilotSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/history/components/history-main/history-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/history/components/history-main/history-main.component.ts
@@ -12,7 +12,7 @@ import { getParticipantMinimalSubscriptionConfig } from '../../../participants/p
     styleUrls: [`./history-main.component.scss`]
 })
 export class HistoryMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: Id | null): void {
+    protected override onShouldCreateModelRequests(_params: any, id: Id | null): void {
         if (id) {
             this.subscribeTo(getMotionListMinimalSubscriptionConfig(id), { hideWhenDestroyed: true });
             this.subscribeTo(getParticipantMinimalSubscriptionConfig(id), { hideWhenDestroyed: true });

--- a/client/src/app/site/pages/meetings/pages/mediafiles/components/mediafile-main/mediafile-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/components/mediafile-main/mediafile-main.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
 
+import { BaseMeetingModelRequestHandler } from '../../../../base/base-meeting-model-request-handler.component';
 import { getMediafilesSubscriptionConfig } from '../../mediafiles.subscription';
 
 @Component({
@@ -8,10 +10,8 @@ import { getMediafilesSubscriptionConfig } from '../../mediafiles.subscription';
     templateUrl: `./mediafile-main.component.html`,
     styleUrls: [`./mediafile-main.component.scss`]
 })
-export class MediafileMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getMediafilesSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-        }
+export class MediafileMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getMediafilesSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-main/meeting-settings-group-detail-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-main/meeting-settings-group-detail-main.component.ts
@@ -17,7 +17,15 @@ export class MeetingSettingsGroupDetailMainComponent extends BaseModelRequestHan
             params[`group`] === MOTIONS_SETTINGS_GROUP &&
             params[`meetingId`] !== oldParams[`meetingId`]
         ) {
-            this.subscribeTo(getMotionWorkflowSubscriptionConfig(+params[`meetingId`]), {
+            this.updateSubscribeTo(getMotionWorkflowSubscriptionConfig(+params[`meetingId`]), {
+                hideWhenMeetingChanged: true
+            });
+        }
+    }
+
+    protected override onShouldCreateModelRequests(params?: any, meetingId?: number): void {
+        if (params[`group`] && params[`group`] === MOTIONS_SETTINGS_GROUP && meetingId) {
+            this.subscribeTo(getMotionWorkflowSubscriptionConfig(meetingId), {
                 hideWhenMeetingChanged: true
             });
         }

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-main/motion-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-main/motion-main.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
 
+import { BaseMeetingModelRequestHandler } from '../../../../base/base-meeting-model-request-handler.component';
 import {
     getMotionBlockSubscriptionConfig,
     getMotionListSubscriptionConfig,
@@ -13,18 +15,13 @@ import {
     templateUrl: `./motion-main.component.html`,
     styleUrls: [`./motion-main.component.scss`]
 })
-export class MotionMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.updateSubscribeTo(
-                [
-                    getMotionListSubscriptionConfig(id),
-                    getMotionBlockSubscriptionConfig(id),
-                    getMotionWorkflowSubscriptionConfig(id),
-                    getMotionsSubmodelSubscriptionConfig(id)
-                ],
-                { hideWhenMeetingChanged: true }
-            );
-        }
+export class MotionMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [
+            getMotionListSubscriptionConfig(id),
+            getMotionBlockSubscriptionConfig(id),
+            getMotionWorkflowSubscriptionConfig(id),
+            getMotionsSubmodelSubscriptionConfig(id)
+        ];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/amendments/components/amendment-list-main/amendment-list-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/amendments/components/amendment-list-main/amendment-list-main.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
+import { BaseMeetingModelRequestHandler } from 'src/app/site/pages/meetings/base/base-meeting-model-request-handler.component';
 
 import { getAmendmentListSubscriptionConfig } from '../../../../motions.subscription';
 
@@ -8,10 +10,8 @@ import { getAmendmentListSubscriptionConfig } from '../../../../motions.subscrip
     templateUrl: `./amendment-list-main.component.html`,
     styleUrls: [`./amendment-list-main.component.scss`]
 })
-export class AmendmentListMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getAmendmentListSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-        }
+export class AmendmentListMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getAmendmentListSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-main/motion-poll-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-main/motion-poll-main.component.ts
@@ -16,6 +16,25 @@ export class MotionPollMainComponent extends BaseModelRequestHandlerComponent {
         super();
     }
 
+    protected override onShouldCreateModelRequests(params?: any, meetingId?: number): void {
+        if (params[`id`]) {
+            this.sequentialNumberMappingService
+                .getIdBySequentialNumber({
+                    collection: ViewPoll.COLLECTION,
+                    meetingId,
+                    sequentialNumber: +params[`id`]
+                })
+                .then(id => {
+                    if (id) {
+                        this.subscribeTo(getPollDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
+                        this.subscribeTo(getParticipantMinimalSubscriptionConfig(+params[`meetingId`]), {
+                            hideWhenDestroyed: true
+                        });
+                    }
+                });
+        }
+    }
+
     protected override onParamsChanged(params: any, oldParams: any): void {
         if (params[`id`] !== oldParams[`id`]) {
             this.sequentialNumberMappingService
@@ -26,8 +45,8 @@ export class MotionPollMainComponent extends BaseModelRequestHandlerComponent {
                 })
                 .then(id => {
                     if (id) {
-                        this.subscribeTo(getPollDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
-                        this.subscribeTo(getParticipantMinimalSubscriptionConfig(+params[`meetingId`]), {
+                        this.updateSubscribeTo(getPollDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
+                        this.updateSubscribeTo(getParticipantMinimalSubscriptionConfig(+params[`meetingId`]), {
                             hideWhenDestroyed: true
                         });
                     }

--- a/client/src/app/site/pages/meetings/pages/participants/components/participant-main/participant-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/components/participant-main/participant-main.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
+import { BaseMeetingModelRequestHandler } from 'src/app/site/pages/meetings/base/base-meeting-model-request-handler.component';
 
 import {
     getParticipantListSubscriptionConfig,
@@ -12,20 +14,12 @@ import { getStructureLevelListSubscriptionConfig } from '../../participants.subs
     templateUrl: `./participant-main.component.html`,
     styleUrls: [`./participant-main.component.scss`]
 })
-export class ParticipantMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            // TODO: Do requests for speaker list and structure level list somewhere else
-            this.subscribeTo(
-                [
-                    getParticipantListSubscriptionConfig(id),
-                    getStructureLevelListSubscriptionConfig(id),
-                    getSpeakersListSubscriptionConfig(id)
-                ],
-                {
-                    hideWhenMeetingChanged: true
-                }
-            );
-        }
+export class ParticipantMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [
+            getParticipantListSubscriptionConfig(id),
+            getStructureLevelListSubscriptionConfig(id),
+            getSpeakersListSubscriptionConfig(id)
+        ];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail/participant-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail/participant-detail.component.ts
@@ -9,9 +9,15 @@ import { getParticipantDetailSubscription } from '../../../../participants.subsc
     styleUrls: [`./participant-detail.component.scss`]
 })
 export class ParticipantDetailComponent extends BaseModelRequestHandlerComponent {
+    protected override onShouldCreateModelRequests(params?: any): void {
+        if (params[`id`]) {
+            this.subscribeTo(getParticipantDetailSubscription(+params[`id`]), { hideWhenDestroyed: true });
+        }
+    }
+
     protected override onParamsChanged(params: any, oldParams: any): void {
         if (params[`id`] && params[`id`] !== oldParams[`id`]) {
-            this.subscribeTo(getParticipantDetailSubscription(+params[`id`]), { hideWhenDestroyed: true });
+            this.updateSubscribeTo(getParticipantDetailSubscription(+params[`id`]), { hideWhenDestroyed: true });
         }
     }
 }

--- a/client/src/app/site/pages/meetings/pages/polls/components/poll-main/poll-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/polls/components/poll-main/poll-main.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
 
+import { BaseMeetingModelRequestHandler } from '../../../../base/base-meeting-model-request-handler.component';
 import { getPollListSubscriptionConfig } from '../../polls.subscription';
 
 @Component({
@@ -8,10 +10,8 @@ import { getPollListSubscriptionConfig } from '../../polls.subscription';
     templateUrl: `./poll-main.component.html`,
     styleUrls: [`./poll-main.component.scss`]
 })
-export class PollMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getPollListSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-        }
+export class PollMainComponent extends BaseMeetingModelRequestHandler {
+    protected override getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getPollListSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/projectors/components/projector-main/projector-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/components/projector-main/projector-main.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
-import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
+import { Id } from 'src/app/domain/definitions/key-types';
+import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
 
+import { BaseMeetingModelRequestHandler } from '../../../../base/base-meeting-model-request-handler.component';
 import { getProjectorListSubscriptionConfig } from '../../projectors.subscription';
 
 @Component({
@@ -8,10 +10,8 @@ import { getProjectorListSubscriptionConfig } from '../../projectors.subscriptio
     templateUrl: `./projector-main.component.html`,
     styleUrls: [`./projector-main.component.scss`]
 })
-export class ProjectorMainComponent extends BaseModelRequestHandlerComponent {
-    protected override onNextMeetingId(id: number | null): void {
-        if (id) {
-            this.subscribeTo(getProjectorListSubscriptionConfig(id), { hideWhenMeetingChanged: true });
-        }
+export class ProjectorMainComponent extends BaseMeetingModelRequestHandler {
+    protected getSubscriptions(id: Id): SubscriptionConfig<any>[] {
+        return [getProjectorListSubscriptionConfig(id)];
     }
 }

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/fullscreen-projector/components/fullscreen-projector-main/fullscreen-projector-main.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/fullscreen-projector/components/fullscreen-projector-main/fullscreen-projector-main.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Id } from 'src/app/domain/definitions/key-types';
 import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
 import { SequentialNumberMappingService } from 'src/app/site/pages/meetings/services/sequential-number-mapping.service';
 
@@ -15,17 +16,17 @@ export class FullscreenProjectorMainComponent extends BaseModelRequestHandlerCom
         super();
     }
 
-    protected override onParamsChanged(params: any, _oldParams?: any): void {
+    protected override onShouldCreateModelRequests(params: any, meetingId: Id): void {
         if (params[`id`]) {
             this.sequentialNumberMappingService
                 .getIdBySequentialNumber({
                     collection: ViewProjector.COLLECTION,
-                    meetingId: params[`meetingId`],
+                    meetingId,
                     sequentialNumber: +params[`id`]
                 })
                 .then(id => {
                     if (id) {
-                        this.subscribeTo(getProjectorSubscriptionConfig(id), { hideWhenMeetingChanged: true });
+                        this.subscribeTo(getProjectorSubscriptionConfig(id), { hideWhenDestroyed: true });
                     }
                 });
         }

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail-main/account-detail-main.component.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail-main/account-detail-main.component.ts
@@ -12,6 +12,13 @@ export class AccountDetailMainComponent extends BaseModelRequestHandlerComponent
     protected override onParamsChanged(params: any, oldParams: any): void {
         if (params[`id`] !== oldParams[`id`]) {
             const id = +params[`id`];
+            this.updateSubscribeTo(getAccountDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
+        }
+    }
+
+    protected override onShouldCreateModelRequests(params: any): void {
+        if (params[`id`]) {
+            const id = +params[`id`];
             this.subscribeTo(getAccountDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
         }
     }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/components/committee-detail/committee-detail.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/components/committee-detail/committee-detail.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { Id } from 'src/app/domain/definitions/key-types';
 import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component/base-model-request-handler.component';
 
 import { getCommitteeDetailSubscriptionConfig } from '../../../../committees.subscription';
@@ -10,12 +9,17 @@ import { getCommitteeDetailSubscriptionConfig } from '../../../../committees.sub
     styleUrls: [`./committee-detail.component.scss`]
 })
 export class CommitteeDetailComponent extends BaseModelRequestHandlerComponent {
-    private committeeId: Id | null = null;
-
     protected override onParamsChanged(params: any, oldParams: any): void {
-        if (params[`committeeId`] !== oldParams[`committeeId`]) {
-            this.committeeId = +params[`committeeId`] || null;
-            this.subscribeTo(getCommitteeDetailSubscriptionConfig(this.committeeId), { hideWhenDestroyed: true });
+        if (params[`committeeId`] !== oldParams[`committeeId`] && +params[`committeeId`]) {
+            this.updateSubscribeTo(getCommitteeDetailSubscriptionConfig(+params[`committeeId`]), {
+                hideWhenDestroyed: true
+            });
+        }
+    }
+
+    protected override onShouldCreateModelRequests(params: any): void {
+        if (+params[`committeeId`]) {
+            this.subscribeTo(getCommitteeDetailSubscriptionConfig(+params[`committeeId`]), { hideWhenDestroyed: true });
         }
     }
 }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/committee-detail-meeting-main/committee-detail-meeting-main.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/committee-detail-meeting-main/committee-detail-meeting-main.component.ts
@@ -13,11 +13,12 @@ import { getCommitteeMeetingDetailSubscriptionConfig } from '../../../../../../c
 export class CommitteeDetailMeetingMainComponent extends BaseModelRequestHandlerComponent {
     protected override onNextMeetingId(id: Id | null): void {
         if (id) {
-            this.subscribeTo(getCommitteeMeetingDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
+            this.updateSubscribeTo(getCommitteeMeetingDetailSubscriptionConfig(id), { hideWhenDestroyed: true });
         }
     }
 
-    protected override onShouldCreateModelRequests(): void {
+    protected override onShouldCreateModelRequests(_params: any, meetingId: Id): void {
         this.subscribeTo(getMeetingCreateSubscriptionConfig());
+        this.subscribeTo(getCommitteeMeetingDetailSubscriptionConfig(meetingId), { hideWhenDestroyed: true });
     }
 }


### PR DESCRIPTION
resolves #3589 

This PR changes behavior of `onNextMeetingId` and `onParamsChanged` to only fire if a change happens and not on initialization anymore. 