### PR TITLE
Update disabled setting fields at SaveAll, too

### DIFF
--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
@@ -128,14 +128,6 @@ export class MeetingSettingsGroupDetailComponent
         this.cd.detach();
         try {
             const data = deepCopy(this.changedSettings);
-            for (const field of this.settingsFields) {
-                if (field.disabled) {
-                    const keys = Array.isArray(field.setting.key) ? field.setting.key : [field.setting.key];
-                    for (const key of keys) {
-                        delete data[key];
-                    }
-                }
-            }
             for (const key of Object.keys(this.keyTransformConfigs)) {
                 if (Array.isArray(data[key])) {
                     data[key] = data[key].map((val: unknown) =>


### PR DESCRIPTION
Resolve #3779 

This resolves a problem with saving disabled fields in the settings dialog. I don't think this should be done this way.
