### PR TITLE
Fix projector: stopwatch linked to countdown setting

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.html
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/countdown-time/countdown-time.component.html
@@ -3,7 +3,7 @@
         class="countdown-time-wrapper"
         [ngClass]="{
             'negative-time': seconds <= 0 && (countdown.default_time !== 0 || seconds < 0),
-            'warning-time': seconds <= warningTime && seconds > 0,
+            'warning-time': countdown.default_time !== 0 && seconds <= warningTime && seconds > 0,
             'stretch-to-fill-parent': fullscreen
         }"
     >
@@ -28,7 +28,7 @@
         id="countdown"
         [ngClass]="{
             'negative-time': seconds <= 0 && (countdown.default_time !== 0 || seconds < 0),
-            'warning-time': seconds <= warningTime && seconds > 0
+            'warning-time': countdown.default_time !== 0 && seconds <= warningTime && seconds > 0
         }"
     >
         {{ time }}


### PR DESCRIPTION
Resolves #3830 

Extended the condition for applying 'warning-time' class to 'countdown' and 'countdown-time-wrapper' components to check if timer is in stopwatch or countdown mode.