### PR TITLE
Small layout fixes to meeting setting: public access

### DIFF
--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.html
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.html
@@ -96,12 +96,12 @@
                             <mat-checkbox formControlName="value">{{ setting.label | translate }}</mat-checkbox>
                             @if (setting.helpText) {
                                 <mat-hint class="hint-checkbox settings-form-group">
-                                    {{ setting.helpText | translate }}
+                                    <span>{{ setting.helpText | translate }}</span>
                                 </mat-hint>
                             }
                             @if (getWarning()) {
-                                <mat-hint class="hint-checkbox red-warning-text">
-                                    {{ setting.warnText | translate }}
+                                <mat-hint class="hint-checkbox">
+                                    <span>{{ setting.warnText | translate }}</span>
                                 </mat-hint>
                             }
                             @if (error) {

--- a/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definitions.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definitions.ts
@@ -217,7 +217,7 @@ export const meetingSettings: SettingsGroup[] = fillInSettingsDefaults([
                             `Enables public access to this meeting without login data. Permissions can be set after activation in the new group 'Public'.`
                         ),
                         warnText: _(
-                            `The public access setting is deactivated for the organization. Please contact your admins or hosting providers to activate the setting.`
+                            `Note: The public access setting is deactivated for the organization. Please contact your admins or hosting providers to activate the setting.`
                         ),
                         warn: orgaSettings => !orgaSettings.instant(`enable_anonymous`)
                     }


### PR DESCRIPTION
Resolve #4413

Worked on:
- use span to fix layout
- change color to grey for `warnText`
- Add Note: to public access warn Text.