### PR TITLE
Rename shared worker

### DIFF
--- a/client/src/app/openslides-main-module/services/shared-worker.service.ts
+++ b/client/src/app/openslides-main-module/services/shared-worker.service.ts
@@ -107,7 +107,7 @@ export class SharedWorkerService {
             try {
                 const worker = new SharedWorker(new URL(`../../worker/default-shared-worker.worker`, import.meta.url), {
                     type: `module`,
-                    name: `openslides-shared-worker`
+                    name: `openslides-shared-worker-module`
                 });
 
                 this.conn = worker.port;


### PR DESCRIPTION
Shared worker type was switched to module in #3993 which could cause issues when a shared worker was registered previously because the name was not changed see 11.4 at https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworker and https://blametest.sesse.net/content/browser/worker_host/shared_worker_service_impl.cc.html#189