### PR TITLE
Allow dialogs to close on ESC and backdrop

### DIFF
--- a/client/src/app/infrastructure/utils/dialog-settings.ts
+++ b/client/src/app/infrastructure/utils/dialog-settings.ts
@@ -1,7 +1,7 @@
 /**
  * General settings all dialogs are using.
  */
-const generalSettings = { disableClose: true, maxWidth: `90vw`, maxHeight: `90vh` };
+const generalSettings = { disableClose: false, maxWidth: `90vw`, maxHeight: `90vh` };
 
 /**
  * Settings to display a large (wide) dialog.


### PR DESCRIPTION
Resolve #4916 

Fixes the usage of ESC and backdrop in dialogs with dialogSettings. Like in the prompt service. 