### PR TITLE
Fix Motion-list CSV export and add new Version to export

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.html
@@ -37,11 +37,8 @@
                     <mat-button-toggle #diffVersionButton [disabled]="isCSVExport" [value]="crMode.Diff">
                         <span>{{ 'Diff version' | translate }}</span>
                     </mat-button-toggle>
-                    <mat-button-toggle [disabled]="isCSVExport" [value]="crMode.Final">
-                        <span>{{ 'Final version' | translate }}</span>
-                    </mat-button-toggle>
                     <mat-button-toggle [value]="crMode.ModifiedFinal">
-                        <span>{{ 'Editorial final version' | translate }}</span>
+                        <span>{{ 'Final version' | translate }}</span>
                     </mat-button-toggle>
                 </mat-button-toggle-group>
             </div>

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.html
@@ -31,14 +31,17 @@
                     <mat-button-toggle [value]="crMode.Original">
                         <span>{{ 'Original version' | translate }}</span>
                     </mat-button-toggle>
-                    <mat-button-toggle [value]="crMode.Changed">
+                    <mat-button-toggle [disabled]="isCSVExport" [value]="crMode.Changed">
                         <span>{{ 'Changed version' | translate }}</span>
                     </mat-button-toggle>
-                    <mat-button-toggle #diffVersionButton [value]="crMode.Diff">
+                    <mat-button-toggle #diffVersionButton [disabled]="isCSVExport" [value]="crMode.Diff">
                         <span>{{ 'Diff version' | translate }}</span>
                     </mat-button-toggle>
-                    <mat-button-toggle [value]="crMode.ModifiedFinal">
+                    <mat-button-toggle [disabled]="isCSVExport" [value]="crMode.Final">
                         <span>{{ 'Final version' | translate }}</span>
+                    </mat-button-toggle>
+                    <mat-button-toggle [value]="crMode.ModifiedFinal">
+                        <span>{{ 'Editorial final version' | translate }}</span>
                     </mat-button-toggle>
                 </mat-button-toggle-group>
             </div>

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
@@ -129,15 +129,7 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
     @ViewChild(MOTION_PDF_OPTIONS.ContinuousText)
     public continuousTextButton!: MatButtonToggle;
 
-    private _isCSVExport = false;
-
-    protected set isCSVExport(format: ExportFileFormat) {
-        this._isCSVExport = format === ExportFileFormat.CSV;
-    }
-
-    protected get isCSVExport(): boolean {
-        return this._isCSVExport;
-    }
+    public isCSVExport = false;
 
     /**
      * Constructor
@@ -188,7 +180,7 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
      * @param format
      */
     private onFormatChange(format: ExportFileFormat): void {
-        this.isCSVExport = format;
+        this.isCSVExport = format === ExportFileFormat.CSV;
 
         // XLSX cannot have "content"
         if (format === ExportFileFormat.XLSX) {

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
@@ -129,6 +129,16 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
     @ViewChild(MOTION_PDF_OPTIONS.ContinuousText)
     public continuousTextButton!: MatButtonToggle;
 
+    private _isCSVExport = false;
+
+    protected set isCSVExport(format: ExportFileFormat) {
+        this._isCSVExport = format === ExportFileFormat.CSV;
+    }
+
+    protected get isCSVExport(): boolean {
+        return this._isCSVExport;
+    }
+
     /**
      * Constructor
      * Sets the default values for the lineNumberingMode and changeRecoMode and creates the form.
@@ -178,6 +188,8 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
      * @param format
      */
     private onFormatChange(format: ExportFileFormat): void {
+        this.isCSVExport = format;
+
         // XLSX cannot have "content"
         if (format === ExportFileFormat.XLSX) {
             this.disableControl(`content`);
@@ -195,7 +207,6 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
 
         if (format === ExportFileFormat.CSV || format === ExportFileFormat.XLSX) {
             this.disableControl(`lnMode`);
-            this.disableControl(`crMode`);
             this.disableControl(`pdfOptions`);
 
             // remove the selection of "votingResult"
@@ -203,6 +214,7 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
                 this.disableMetaInfoControl(`polls`, `speakers`);
             } else {
                 this.disableMetaInfoControl(`polls`);
+                this.disableControl(`crMode`);
             }
             this.votingResultButton.disabled = true;
             this.referringMotionsButton.disabled = true;
@@ -214,6 +226,10 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
             this.enableControl(`pdfOptions`);
             this.votingResultButton.disabled = false;
             this.referringMotionsButton.disabled = false;
+        }
+
+        if (format === ExportFileFormat.CSV) {
+            this.enableControl(`crMode`);
         }
     }
 

--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-export-dialog/components/motion-export-dialog/motion-export-dialog.component.ts
@@ -229,6 +229,9 @@ export class MotionExportDialogComponent extends BaseUiComponent implements OnIn
         }
 
         if (format === ExportFileFormat.CSV) {
+            if (this.exportForm.get(`crMode`)!.getRawValue() === (this.crMode.Changed || this.crMode.Diff)) {
+                this.exportForm.get(`crMode`)!.setValue(this.getOffState(`crMode`));
+            }
             this.enableControl(`crMode`);
         }
     }

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-csv-export.service/motion-csv-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-csv-export.service/motion-csv-export.service.ts
@@ -56,6 +56,8 @@ const MotionCsvExportExample: MotionCsvExport[] = [
     providedIn: MotionsExportModule
 })
 export class MotionCsvExportService {
+    public crMode = ChangeRecoMode;
+
     public constructor(
         private csvExport: MeetingCsvExportService,
         private translate: TranslateService,
@@ -96,7 +98,7 @@ export class MotionCsvExportService {
         crMode?: ChangeRecoMode
     ): void {
         if (!crMode) {
-            crMode = this.meetingSettingsService.instant(`motions_recommendation_text_mode`)!;
+            crMode = this.crMode.Original;
         }
 
         const properties = sortMotionPropertyList([`number`, `title`].concat(contentToExport));


### PR DESCRIPTION
closes #4050 

Added the editorial final version for the CSV export 
=> the PDF now has the two options "final Version" and "editorial final Version", This can be changed back to only one option (If that is wanted which version should be used?)
=> The CSV only has two options ("Original" and "editorial final" Version), are these the only two options wanted for the CSV export?