### PR TITLE
Change poll title in Autopilot

### DIFF
--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
@@ -2,8 +2,10 @@ import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit } from '@angular
 import { TranslateService } from '@ngx-translate/core';
 import { map } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
+import { Assignment } from 'src/app/domain/models/assignments/assignment';
 import { PollContentObject } from 'src/app/domain/models/poll';
 import { PollClassType } from 'src/app/domain/models/poll/poll-constants';
+import { Topic } from 'src/app/domain/models/topics/topic';
 import { BaseComponent } from 'src/app/site/base/base.component';
 import { BaseViewModel } from 'src/app/site/base/base-view-model';
 import { PollControllerService } from 'src/app/site/pages/meetings/modules/poll/services/poll-controller.service';
@@ -106,13 +108,13 @@ export class PollCollectionComponent<C extends PollContentObject> extends BaseCo
     public getPollVoteTitle(poll: ViewPoll): string {
         const contentObject = poll.getContentObject();
         const listTitle = contentObject.getListTitle();
-        const model = contentObject.getVerboseName();
+        const objectCollection = contentObject.COLLECTION;
         const pollTitle = poll.getTitle();
 
         if (
             this.showExtendedTitle &&
             contentObject?.fqid !== this.currentProjection?.fqid &&
-            [`Topic`, `Election`].includes(model)
+            [Topic.COLLECTION, Assignment.COLLECTION].includes(objectCollection)
         ) {
             return `${listTitle}: ${pollTitle}`;
         } else {

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
@@ -109,8 +109,12 @@ export class PollCollectionComponent<C extends PollContentObject> extends BaseCo
         const model = contentObject.getVerboseName();
         const pollTitle = poll.getTitle();
 
-        if (this.showExtendedTitle && contentObject?.fqid !== this.currentProjection?.fqid) {
-            return `(${model}) ${listTitle} - ${pollTitle}`;
+        if (
+            this.showExtendedTitle &&
+            contentObject?.fqid !== this.currentProjection?.fqid &&
+            [`Topic`, `Election`].includes(model)
+        ) {
+            return `${listTitle}: ${pollTitle}`;
         } else {
             return pollTitle;
         }


### PR DESCRIPTION
Resolves #3828 

- Made 'getPollVoteTitle' return the default value for the motion poll (just the poll title without any extra info)
- Changed projected value for topic and election polls: removed brackets and their content, changed separator from " - " to ": "