### PR TITLE
Fix problems with missing fonts in motion export

### DIFF
--- a/client/src/app/gateways/export/pdf-document.service/pdf-worker.worker.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-worker.worker.ts
@@ -48,7 +48,12 @@ function applyLayout(content: any): void {
 function initPdfMake(data: any): void {
     pdfMake.fonts = {
         PdfFont: data.fonts,
-        LineNumbering: { normal: `fira-sans-latin-400.woff` }
+        LineNumbering: {
+            normal: `fira-sans-latin-400.woff`,
+            italics: `fira-sans-latin-400.woff`,
+            bold: `fira-sans-latin-400.woff`,
+            bolditalics: `fira-sans-latin-400.woff`
+        }
     };
     pdfMake.vfs = data.vfs;
 }


### PR DESCRIPTION
Resolve #4656 

Some fonts are missing. Use the same font for bold for LineNumbering as for normal.