### PR TITLE
Fix sort-filter-bar focus on ctrl-f

### DIFF
--- a/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.ts
+++ b/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.ts
@@ -48,7 +48,7 @@ import { SortBottomSheetComponent } from '../sort-bottom-sheet/sort-bottom-sheet
     standalone: false
 })
 export class SortFilterBarComponent<V extends Identifiable> implements OnDestroy, OnInit {
-    @ViewChild(`searchField`, { static: true })
+    @ViewChild(`searchField`)
     private readonly _searchFieldComponent!: RoundedInputComponent | undefined;
 
     /**


### PR DESCRIPTION
Resolve #5099 

The search field is in a "if"-block and is dynamic. So I removed the static from the query of the search field.