### PR TITLE
Add missing 's' tag to html to pdf

### DIFF
--- a/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
+++ b/client/src/app/gateways/export/html-to-pdf.service/html-to-pdf.service.ts
@@ -65,6 +65,7 @@ export class HtmlToPdfService {
         h6: [`font-size:10`],
         a: [`color:blue`, `text-decoration:underline`],
         strike: [`text-decoration:line-through`],
+        s: [`text-decoration:line-through`],
         // Pretty specific stuff that might be excluded for other projects than OpenSlides
         del: [`color:red`, `text-decoration:line-through`],
         ins: [`color:green`, `text-decoration:underline`]
@@ -102,6 +103,9 @@ export class HtmlToPdfService {
      */
     public convertHtml({ htmlText }: { htmlText: string }): Content[] {
         const docDef = [];
+
+        // DEBUG: printing htmlText. Do not remove, just comment out
+        // console.log('MakePDF htmlText:\n---\n', htmlText, '\n---\n');
 
         // Create a HTML DOM tree out of html string
         const parser = new DOMParser();
@@ -188,6 +192,7 @@ export class HtmlToPdfService {
             case `i`:
             case `ins`:
             case `del`:
+            case `s`:
             case `strike`: {
                 newParagraph = this.createFormattedParagraph(createPayload);
                 break;


### PR DESCRIPTION
Resolve #3889 

Please check, if this improves the situation in #3889 . I just added the missing 's' for strike thru tag.
If there are other problems, I will need a more deep dive into the html-to-pdf.service.