### PR TITLE
Fix problem with poll pdf export and entitled users 

### DIFF
--- a/client/src/app/site/pages/meetings/modules/poll/base/base-poll-detail.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/base/base-poll-detail.component.ts
@@ -191,7 +191,7 @@ export abstract class BasePollDetailComponent<V extends PollContentObject, S ext
     public exportPollResults(): void {
         this.pollPdfService.exportSinglePoll(this.poll, {
             votesData: this._votesDataSubject.value,
-            entitledUsersData: this._liveRegisterObservable.value
+            entitledUsersData: this.poll.isStarted ? this._liveRegisterObservable.value : this._entitledUsersSubject.value
         });
     }
 


### PR DESCRIPTION
Resolve #4873 

Only in a poll with status 'started' the live vote register data are available. In the other status the entitled users data should be used.