### PR TITLE
Provide missing pipes poll-key-verbose and poll-parse-number

### DIFF
--- a/client/src/app/site/pages/meetings/modules/poll/pipes/poll-key-verbose/poll-key-verbose.pipe.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/pipes/poll-key-verbose/poll-key-verbose.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Injectable, Pipe, PipeTransform } from '@angular/core';
 import { _ } from '@ngx-translate/core';
 
 const PollValues: any = {
@@ -20,6 +20,9 @@ const PollValues: any = {
  */
 @Pipe({
     name: `pollKeyVerbose`
+})
+@Injectable({
+    providedIn: `root`
 })
 export class PollKeyVerbosePipe implements PipeTransform {
     public transform(value: string): string {

--- a/client/src/app/site/pages/meetings/modules/poll/pipes/poll-parse-number/poll-parse-number.pipe.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/pipes/poll-parse-number/poll-parse-number.pipe.ts
@@ -1,9 +1,12 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Injectable, Pipe, PipeTransform } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { VOTE_MAJORITY, VOTE_UNDOCUMENTED } from 'src/app/domain/models/poll/poll-constants';
 
 @Pipe({
     name: `pollParseNumber`
+})
+@Injectable({
+    providedIn: `root`
 })
 export class PollParseNumberPipe implements PipeTransform {
     private formatter = new Intl.NumberFormat(`us-us`, {

--- a/client/src/app/site/pages/meetings/pages/motions/services/export/motion-xlsx-export.service/motion-xlsx-export.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/services/export/motion-xlsx-export.service/motion-xlsx-export.service.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line simple-import-sort/imports
 import { Injectable } from '@angular/core';
 import { _ } from '@ngx-translate/core';
 import { TranslateService } from '@ngx-translate/core';


### PR DESCRIPTION
Resolve #4887 

With the change to standalone, these pipes are not provided, which leads to a NullInjection error. This is a quick fix.