### PR TITLE
Fix missing buttons in LoS, motion/amendments create and support button

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.ts
@@ -78,7 +78,8 @@ export class ListOfSpeakersContentComponent extends BaseMeetingComponent impleme
 
     public get addSelf(): boolean {
         return (
-            this.permission.listOfSpeakersCanBeSpeaker && !(this.voteDelegationEnabled && this.forbidDelegatorToAddSelf)
+            this.permission.listOfSpeakersCanBeSpeaker &&
+            !(this.voteDelegationEnabled && this.forbidDelegatorToAddSelf && this.operator.user.isVoteRightDelegated)
         );
     }
 

--- a/client/src/app/site/pages/meetings/pages/motions/services/common/motion-permission.service/motion-permission.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/common/motion-permission.service/motion-permission.service.ts
@@ -52,6 +52,14 @@ export class MotionPermissionService {
         );
     }
 
+    public canDoActionWhileDelegationEnabled(isAdditionalDelegationSettingEnabled: boolean): boolean {
+        return !(
+            this.operator.user.isVoteRightDelegated &&
+            this._delegationEnabled &&
+            isAdditionalDelegationSettingEnabled
+        );
+    }
+
     /**
      * Determine if the user (Operator) has the correct permission to perform the given action.
      *
@@ -76,11 +84,7 @@ export class MotionPermissionService {
         switch (action) {
             case `create`: {
                 return this.operator.hasPerms(
-                    !(
-                        this._delegationEnabled &&
-                        this._forbidDelegatorCreateMotions &&
-                        this.operator.user.isVoteRightDelegated
-                    )
+                    this.canDoActionWhileDelegationEnabled(this._forbidDelegatorCreateMotions)
                         ? Permission.motionCanCreate
                         : Permission.motionCanManage
                 );
@@ -91,11 +95,7 @@ export class MotionPermissionService {
                 }
                 return (
                     this.operator.hasPerms(
-                        !(
-                            this._delegationEnabled &&
-                            this._forbidDelegatorSupportMotions &&
-                            this.operator.user.isVoteRightDelegated
-                        )
+                        this.canDoActionWhileDelegationEnabled(this._forbidDelegatorSupportMotions)
                             ? Permission.motionCanSupport
                             : Permission.motionCanManage
                     ) &&
@@ -112,11 +112,7 @@ export class MotionPermissionService {
                 }
                 return (
                     this.operator.hasPerms(
-                        !(
-                            this._delegationEnabled &&
-                            this._forbidDelegatorSupportMotions &&
-                            this.operator.user.isVoteRightDelegated
-                        )
+                        this.canDoActionWhileDelegationEnabled(this._forbidDelegatorSupportMotions)
                             ? Permission.motionCanSupport
                             : Permission.motionCanManage
                     ) &&
@@ -197,11 +193,7 @@ export class MotionPermissionService {
                 }
                 return (
                     this.operator.hasPerms(
-                        !(
-                            this._delegationEnabled &&
-                            this._forbidDelegatorCreateMotions &&
-                            this.operator.user.isVoteRightDelegated
-                        )
+                        this.canDoActionWhileDelegationEnabled(this._forbidDelegatorCreateMotions)
                             ? Permission.motionCanCreateAmendments
                             : Permission.motionCanManage
                     ) &&

--- a/client/src/app/site/pages/meetings/pages/motions/services/common/motion-permission.service/motion-permission.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/common/motion-permission.service/motion-permission.service.ts
@@ -76,7 +76,11 @@ export class MotionPermissionService {
         switch (action) {
             case `create`: {
                 return this.operator.hasPerms(
-                    !(this._delegationEnabled && this._forbidDelegatorCreateMotions)
+                    !(
+                        this._delegationEnabled &&
+                        this._forbidDelegatorCreateMotions &&
+                        this.operator.user.isVoteRightDelegated
+                    )
                         ? Permission.motionCanCreate
                         : Permission.motionCanManage
                 );
@@ -87,7 +91,11 @@ export class MotionPermissionService {
                 }
                 return (
                     this.operator.hasPerms(
-                        !(this._delegationEnabled && this._forbidDelegatorSupportMotions)
+                        !(
+                            this._delegationEnabled &&
+                            this._forbidDelegatorSupportMotions &&
+                            this.operator.user.isVoteRightDelegated
+                        )
                             ? Permission.motionCanSupport
                             : Permission.motionCanManage
                     ) &&
@@ -104,7 +112,11 @@ export class MotionPermissionService {
                 }
                 return (
                     this.operator.hasPerms(
-                        !(this._delegationEnabled && this._forbidDelegatorSupportMotions)
+                        !(
+                            this._delegationEnabled &&
+                            this._forbidDelegatorSupportMotions &&
+                            this.operator.user.isVoteRightDelegated
+                        )
                             ? Permission.motionCanSupport
                             : Permission.motionCanManage
                     ) &&
@@ -185,7 +197,11 @@ export class MotionPermissionService {
                 }
                 return (
                     this.operator.hasPerms(
-                        !(this._delegationEnabled && this._forbidDelegatorCreateMotions)
+                        !(
+                            this._delegationEnabled &&
+                            this._forbidDelegatorCreateMotions &&
+                            this.operator.user.isVoteRightDelegated
+                        )
                             ? Permission.motionCanCreateAmendments
                             : Permission.motionCanManage
                     ) &&


### PR DESCRIPTION
closes #3716 

This PR also fixes the motion/amendments create button  and the support button in motion-detail view
These options also vanished when the according settings were activated