### PR TITLE
Fix vote components using wrong change detection strategy

### DIFF
--- a/client/src/app/site/pages/meetings/modules/poll/components/base-poll-vote/base-poll-vote.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/base-poll-vote/base-poll-vote.component.html
@@ -63,7 +63,7 @@
                         }"
                     >
                         <div *ngIf="showAvailableVotes" class="grid-name-area"></div>
-                        <b *ngIf="!showAvailableVotes" class="grid-name-area">
+                        <b *ngIf="!showAvailableVotes && poll.option_ids" class="grid-name-area">
                             {{ poll.option_ids.length }} {{ optionPluralLabel | translate }}
                         </b>
                         <b

--- a/client/src/app/site/pages/meetings/modules/poll/components/base-poll-vote/base-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/base-poll-vote/base-poll-vote.component.ts
@@ -162,8 +162,8 @@ export abstract class BasePollVoteComponent<C extends PollContentObject = any> e
                         this._canVoteForSubjectMap[+key].next(this.canVote(this._delegationsMap[+key]));
                     }
 
-                    this.cd.markForCheck();
                     this._isReady = true;
+                    this.cd.markForCheck();
                 }
             }),
             this.translate.onLangChange.subscribe(() => {
@@ -423,19 +423,10 @@ export abstract class BasePollVoteComponent<C extends PollContentObject = any> e
         }
     }
 
-    private createVotingDataObjects(): void {
-        this.voteRequestData[this.user.id] = { value: {} } as VotingData;
-        this.alreadyVoted[this.user.id] = this.poll.hasVoted;
-        this.deliveringVote[this.user.id] = false;
-
-        if (this.delegations) {
-            this.setupDelegations();
-        }
-    }
-
     protected updatePoll(): void {
         this.setupHasVotedSubscription();
         this.defineVoteOptions();
+        this.cd.markForCheck();
     }
 
     private setupHasVotedSubscription(): void {
@@ -451,6 +442,8 @@ export abstract class BasePollVoteComponent<C extends PollContentObject = any> e
                 for (const key of Object.keys(this._canVoteForSubjectMap)) {
                     this._canVoteForSubjectMap[+key].next(this.canVote(this._delegationsMap[+key]));
                 }
+
+                this.cd.markForCheck();
             })
         );
     }
@@ -486,7 +479,7 @@ export abstract class BasePollVoteComponent<C extends PollContentObject = any> e
             };
 
             for (const option of this.voteOptions) {
-                if (this.poll.pollmethod.includes(option.vote)) {
+                if (this.poll.pollmethod?.includes(option.vote)) {
                     this.voteActions.push(option);
                 }
 

--- a/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/pages/assignments/modules/assignment-poll/components/assignment-poll-vote/assignment-poll-vote.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { marker as _ } from '@colsen1991/ngx-translate-extract-marker';
 import { PollMethod } from 'src/app/domain/models/poll/poll-constants';
 import { VoteValue } from 'src/app/domain/models/poll/vote-constants';
@@ -17,7 +17,8 @@ import { UnknownUserLabel } from '../../services/assignment-poll.service';
 @Component({
     selector: `os-assignment-poll-vote`,
     templateUrl: `../../../../../../modules/poll/components/base-poll-vote/base-poll-vote.component.html`,
-    styleUrls: [`../../../../../../modules/poll/components/base-poll-vote/base-poll-vote.component.scss`]
+    styleUrls: [`../../../../../../modules/poll/components/base-poll-vote/base-poll-vote.component.scss`],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AssignmentPollVoteComponent extends BasePollVoteComponent<ViewAssignment> {
     public unknownUserLabel = UnknownUserLabel;

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-vote/motion-poll-vote.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-vote/motion-poll-vote.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { VoteValue } from 'src/app/domain/models/poll/vote-constants';
 import {
@@ -14,7 +14,8 @@ import { ViewOption } from '../../../../../polls';
 @Component({
     selector: `os-motion-poll-vote`,
     templateUrl: `../../../../../../modules/poll/components/base-poll-vote/base-poll-vote.component.html`,
-    styleUrls: [`../../../../../../modules/poll/components/base-poll-vote/base-poll-vote.component.scss`]
+    styleUrls: [`../../../../../../modules/poll/components/base-poll-vote/base-poll-vote.component.scss`],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MotionPollVoteComponent extends BasePollVoteComponent {
     public override readonly settings = {


### PR DESCRIPTION
resolves #3795

Please test if motion and assignment polls are still working as intended. As this already works fine for topic polls like this I don't think changing the strategy should make any problems. 

Calls to `getVotesCount` after an autoupdate were reduced from +100 to ~4. 
