### PR TITLE
Change pollmethod label for motion polls

### DIFF
--- a/client/src/app/domain/models/poll/poll-constants.ts
+++ b/client/src/app/domain/models/poll/poll-constants.ts
@@ -131,7 +131,22 @@ export const PollTypeVerbose = {
 
 export type PollTypeVerboseKey = keyof typeof PollTypeVerbose;
 
-export const PollPropertyVerbose = {
+export interface PollPropertyVerboseType {
+    onehundred_percent_base: string;
+    type: string;
+    pollmethod: string;
+    state: string;
+    groups: string;
+    votes_amount: string;
+    global_yes: string;
+    global_no: string;
+    global_abstain: string;
+    max_votes_amount: string;
+    min_votes_amount: string;
+    max_votes_per_option: string;
+};
+
+export const PollPropertyVerbose: PollPropertyVerboseType = {
     onehundred_percent_base: _(`100% base`),
     type: _(`Voting type`),
     pollmethod: _(`Voting method`),

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-form/motion-poll-form.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll-form/motion-poll-form.component.ts
@@ -1,4 +1,5 @@
 import { Component, ViewEncapsulation } from '@angular/core';
+import { PollPropertyVerboseType } from 'src/app/domain/models/poll';
 import {
     BasePollFormComponent,
     PollFormHideSelectsData
@@ -13,6 +14,7 @@ import {
     standalone: false
 })
 export class MotionPollFormComponent extends BasePollFormComponent {
+    public override PollPropertyVerbose: PollPropertyVerboseType = { ...this.PollPropertyVerbose, pollmethod: `Poll method` };
     public get hideSelects(): PollFormHideSelectsData {
         return {
             globalOptions: true


### PR DESCRIPTION
Resolve #4898 

Changed the label from 'Voting method' to 'Poll method' for motion polls.