### PR TITLE
Clean up group call

### DIFF
--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
@@ -366,8 +366,8 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
 
     private cleanUpGroups(group_ids: number[]): number[] {
         const meeting_group_ids = this.activeMeetingService.meeting.group_ids;
-        group_ids = group_ids.filter(group_id_1 =>
-            meeting_group_ids.find(group_id_2 => group_id_1 === group_id_2)
+        group_ids = group_ids.filter(group_id =>
+            meeting_group_ids.includes(group_id)
         );
         return group_ids;
     }

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.ts
@@ -279,6 +279,7 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
             if (payload.gender_id === 0) {
                 payload.gender_id = null;
             }
+            payload.group_ids = this.cleanUpGroups(payload.group_ids);
             if (this._accountId) {
                 const dirtyPayload = {};
                 for (const field in payload) {
@@ -361,5 +362,13 @@ export class ParticipantCreateWizardComponent extends BaseMeetingComponent imple
         return group_ids
             .map((id: Id): ViewGroup => this.groupRepo.getViewModel(id))
             .some(group => group.hasPermission(Permission.userCanManage));
+    }
+
+    private cleanUpGroups(group_ids: number[]): number[] {
+        const meeting_group_ids = this.activeMeetingService.meeting.group_ids;
+        group_ids = group_ids.filter(group_id_1 =>
+            meeting_group_ids.find(group_id_2 => group_id_1 === group_id_2)
+        );
+        return group_ids;
     }
 }


### PR DESCRIPTION
closes #4731 

As I already stated in the issue it is rather hard to get this bug via normal behaviour
It would be easier to use curl and try to create a user with (on purpose) wrong groups