### PR TITLE
Make some conformity changes for backend issue 2866

### DIFF
--- a/client/src/app/domain/models/meetings/meeting.ts
+++ b/client/src/app/domain/models/meetings/meeting.ts
@@ -508,7 +508,7 @@ export class Meeting extends BaseModel<Meeting> {
         `default_projector_agenda_item_list_ids`,
         `default_projector_topic_ids`,
         `default_projector_list_of_speakers_ids`,
-        `default_projector_current_list_of_speakers_ids`,
+        `default_projector_current_los_ids`,
         `default_projector_motion_ids`,
         `default_projector_amendment_ids`,
         `default_projector_motion_block_ids`,

--- a/client/src/app/domain/models/projector/projection-default.ts
+++ b/client/src/app/domain/models/projector/projection-default.ts
@@ -4,7 +4,7 @@ export const PROJECTIONDEFAULT = {
     agendaItemList: `agenda_item_list`,
     topics: `topic`,
     listOfSpeakers: `list_of_speakers`,
-    currentListOfSpeakers: `current_list_of_speakers`,
+    currentListOfSpeakers: `current_los`,
     motion: `motion`,
     amendment: `amendment`,
     motionBlock: `motion_block`,

--- a/client/src/app/gateways/repositories/meeting-repository.service.ts
+++ b/client/src/app/gateways/repositories/meeting-repository.service.ts
@@ -18,7 +18,7 @@ import { RepositoryServiceCollectorService } from './repository-service-collecto
 import { UserAction } from './users/user-action';
 
 export enum MeetingProjectionType {
-    CurrentListOfSpeakers = `current_list_of_speakers`,
+    CurrentListOfSpeakers = `current_los`,
     CurrentSpeakerChyron = `current_speaker_chyron`,
     CurrentSpeakingStructureLevel = `current_speaking_structure_level`,
     CurrentStructureLevelList = `current_structure_level_list`,

--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/list-of-speakers/modules/current-los-slide/current-los-slide.module.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/list-of-speakers/modules/current-los-slide/current-los-slide.module.ts
@@ -9,4 +9,4 @@ import { CommonListOfSpeakersSlideComponent } from '../common-list-of-speakers-s
     imports: [CommonModule, CommonListOfSpeakersSlideModule],
     providers: [{ provide: SlideToken.token, useValue: CommonListOfSpeakersSlideComponent }]
 })
-export class CurrentListOfSpeakersSlideModule {}
+export class CurrentLosSlideModule {}

--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/definitions/slides.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/definitions/slides.ts
@@ -42,7 +42,7 @@ export const Slides: SlideManifest[] = [
         scrollable: true
     },
     {
-        path: `current_list_of_speakers`,
+        path: `current_los`,
         loadChildren: () =>
             import(`../components/list-of-speakers/modules/current-los-slide/current-los-slide.module`).then(
                 m => m.CurrentLosSlideModule

--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/definitions/slides.ts
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/definitions/slides.ts
@@ -44,9 +44,9 @@ export const Slides: SlideManifest[] = [
     {
         path: `current_list_of_speakers`,
         loadChildren: () =>
-            import(
-                `../components/list-of-speakers/modules/current-list-of-speakers-slide/current-list-of-speakers-slide.module`
-            ).then(m => m.CurrentListOfSpeakersSlideModule),
+            import(`../components/list-of-speakers/modules/current-los-slide/current-los-slide.module`).then(
+                m => m.CurrentLosSlideModule
+            ),
         verboseName: _(`Current list of speakers`),
         scaleable: true,
         scrollable: true

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/projector-detail/projector-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/projector-detail/projector-detail.component.ts
@@ -123,7 +123,7 @@ export class ProjectorDetailComponent extends BaseMeetingComponent implements On
         private projectionRepo: ProjectionControllerService,
         private countdownRepo: ProjectorCountdownControllerService,
         private messageRepo: ProjectorMessageControllerService,
-        private currentListOfSpeakersSlideService: CurrentListOfSpeakersSlideService,
+        private currentLosSlideService: CurrentListOfSpeakersSlideService,
         private currentStructureLevelListSlideService: CurrentStructureLevelListSlideService,
         private currentSpeakingStructureLevelSlideService: CurrentSpeakingStructureLevelSlideService,
         private currentSpeakerChyronService: CurrentSpeakerChyronSlideService,
@@ -266,15 +266,15 @@ export class ProjectorDetailComponent extends BaseMeetingComponent implements On
     }
 
     public isClosProjected(overlay: boolean): boolean {
-        return this.currentListOfSpeakersSlideService.isProjectedOn(this.projector, overlay);
+        return this.currentLosSlideService.isProjectedOn(this.projector, overlay);
     }
 
     public toggleClos(overlay: boolean): void {
-        this.currentListOfSpeakersSlideService.toggleOn(this.projector, overlay);
+        this.currentLosSlideService.toggleOn(this.projector, overlay);
     }
 
     public getCurrentLoSBuildDesc(overlay: boolean): ProjectionBuildDescriptor {
-        return this.currentListOfSpeakersSlideService.getProjectionBuildDescriptor(overlay);
+        return this.currentLosSlideService.getProjectionBuildDescriptor(overlay);
     }
 
     public getCurrentStructureLevel(): ProjectionBuildDescriptor {


### PR DESCRIPTION
See backend issue OpenSlides/openslides-backend#2866 for context. The name of the slide-type was changed in migration to ensure the thematic connection would remain.

Needs OpenSlides/openslides-backend#2869, OpenSlides/openslides-meta#223 and OpenSlides/openslides-autoupdate-service#1157

Autoupdate service seems still broken for autoupdate go-service reasons.

After that is fixed, please check if the current los projection still works as intended, if the default can be set and is shown in the projection dialog.