### PR TITLE
Allow empty html element at the begining of an amendment

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/change-recommendations/services/motion-diff.service/motion-diff.service.ts
@@ -1347,7 +1347,9 @@ export class MotionDiffService {
                 htmlOldEl.content.querySelector(`.os-line-number`)
             ) {
                 const ln = htmlNewEl.content.querySelector(`.os-line-number`);
-                htmlNewEl.content.children[0].before(ln);
+                htmlNewEl.content.children[0].childNodes.length > 0
+                    ? htmlNewEl.content.children[0].childNodes[0].before(ln)
+                    : htmlNewEl.content.children[0].before(ln);
                 htmlOldEl.content.children[0].querySelector(`.os-line-number`).remove();
 
                 htmlNew = htmlNewEl.innerHTML;


### PR DESCRIPTION
Relevant if the amendment  starts with a header and you add bfore the header.