### PR TITLE
Rename orga mediafiles fix

### DIFF
--- a/client/src/app/gateways/repositories/mediafiles/mediafile-repository.service.ts
+++ b/client/src/app/gateways/repositories/mediafiles/mediafile-repository.service.ts
@@ -115,7 +115,7 @@ export class MediafileRepositoryService extends BaseRepository<ViewMediafile, Me
             id: viewMediafile.id,
             title: update.title,
             parent_id: update.parent_id,
-            meeting_id: this.activeMeetingId,
+            meeting_id: this.activeMeetingId ?? undefined,
             ...variables
         };
         return this.sendActionToBackend(MediafileAction.UPDATE, payload);


### PR DESCRIPTION
Resolve #4135
It sends undefined as meeting_id, because null run into backend problems.