### PR TITLE
Update dependabot docker assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,7 @@ updates:
       - "bastianjoel"
     assignees:
       - "bastianjoel"
+      - "rrenkert"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Add @rrenkert to `dependabot.yml` docker ecosystem as he is responsible for managing our available docker images. 