### PR TITLE
Small fix for use getPollVoteTitle without currentProjection

### DIFF
--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
@@ -106,7 +106,7 @@ export class PollCollectionComponent<C extends PollContentObject> extends BaseCo
         const model = contentObject.getVerboseName();
         const pollTitle = poll.getTitle();
 
-        if (this.showExtendedTitle && contentObject.fqid !== this.currentProjection.fqid) {
+        if (this.showExtendedTitle && contentObject?.fqid !== this.currentProjection?.fqid) {
             return `(${model}) ${listTitle} - ${pollTitle}`;
         } else {
             return pollTitle;


### PR DESCRIPTION
Resolve #3698 

Small fix to handle the "currentProjection is null" case in `getPollVoteTitle`.