### PR TITLE
Hide internal motions from list

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/view-models/view-motion.ts
@@ -383,6 +383,10 @@ export class ViewMotion extends BaseProjectableViewModel<Motion> {
             return PROJECTIONDEFAULT.motion;
         }
     }
+
+    public override canAccess(): boolean {
+        return !!this.sequential_number;
+    }
 }
 
 interface IMotionRelations extends HasPolls<ViewMotion> {


### PR DESCRIPTION
Fixes an issue where empty internal motions were displayed in the motion list if the motion was forwarded from another meeting and the user is allowed to see the motion in the source meeting. 