### PR TITLE
Prevent null in calculated group_ids of assign meetings

### DIFF
--- a/client/src/app/site/pages/organization/pages/accounts/services/common/account-controller.service.ts
+++ b/client/src/app/site/pages/organization/pages/accounts/services/common/account-controller.service.ts
@@ -73,9 +73,10 @@ export class AccountControllerService extends BaseController<ViewUser, User> {
                 return {
                     id: user.id,
                     meeting_id: meeting.id,
-                    group_ids: groupIds?.includes(meeting.default_group_id)
+                    group_ids: (groupIds?.includes(meeting.default_group_id)
                         ? groupIds
                         : (groupIds ?? []).concat(meeting.default_group_id)
+                    ).filter(id => !!id)
                 };
             });
         };


### PR DESCRIPTION
Resolve #4085 

I don't understand, why the meeting.default_group_id is null in some rare cases, but it leads to an error, because it
sends null in group_ids. So I exclude broken stuff from this array.