### PR TITLE
Fix missing translation of start/end date in meeting export

### DIFF
--- a/client/src/app/site/pages/organization/pages/orga-meetings/pages/meeting-list/services/meeting-export.service.ts
+++ b/client/src/app/site/pages/organization/pages/orga-meetings/pages/meeting-list/services/meeting-export.service.ts
@@ -40,9 +40,10 @@ export class MeetingCsvExportService {
             meetings,
             Object.keys(this.meetingHeadersAndVerboseNames).map(key => {
                 if (typeof this.meetingHeadersAndVerboseNames[key] !== `string`) {
-                    return this.meetingHeadersAndVerboseNames[key];
+                    const res = this.meetingHeadersAndVerboseNames[key];
+                    res.label = this.translate.instant(res.label);
+                    return res;
                 }
-
                 return {
                     property: key,
                     label: this.translate.instant(this.meetingHeadersAndVerboseNames[key])

--- a/client/src/app/site/pages/organization/pages/orga-meetings/pages/meeting-list/services/meeting-export.service.ts
+++ b/client/src/app/site/pages/organization/pages/orga-meetings/pages/meeting-list/services/meeting-export.service.ts
@@ -40,7 +40,7 @@ export class MeetingCsvExportService {
             meetings,
             Object.keys(this.meetingHeadersAndVerboseNames).map(key => {
                 if (typeof this.meetingHeadersAndVerboseNames[key] !== `string`) {
-                    const res = this.meetingHeadersAndVerboseNames[key];
+                    const res = { ...this.meetingHeadersAndVerboseNames[key] };
                     res.label = this.translate.instant(res.label);
                     return res;
                 }


### PR DESCRIPTION
Resolve #3753 

The translation of these two fields were missing, because this two fields are special (They include `map`). I updated this.