### PR TITLE
Fix filterObject function

### DIFF
--- a/client/src/app/infrastructure/utils/functions.spec.ts
+++ b/client/src/app/infrastructure/utils/functions.spec.ts
@@ -583,6 +583,10 @@ describe(`utils: functions`, () => {
         it(`test with null`, () => {
             expect(filterObject(null, keyVal => !!keyVal.value)).toEqual(null);
         });
+
+        it(`test with all filtered out`, () => {
+            expect(filterObject({ a: [], b: [] }, keyVal => keyVal.value.length > 0)).toEqual({});
+        });
     });
 
     describe(`partitionModelsForUpdate function`, () => {

--- a/client/src/app/infrastructure/utils/functions.ts
+++ b/client/src/app/infrastructure/utils/functions.ts
@@ -430,7 +430,7 @@ export function filterObject(obj: unknown, callbackFn: (keyValue: { key: string;
     return Object.entries(obj)
         .filter(([key, value]) => callbackFn({ key, value }))
         .map(([key, value]) => ({ [key]: value }))
-        .reduce((prev, curr) => Object.assign(prev, curr));
+        .reduce((prev, curr) => Object.assign(prev, curr), {});
 }
 
 export interface ListUpdateData<T extends Identifiable> {


### PR DESCRIPTION
Resolve #5112

Add initial object for reduce and add a karma test.

Note the ranking type setting sometimes throws NG0100 in this context, but that is another issue. 