### PR TITLE
Remove margin from amendment-nr to parargraph below

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/services/common/motion-format.service/motion-format.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/common/motion-format.service/motion-format.service.ts
@@ -299,6 +299,7 @@ export class MotionFormatService {
             // Removes the unwanted gap between the paragraph and the amendment number
             if (text[i]?.indexOf(`amendment-nr-n-icon`) !== -1) {
                 text[i + 1] = text[i + 1]?.replace(`os-split-after`, `os-split-after margin-top-0`);
+                text[i + 1] = text[i + 1]?.replace(`<p>`, `<p class="margin-top-0">`);
             }
 
             if (text[i]?.search(`<os-linebreak`) > -1) {


### PR DESCRIPTION
In some cases the distance between the new amendment nr and the paragraph below was too big

Now the distance between the amendment nr and the paragraph should always be zero