### PR TITLE
Fix category multi sorting

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail-sort/category-detail-sort.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail-sort/category-detail-sort.component.ts
@@ -152,7 +152,6 @@ export class CategoryDetailSortComponent extends BaseMeetingComponent implements
             const selectedChoice = await this.choiceService.open(content, choices, false, actions);
             if (selectedChoice) {
                 const newIndex = selectedChoice.firstId;
-
                 this.sortSelector.drop(
                     {
                         currentIndex: newIndex,

--- a/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail-sort/category-detail-sort.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail-sort/category-detail-sort.component.ts
@@ -151,10 +151,11 @@ export class CategoryDetailSortComponent extends BaseMeetingComponent implements
             const actions = [this.translate.instant(`Insert before`), this.translate.instant(`Insert behind`)];
             const selectedChoice = await this.choiceService.open(content, choices, false, actions);
             if (selectedChoice) {
-                const newIndex = selectedChoice.firstId;
+                const selectedId = selectedChoice.firstId;
+                const itemIndex = this.sortSelector.sortedItems.findIndex(item => item.id === selectedId);
                 this.sortSelector.drop(
                     {
-                        currentIndex: newIndex,
+                        currentIndex: itemIndex,
                         previousIndex: 0
                     },
                     selectedChoice.action === actions[1] // true if 'insert behind'

--- a/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
+++ b/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
@@ -168,10 +168,11 @@ export class SortingListComponent<T extends Selectable = Selectable> implements 
         event: CdkDragDrop<T[]> | { currentIndex: number; previousIndex: number },
         dropBehind?: boolean
     ): Promise<void> {
-        if (!this.draggingUnlockFnPromise) {
+        if (!this.draggingUnlockFnPromise && typeof event?.currentIndex !== `number`) {
             throw new Error(`Drop was called without previous drag call`);
         }
         const unlock = await this.draggingUnlockFnPromise;
+
         this.draggingUnlockFnPromise = undefined;
         let multiSelectedIndex = this.multiSelectedIndex;
         if (this.sortingChanged) {
@@ -188,7 +189,9 @@ export class SortingListComponent<T extends Selectable = Selectable> implements 
             this.sortEvent.emit(this.sortedItems);
             this.multiSelectedIndex = [];
         }
-        unlock();
+        if (typeof unlock === `function`) {
+            unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
Resolve #5174

Update the `drop` function. There are three cases, dragndrop single/multi and move button.