### PR TITLE
Fix general meeting settings problem

### DIFF
--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
@@ -213,7 +213,7 @@ export class MeetingSettingsGroupDetailComponent
     }
 
     public hasErrors(): boolean {
-        return this.settingsFields?.some(field => !field.disabled && !field.valid);
+        return this.settingsFields?.some(field => !field.disabled && !field.hasWarning() && !field.valid);
     }
 
     /**


### PR DESCRIPTION
Resolve #4524 

The `enable_anonymous` field in the meeting general settings sometimes leads to problems.
If warn is true, the group has hasErrors() = true, which prevents saving.