### PR TITLE
Add moderation note pdf export

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
@@ -33,6 +33,15 @@
                                 <mat-icon>edit</mat-icon>
                             </button>
                         }
+                        @if (showModerationNotesExport) {
+                            <button
+                                mat-icon-button
+                                matTooltip="{{ 'Export moderator note as PDF' | translate }}"
+                                (click)="onDownloadPDF()"
+                            >
+                                <mat-icon>picture_as_pdf</mat-icon>
+                            </button>
+                        }
                     </div>
                 }
             </div>

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
@@ -5,8 +5,8 @@
             <!-- Title edit/save/cancle-->
             <div class="action-title">
                 <p class="subtitle-text" translate>Moderation note</p>
-                @if (canManageModerationNote) {
-                    <div class="buttons">
+                <div class="buttons">
+                    @if (canManageModerationNote) {
                         @if (isEditing) {
                             <button
                                 color="warn"
@@ -23,8 +23,7 @@
                             >
                                 <mat-icon>close</mat-icon>
                             </button>
-                        }
-                        @if (!isEditing) {
+                        } @else {
                             <button
                                 mat-icon-button
                                 matTooltip="{{ 'Edit moderation note' | translate }}"
@@ -33,17 +32,17 @@
                                 <mat-icon>edit</mat-icon>
                             </button>
                         }
-                        @if (showModerationNotesExport) {
-                            <button
-                                mat-icon-button
-                                matTooltip="{{ 'Export moderator note as PDF' | translate }}"
-                                (click)="onDownloadPDF()"
-                            >
-                                <mat-icon>picture_as_pdf</mat-icon>
-                            </button>
-                        }
-                    </div>
-                }
+                    }
+                    @if (showModerationNotesExport) {
+                        <button
+                            mat-icon-button
+                            matTooltip="{{ 'Export moderator note as PDF' | translate }}"
+                            (click)="onDownloadPDF()"
+                        >
+                            <mat-icon>picture_as_pdf</mat-icon>
+                        </button>
+                    }
+                </div>
             </div>
             @if (!isEditing) {
                 <div class="app-content underlined-links detail-view-appearance-container">

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.ts
@@ -19,13 +19,15 @@ import { ViewListOfSpeakers } from 'src/app/site/pages/meetings/pages/agenda';
 import { OperatorService } from 'src/app/site/services/operator.service';
 
 import { ListOfSpeakersContentTitleDirective } from '../../directives/list-of-speakers-content-title.directive';
+import { ModerationNotePdfService } from '../../services/moderation-note-pdf.service/moderation-note-pdf.service';
 
 @Component({
     selector: `os-moderation-note`,
     templateUrl: `./moderation-note.component.html`,
     styleUrls: [`./moderation-note.component.scss`],
     encapsulation: ViewEncapsulation.None,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [ModerationNotePdfService]
 })
 export class ModerationNoteComponent extends BaseMeetingComponent implements OnInit {
     public isEditing = false;
@@ -48,6 +50,9 @@ export class ModerationNoteComponent extends BaseMeetingComponent implements OnI
     public set contentObject(contentObject: BaseViewModel) {
         this._contentObject = contentObject;
     }
+
+    @Input()
+    public showModerationNotesExport = true;
 
     public get moderatorNotes(): Observable<string> {
         return this.LoSRepo.getViewModelObservable(this._listOfSpeakers?.getModel().id).pipe(
@@ -83,6 +88,7 @@ export class ModerationNoteComponent extends BaseMeetingComponent implements OnI
         private operator: OperatorService,
         private formBuilder: FormBuilder,
         protected LoSRepo: ListOfSpeakersRepositoryService,
+        private moderationNotePdfService: ModerationNotePdfService,
         private cd: ChangeDetectorRef
     ) {
         super();
@@ -113,5 +119,12 @@ export class ModerationNoteComponent extends BaseMeetingComponent implements OnI
                 this.isEditing = false;
             })
             .catch(this.raiseError);
+    }
+
+    public onDownloadPDF(): void {
+        this.moderationNotePdfService.exportSingleModerationNote(
+            this.moderatorNotesForForm,
+            this._listOfSpeakers?.getTitle()
+        );
     }
 }

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/list-of-speakers-content.module.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/list-of-speakers-content.module.ts
@@ -20,6 +20,7 @@ import { SortingListModule } from 'src/app/ui/modules/sorting/modules/sorting-li
 import { PipesModule } from 'src/app/ui/pipes';
 
 import { ParticipantCommonServiceModule } from '../../pages/participants/services/common/participant-common-service.module';
+import { MeetingExportModule } from '../../services/export';
 import { DetailViewModule } from '../meetings-component-collector/detail-view/detail-view.module';
 import { ProjectorButtonModule } from '../meetings-component-collector/projector-button/projector-button.module';
 import { ParticipantSearchSelectorModule } from '../participant-search-selector';
@@ -67,7 +68,8 @@ const DECLARATIONS = [
         CountdownTimeModule,
         DirectivesModule,
         OpenSlidesTranslationModule.forChild(),
-        PipesModule
+        PipesModule,
+        MeetingExportModule
     ]
 })
 export class ListOfSpeakersContentModule {}

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/services/moderation-note-pdf.service/moderation-note-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/services/moderation-note-pdf.service/moderation-note-pdf.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Content, ContentText } from 'pdfmake/interfaces';
+import { HtmlToPdfService } from 'src/app/gateways/export/html-to-pdf.service';
+import { MeetingPdfExportService } from 'src/app/site/pages/meetings/services/export';
+
+/**
+ * Creates a PDF document from a single tpoic
+ */
+@Injectable()
+export class ModerationNotePdfService {
+    public constructor(
+        private translate: TranslateService,
+        private htmlToPdfService: HtmlToPdfService,
+        private pdfDocumentService: MeetingPdfExportService
+    ) {}
+
+    /**
+     * Generates an pdf out of a given topic and saves it as file
+     *
+     * @param topic the topic to export
+     */
+    public exportSingleModerationNote(moderationNote: string, title: string): void {
+        const doc = this.moderationNoteToDocDef(moderationNote, title);
+        const filename = `${this.translate.instant(`Moderation-Note`)}`;
+        const metadata = {
+            title: filename
+        };
+
+        this.pdfDocumentService.download({ docDefinition: doc, filename, metadata });
+    }
+
+    private moderationNoteToDocDef(moderationNote: string, moderationNoteTitle: string): Content[] {
+        const title = this.createTitle(moderationNoteTitle);
+        const text = this.createTextContent(moderationNote);
+
+        return [title, text];
+    }
+
+    private createTitle(title: string): ContentText {
+        return {
+            text: title,
+            style: `title`
+        };
+    }
+
+    private createTextContent(moderationNote: string): Content {
+        if (moderationNote) {
+            return this.htmlToPdfService.addPlainText(moderationNote);
+        } else {
+            return [];
+        }
+    }
+}

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -127,7 +127,10 @@
             <!-- Moderator Note-->
             @if (hasCurrentProjection && disabledContentElements['moderation-note'] !== true) {
                 <div>
-                    <os-moderation-note [listOfSpeakers]="listOfSpeakers"></os-moderation-note>
+                    <os-moderation-note
+                        [listOfSpeakers]="listOfSpeakers"
+                        [showModerationNotesExport]="false"
+                    ></os-moderation-note>
                 </div>
             }
 


### PR DESCRIPTION
Resolve #4590 

Add a service for the PDF export. Use the title of the los as header. A moderation note is always attached to a los. Use MeetingPdfExport, like in topic export.