### PR TITLE
Add committee selector to motion meta data submitters

### DIFF
--- a/client/src/app/gateways/presenter/get-forwarding-committees-presenter.service.ts
+++ b/client/src/app/gateways/presenter/get-forwarding-committees-presenter.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Id } from 'src/app/domain/definitions/key-types';
+
+import { Presenter } from './presenter';
+import { PresenterService } from './presenter.service';
+
+interface GetForwardCommitteesPresenterPayload {
+    meeting_id: Id;
+}
+
+type GetForwardingCommitteesPresenterResult = string[];
+
+@Injectable({
+    providedIn: `root`
+})
+export class GetForwardingCommitteesPresenterService {
+    public constructor(private presenter: PresenterService) {}
+
+    public async call(payload: GetForwardCommitteesPresenterPayload): Promise<GetForwardingCommitteesPresenterResult> {
+        return await this.presenter.call<GetForwardingCommitteesPresenterResult>(
+            Presenter.GET_FORWARDING_COMMITTEES,
+            payload
+        );
+    }
+}

--- a/client/src/app/gateways/presenter/presenter.ts
+++ b/client/src/app/gateways/presenter/presenter.ts
@@ -4,6 +4,7 @@ export enum Presenter {
     GET_ACTIVE_USER_AMOUNT = `get_active_users_amount`,
     GET_USER_RELATED_MODELS = `get_user_related_models`,
     GET_USER_SCOPE = `get_user_scope`,
+    GET_FORWARDING_COMMITTEES = `get_forwarding_committees`,
     GET_FORWARDING_MEETINGS = `get_forwarding_meetings`,
     SEARCH_USERS = `search_users`,
     SEARCH_DELETED_MODELS = `search_deleted_models`,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.html
@@ -69,6 +69,16 @@
         </mat-form-field>
     </div>
 
+    <div *ngIf="useAdditionalInput" class="text-field-container">
+        <mat-form-field>
+            <mat-label>{{ secondSelectorLabel }}</mat-label>
+            <os-list-search-selector
+                [formControl]="secondSelectorFormControl"
+                [inputListValues]="secondSelectorValues"
+            ></os-list-search-selector>
+        </mat-form-field>
+    </div>
+
     <p>
         <button type="button" mat-button (click)="onSave()">
             <span>{{ 'Save' | translate }}</span>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.html
@@ -75,6 +75,9 @@
             <os-list-search-selector
                 [formControl]="secondSelectorFormControl"
                 [inputListValues]="secondSelectorValues"
+                [keepOpen]="true"
+                [disableOptionWhenFn]="getDisabledFn()"
+                (openedChange)="openedChange($event)"
             ></os-list-search-selector>
         </mat-form-field>
     </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.ts
@@ -65,9 +65,17 @@ export class MotionManageMotionMeetingUsersComponent<V extends BaseHasMeetingUse
 
     public additionalInputControl: UntypedFormControl;
 
+    @Input()
+    public secondSelectorLabel: string;
+
+    @Input()
+    public secondSelectorValues: Selectable[];
+
     public get intermediateModels(): V[] {
         return this.getIntermediateModels(this.motion);
     }
+
+    public secondSelectorFormControl: UntypedFormControl;
 
     /**
      * The current list of intermediate models.
@@ -117,6 +125,7 @@ export class MotionManageMotionMeetingUsersComponent<V extends BaseHasMeetingUse
 
     public ngOnInit(): void {
         this.additionalInputControl = this.fb.control(``);
+        this.secondSelectorFormControl = this.fb.control(``);
         this.subscriptions.push(
             this.editSubject.subscribe(ids => (this.editUserIds = ids.map(model => model.user_id ?? model.id)))
         );
@@ -151,12 +160,11 @@ export class MotionManageMotionMeetingUsersComponent<V extends BaseHasMeetingUse
             )
         );
         if (this.useAdditionalInput) {
-            actions.push(
-                this.motionController.update(
-                    { [this.additionalInputField]: this.additionalInputControl.value },
-                    this.motion
-                )
-            );
+            const value = this.additionalInputControl.value
+                ? this.additionalInputControl.value + ` ` + this.secondSelectorSelectedValue
+                : this.secondSelectorSelectedValue;
+            actions.push(this.motionController.update({ [this.additionalInputField]: value }, this.motion));
+            this.secondSelectorFormControl.setValue(null);
         }
 
         await Action.from(...actions).resolve();
@@ -269,5 +277,14 @@ export class MotionManageMotionMeetingUsersComponent<V extends BaseHasMeetingUse
         }
         const models = this.editSubject.value;
         this.editSubject.next(models.concat(model));
+    }
+
+    private get secondSelectorSelectedValue(): string {
+        if (!this.secondSelectorFormControl.value) {
+            return ``;
+        }
+        const searchId = +this.secondSelectorFormControl.value;
+        const foundEntry = this.secondSelectorValues.find(entry => entry.id === searchId);
+        return !!foundEntry ? foundEntry.getTitle() : ``;
     }
 }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-meta-data/motion-meta-data.component.html
@@ -10,6 +10,8 @@
             additionalInputField="additional_submitter"
             additionalInputLabel="{{ 'Extension' | translate }}"
             [additionalInputValue]="motion?.additional_submitter"
+            secondSelectorLabel="{{ 'Committees' | translate }}"
+            [secondSelectorValues]="forwardingCommittees"
         ></os-motion-manage-motion-meeting-users>
     </div>
 </div>


### PR DESCRIPTION
Resolve #3429 

This selector allows to fill the submitters extension text field with committee names. Select a committee and press save, the committee name is appended to the extension text field.

The received forwarding committees are returned by the presenter, which fills the possible committee names.