### PR TITLE
Fix motion styling around long list of tags

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-call-list/components/motion-call-list/motion-call-list.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-call-list/components/motion-call-list/motion-call-list.component.scss
@@ -8,6 +8,7 @@
 
     .left {
         vertical-align: middle;
+        min-width: 25%;
         max-width: 100%;
         flex-grow: 1;
     }


### PR DESCRIPTION
closes #2430

I couldn't reproduce the separation issue, as the mentioned weird breaks between the tag list didn't occur. Perhaps it was accidently fixed in another issue as this one was a bit older. If it's occuring during the tests let me know the reproduction steps and I'll fix it.