### PR TITLE
Hide moderation note in missing los context

### DIFF
--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -139,7 +139,7 @@
             </ng-container>
 
             <!-- Moderator Note-->
-            @if (hasCurrentProjection && disabledContentElements['moderation-note'] !== true) {
+            @if (hasCurrentProjection && !!listOfSpeakers && disabledContentElements['moderation-note'] !== true) {
                 <div>
                     <os-moderation-note
                         [listOfSpeakers]="listOfSpeakers"


### PR DESCRIPTION
Resolve #5025 

The moderation note needs a los to be displayed correct. So add a condition that the los is in place.