### PR TITLE
Add hc and external to account list in username row

### DIFF
--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.html
@@ -81,6 +81,11 @@
                     @if (user.member_number) {
                         &middot; {{ user.member_number }}
                     }
+                    @if (user.home_committee) {
+                        &middot; {{ user.home_committee.getTitle() }}
+                    } @else if (user.guest) {
+                        &middot; {{ 'external' | translate }}
+                    }
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Part of #5133 

Add external and home committee in the small username row in the account list. Implements solution B) of the
point 1. of #5133.