### PR TITLE
Fix new file dialog component

### DIFF
--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/attachment-control/attachment-control.module.ts
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/attachment-control/attachment-control.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { OpenSlidesTranslationModule } from 'src/app/site/modules/translations';
@@ -20,6 +21,7 @@ const DECLARATIONS = [AttachmentControlComponent];
     exports: DECLARATIONS,
     imports: [
         CommonModule,
+        MatCardModule,
         MatFormFieldModule,
         MatIconModule,
         MatButtonModule,

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/attachment-control/components/attachment-control/attachment-control.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/attachment-control/components/attachment-control/attachment-control.component.html
@@ -25,26 +25,28 @@
 
 <!-- upload file dialog -->
 <ng-template #uploadDialog>
-    <h1 mat-dialog-title>
-        <span>{{ 'New file' | translate }}</span>
-    </h1>
-    <os-media-upload-content
-        [directories]="directoriesObservable"
-        [uploadFn]="uploadFn"
-        (errorEvent)="uploadError($event)"
-        (uploadSuccessEvent)="uploadSuccess($event.uploadedIds)"
-    >
-        <div *osScrollingTableCell="'access_groups'; row as file" class="cell-slot">
-            <form [formGroup]="file.form">
-                <mat-form-field subscriptSizing="dynamic">
-                    <mat-label>{{ 'Access groups' | translate }}</mat-label>
-                    <os-list-search-selector
-                        formControlName="access_group_ids"
-                        [inputListValues]="availableGroups"
-                        [multiple]="true"
-                    ></os-list-search-selector>
-                </mat-form-field>
-            </form>
-        </div>
-    </os-media-upload-content>
+    <mat-card-content>
+        <h1 mat-dialog-title>
+            <span>{{ 'New file' | translate }}</span>
+        </h1>
+        <os-media-upload-content
+            [directories]="directoriesObservable"
+            [uploadFn]="uploadFn"
+            (errorEvent)="uploadError($event)"
+            (uploadSuccessEvent)="uploadSuccess($event.uploadedIds)"
+        >
+            <div *osScrollingTableCell="'access_groups'; row as file" class="cell-slot">
+                <form [formGroup]="file.form">
+                    <mat-form-field subscriptSizing="dynamic">
+                        <mat-label>{{ 'Access groups' | translate }}</mat-label>
+                        <os-list-search-selector
+                            formControlName="access_group_ids"
+                            [inputListValues]="availableGroups"
+                            [multiple]="true"
+                        ></os-list-search-selector>
+                    </mat-form-field>
+                </form>
+            </div>
+        </os-media-upload-content>
+    </mat-card-content>
 </ng-template>

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/attachment-control/components/attachment-control/attachment-control.component.scss
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/attachment-control/components/attachment-control/attachment-control.component.scss
@@ -18,3 +18,7 @@
         }
     }
 }
+
+mat-card-content {
+    font-size: 16px;
+}

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/components/motion-detail-view/motion-detail-view.component.scss
@@ -166,18 +166,3 @@ button.motion-detail-nav-button {
         }
     }
 }
-
-.mat-mdc-dialog-surface {
-    padding: 16px;
-    font-size: 16px;
-}
-
-.file-drop-content-style {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    .ngx-file-drop__drop-zone-label {
-        line-height: 24px;
-    }
-}

--- a/client/src/app/ui/modules/media-upload-content/components/media-upload-content/media-upload-content.component.scss
+++ b/client/src/app/ui/modules/media-upload-content/components/media-upload-content/media-upload-content.component.scss
@@ -2,3 +2,9 @@
     display: flex;
     flex-direction: column;
 }
+
+mat-form-field {
+    mat-label {
+        color: var(--mdc-filled-text-field-label-text-color);
+    }
+}

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -126,14 +126,17 @@
 .file-drop-zone-style {
     border: 2px dotted #0782d0 !important;
     height: 100px;
+    display: flex;
+    justify-content: center;
 }
 
 .file-drop-content-style {
     height: 100px;
+    align-content: center;
 
     .ngx-file-drop__drop-zone-label {
         color: #0782d0;
-        line-height: 100px;
+        line-height: 24px;
     }
 }
 


### PR DESCRIPTION
Resolves #4004 

Updated styles of the new file dialog component to make sure that it looks the same in all views:
1. Moved styling from Motion detail view to compont-related files.
2. Put dialog component into 'mat-card-content' container.

===

The second commit of this branch fixes an issue when directory selection label text is white instead of gray in dark mode after opening the dialog but before clicking anywhere:

![image](https://github.com/user-attachments/assets/67966348-7442-4fe4-8fa7-29fb1109f4ad)


