### PR TITLE
Fix search term permanence in lists

### DIFF
--- a/client/src/app/ui/modules/list/base/base-list.component.ts
+++ b/client/src/app/ui/modules/list/base/base-list.component.ts
@@ -248,6 +248,7 @@ export class BaseListComponent<V extends Identifiable> implements OnInit, OnDest
      */
     public searchFilter(filterValue: string): void {
         this.inputValue = filterValue;
+        this.cd.markForCheck();
     }
 
     public scrollTo(offset: number): void {


### PR DESCRIPTION
Closes #4960 

Didn't seem like an issue of the browser btw, just an issue of which concurrent processes finish first, as some of them will cause data to be passed on to sub-components and the one loading the old search value specifically didn't.