### PR TITLE
Fix new file dialog

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
@@ -172,3 +172,12 @@ button.motion-detail-nav-button {
     font-size: 16px;
 }
 
+.file-drop-content-style {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    
+    .ngx-file-drop__drop-zone-label {
+        line-height: 24px;
+    }
+}

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
@@ -176,7 +176,7 @@ button.motion-detail-nav-button {
     display: flex;
     align-items: center;
     justify-content: center;
-    
+
     .ngx-file-drop__drop-zone-label {
         line-height: 24px;
     }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
@@ -166,3 +166,9 @@ button.motion-detail-nav-button {
         }
     }
 }
+
+.mat-mdc-dialog-surface {
+    padding: 16px;
+    font-size: 16px;
+}
+

--- a/client/src/app/ui/modules/media-upload-content/components/media-upload-content/media-upload-content.component.html
+++ b/client/src/app/ui/modules/media-upload-content/components/media-upload-content/media-upload-content.component.html
@@ -7,7 +7,7 @@
 >
     <ng-template #additionalContent>
         <!-- Directory selector-->
-        <div [formGroup]="directorySelectionForm">
+        <mat-dialog-content class="os-form-card-mobile" [formGroup]="directorySelectionForm">
             <mat-form-field>
                 <mat-label>{{ 'Upload to' | translate }}</mat-label>
                 <os-list-search-selector
@@ -17,7 +17,7 @@
                     [multiple]="false"
                 ></os-list-search-selector>
             </mat-form-field>
-        </div>
+        </mat-dialog-content>
     </ng-template>
 
     <div *osScrollingTableCell="'title'; row as file" class="cell-slot">


### PR DESCRIPTION
Resolve #3858 

1. Updated MDC in 'media-upload-content.component.html' similar to 'file-list.component.html' where file uploading card is displayed correctly.
2. Added paddings and set font size to 16px for '.mat-mdc-dialog-surface' container of the dialog (similar to the container on '/mediafiles/upload' page).

The changes above together made file upload dialog on the '/motions/new' page look the same as on the '/mediafiles/upload' page.

===
3. Additional ui improvement: made text of dropZoneLabel wrappable.
On the smaller screens file upload dialog on the '/motions/new' page is narrower than on the '/mediafiles/upload' page because of the styles of the rest of the page.
That made part of the sentense 'Drop files into this area OR click here to select files' invisible on small screens.
Moved upload area to the flex container and reduced line height of the sentense to 24px to let the text wrap correctly.