### PR TITLE
Use backend directory structure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           path: "./openslides-client"
 
       - name: Use example data instead of initial data
-        working-directory: "./openslides-backend/global/data/"
+        working-directory: "./openslides-backend/data/"
         run: cp example-data.json initial-data.json
 
       - name: Start setup


### PR DESCRIPTION
Since the backend directory structure will change as per https://github.com/OpenSlides/openslides-backend/issues/2604 we need a small change within the github workflows.
This means that the `build-and-test-prod-image` of the build.yml will use the new backend location of the data folder.