### PR TITLE
Update permission for use of get-forwarding-meetings

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/services/motion-forward-dialog.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/services/motion-forward-dialog.service.ts
@@ -99,7 +99,7 @@ export class MotionForwardDialogService extends BaseDialogService<MotionForwardD
                 this.activeMeeting.meetingIdObservable.pipe(filter(id => id !== undefined))
             );
             const meetings =
-                this.operator.hasPerms(Permission.motionCanManageMetadata) && !!meetingId
+                this.operator.hasPerms(Permission.motionCanForward) && !!meetingId
                     ? await this.presenter.call({ meeting_id: meetingId })
                     : [];
             this._forwardingMeetings = meetings;


### PR DESCRIPTION
Resolve #4291 

The get-forwarding-meetings needs the 'motion.can_forward' permission. So I updated it here.