### PR TITLE
Add line numbers to empty paragraphs

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.spec.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.spec.ts
@@ -552,13 +552,23 @@ describe(`LineNumberingService`, () => {
             }
         ));
 
+        it(`counts empty paragraphs and adds space`, inject([LineNumberingService], (service: LineNumberingService) => {
+            const inHtml = `<p></p><p><ins>Test 123</ins></p>`;
+            const inHtmlAfter = `<p>&nbsp;</p><p><ins>Test 123</ins></p>`;
+            const outHtml = service.insertLineNumbers({ html: inHtml, lineLength: 80, firstLine: 1 });
+            expect(outHtml).toBe(`<p>` + noMarkup(1) + `&nbsp;</p><p>` + noMarkup(2) + `<ins>Test 123</ins></p>`);
+            expect(service.stripLineNumbers(outHtml)).toBe(inHtmlAfter);
+            expect(service.insertLineBreaksWithoutNumbers(outHtml, 80)).toBe(outHtml);
+        }));
+
         it(`does not fail in a weird case`, inject([LineNumberingService], (service: LineNumberingService) => {
             const inHtml = `<ins>seid Noch</ins><p></p><p><ins>Test 123</ins></p>`;
+            const inHtmlAfter = `<ins>seid Noch</ins><p>&nbsp;</p><p><ins>Test 123</ins></p>`;
             const outHtml = service.insertLineNumbers({ html: inHtml, lineLength: 80, firstLine: 1 });
             expect(outHtml).toBe(
-                noMarkup(1) + `<ins>seid Noch</ins><p></p><p>` + noMarkup(2) + `<ins>Test 123</ins></p>`
+                noMarkup(1) + `<ins>seid Noch</ins><p>&nbsp;</p><p>` + noMarkup(2) + `<ins>Test 123</ins></p>`
             );
-            expect(service.stripLineNumbers(outHtml)).toBe(inHtml);
+            expect(service.stripLineNumbers(outHtml)).toBe(inHtmlAfter);
             expect(service.insertLineBreaksWithoutNumbers(outHtml, 80)).toBe(outHtml);
         }));
     });

--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.spec.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.spec.ts
@@ -552,23 +552,21 @@ describe(`LineNumberingService`, () => {
             }
         ));
 
-        it(`counts empty paragraphs and adds space`, inject([LineNumberingService], (service: LineNumberingService) => {
+        it(`counts empty paragraphs`, inject([LineNumberingService], (service: LineNumberingService) => {
             const inHtml = `<p></p><p><ins>Test 123</ins></p>`;
-            const inHtmlAfter = `<p>&nbsp;</p><p><ins>Test 123</ins></p>`;
             const outHtml = service.insertLineNumbers({ html: inHtml, lineLength: 80, firstLine: 1 });
-            expect(outHtml).toBe(`<p>` + noMarkup(1) + `&nbsp;</p><p>` + noMarkup(2) + `<ins>Test 123</ins></p>`);
-            expect(service.stripLineNumbers(outHtml)).toBe(inHtmlAfter);
+            expect(outHtml).toBe(`<p>` + noMarkup(1) + `</p><p>` + noMarkup(2) + `<ins>Test 123</ins></p>`);
+            expect(service.stripLineNumbers(outHtml)).toBe(inHtml);
             expect(service.insertLineBreaksWithoutNumbers(outHtml, 80)).toBe(outHtml);
         }));
 
         it(`does not fail in a weird case`, inject([LineNumberingService], (service: LineNumberingService) => {
             const inHtml = `<ins>seid Noch</ins><p></p><p><ins>Test 123</ins></p>`;
-            const inHtmlAfter = `<ins>seid Noch</ins><p>&nbsp;</p><p><ins>Test 123</ins></p>`;
             const outHtml = service.insertLineNumbers({ html: inHtml, lineLength: 80, firstLine: 1 });
             expect(outHtml).toBe(
-                noMarkup(1) + `<ins>seid Noch</ins><p>&nbsp;</p><p>` + noMarkup(2) + `<ins>Test 123</ins></p>`
+                noMarkup(1) + `<ins>seid Noch</ins><p></p><p>` + noMarkup(2) + `<ins>Test 123</ins></p>`
             );
-            expect(service.stripLineNumbers(outHtml)).toBe(inHtmlAfter);
+            expect(service.stripLineNumbers(outHtml)).toBe(inHtml);
             expect(service.insertLineBreaksWithoutNumbers(outHtml, 80)).toBe(outHtml);
         }));
     });

--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.ts
@@ -753,6 +753,10 @@ export class LineNumberingService {
         } else if (isInlineElement(element)) {
             return this.insertLineNumbersToInlineNode(element, length, highlight);
         } else {
+            if (element.tagName === `P` && !element.childNodes.length) {
+                element.appendChild(document.createTextNode(`\xa0`));
+            }
+
             const newLength = this.calcBlockNodeLength(element, length);
             return this.insertLineNumbersToBlockNode(element, newLength, highlight);
         }

--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/line-numbering.service/line-numbering.service.ts
@@ -752,11 +752,13 @@ export class LineNumberingService {
             return element;
         } else if (isInlineElement(element)) {
             return this.insertLineNumbersToInlineNode(element, length, highlight);
-        } else {
-            if (element.tagName === `P` && !element.childNodes.length) {
-                element.appendChild(document.createTextNode(`\xa0`));
+        } else if (element.tagName === `P` && !element.childNodes.length && this.currentLineNumber !== null) {
+            const lineNumber = this.createLineNumber();
+            if (lineNumber) {
+                element.appendChild(lineNumber);
             }
-
+            return element;
+        } else {
             const newLength = this.calcBlockNodeLength(element, length);
             return this.insertLineNumbersToBlockNode(element, newLength, highlight);
         }

--- a/client/src/assets/styles/tiptap.scss
+++ b/client/src/assets/styles/tiptap.scss
@@ -7,4 +7,8 @@
     & li > p:last-of-type {
         margin-bottom: 0;
     }
+    p:after {
+        content: '';
+        display: inline-block;
+    }
 }


### PR DESCRIPTION
resolves #4181

It should be tested if this impacts old motions which contain empty paragraphs. This is basically the same workaround as described in the issue just added to the line numbering instead of the editor. 