### PR TITLE
Fix motion export with headings

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-html-to-pdf.service/motion-html-to-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-html-to-pdf.service/motion-html-to-pdf.service.ts
@@ -264,7 +264,10 @@ export class MotionHtmlToPdfService extends HtmlToPdfService {
                     text: line.lineNumber,
                     color: `gray`,
                     fontSize: 8,
-                    font: `LineNumbering`
+                    font: `LineNumbering`,
+                    bold: false,
+                    italics: false,
+                    bolditalics: false
                 }
             ],
             marginBottom: line.marginBottom,


### PR DESCRIPTION
Closes #4656 
Makes export available again but has issues with displaying at least the correct h5 style. Please state if this issue should be fixed here or in its own issue.