### PR TITLE
Fix countdown controls layout

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.scss
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.scss
@@ -77,6 +77,7 @@
 
         &.only-countdown {
             width: 100%;
+            min-width: auto;
             line-height: 100%;
             text-align: center;
         }

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/countdown-controls/countdown-controls.component.scss
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/countdown-controls/countdown-controls.component.scss
@@ -34,6 +34,7 @@
 .timer {
     grid-area: controls;
     display: flex;
+    justify-content: space-between;
 }
 
 .larger-countdown {


### PR DESCRIPTION
Currently the alignment of the start/pause buttons within the projector countdown control cards is broken. 