### PR TITLE
Add the missing summary title and allow translation

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/services/participant-import.service/participant-import.service.ts
@@ -33,12 +33,13 @@ export class ParticipantImportService extends BaseBackendImportService {
     };
 
     public override readonly verboseSummaryTitles: Record<string, string> = {
-        total: _(`Total participants`),
-        created: _(`Participants created`),
-        updated: _(`Participants updated`),
-        omitted: _(`Participants skipped`),
-        warning: _(`Participants with warnings: affected cells will be skipped`),
-        error: _(`Participants with errors`)
+        "total": _(`Total participants`),
+        "created": _(`Participants created`),
+        "updated": _(`Participants updated`),
+        "omitted": _(`Participants skipped`),
+        "warning": _(`Participants with warnings: affected cells will be skipped`),
+        "error": _(`Participants with errors`),
+        "structure levels created": _(`Structure levels created`)
     };
 
     public constructor(


### PR DESCRIPTION
Resolve #4833 

Add the missing title in the participant import. Now it can be translated, 'cause it has a translation tag. 