### PR TITLE
Fix renderDiffLines in amendment-list-pdf service

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/services/export/amendment-list-pdf.service/amendment-list-pdf.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/amendment-list-pdf.service/amendment-list-pdf.service.ts
@@ -25,12 +25,12 @@ export class AmendmentListPdfService {
      * @param amendment
      * @return rendered PDF text
      */
-    private renderDiffLines(amendment: ViewMotion): object {
+    private renderDiffLines(amendment: ViewMotion): Content[] {
         if (amendment.affectedAmendmentLines?.length) {
             const linesHtml = amendment.affectedAmendmentLines.map(line => line.text).join(`<br />[...]<br />`);
             return this.htmlToPdfService.convertHtml({ htmlText: linesHtml });
         }
-        return {};
+        return [];
     }
 
     /**


### PR DESCRIPTION
Resolve #4747 

The edge case was broken, the method returned an object instead of an array. 
Stack required an array later. 