### PR TITLE
Add parsed data cleanup rule

### DIFF
--- a/client/src/app/site/base/base-import.service/base-backend-import.service.ts
+++ b/client/src/app/site/base/base-import.service/base-backend-import.service.ts
@@ -176,7 +176,7 @@ export abstract class BaseBackendImportService implements BackendImportService {
             header: true,
             skipEmptyLines: `greedy`,
             quoteChar: this.textSeparator,
-            transform: value => (!value ? undefined : value.trim())
+            transform: value => (!value.trim() ? undefined : value.trim())
         };
         if (this.columnSeparator) {
             papaConfig.delimiter = this.columnSeparator;

--- a/client/src/app/site/base/base-import.service/base-backend-import.service.ts
+++ b/client/src/app/site/base/base-import.service/base-backend-import.service.ts
@@ -176,7 +176,7 @@ export abstract class BaseBackendImportService implements BackendImportService {
             header: true,
             skipEmptyLines: `greedy`,
             quoteChar: this.textSeparator,
-            transform: value => (!value ? undefined : value)
+            transform: value => (!value ? undefined : value.trim())
         };
         if (this.columnSeparator) {
             papaConfig.delimiter = this.columnSeparator;


### PR DESCRIPTION
Resolves #3823 

Extended parseInput config with .trim() rule to remove extra whitespaces on the ends of the input values.