### PR TITLE
Add default_password to account_list subscription

### DIFF
--- a/client/src/app/gateways/repositories/users/user-repository.service.ts
+++ b/client/src/app/gateways/repositories/users/user-repository.service.ts
@@ -122,7 +122,8 @@ export class UserRepositoryService extends BaseRepository<ViewUser, User> {
 
         const accountListFields: TypedFieldset<User> = filterableListFields.concat([
             `committee_ids`,
-            `committee_management_ids`
+            `committee_management_ids`,
+            `default_password`
         ]);
 
         const participantListFieldsMinimal: TypedFieldset<User> = listFields.concat([`meeting_user_ids`]);


### PR DESCRIPTION
Resolve #4145

There is a problem with missing default pw on a prod instance. It seems like export needs these data for exporting it. So I included it in the subscription. The participant_list subscription already includes the "default_password" for this usage.

The autoupdate service needs to restrict the access, if these info should not be seen.

This enlarges the subscription with one field, perhaps it is a performance problem. 