### PR TITLE
When projection los, the projected los is displayed, too

### DIFF
--- a/client/src/app/site/pages/meetings/pages/autopilot/autopilot.subscription.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/autopilot.subscription.ts
@@ -36,6 +36,29 @@ export const getAutopilotSubscriptionConfig: SubscriptionConfigGenerator = (id: 
     subscriptionName: AUTOPILOT_SUBSCRIPTION
 });
 
+const speakersFields = {
+    idField: `speaker_ids`,
+    fieldset: FULL_FIELDSET,
+    follow: [
+        mergeSubscriptionFollow(
+            {
+                idField: `meeting_user_id`,
+                follow: [
+                    {
+                        idField: `structure_level_ids`,
+                        fieldset: [`name`, `color`]
+                    }
+                ]
+            },
+            { idField: `meeting_user_id`, ...MeetingUserFieldsets.FullNameSubscription }
+        ),
+        {
+            idField: `structure_level_list_of_speakers_id`,
+            fieldset: FULL_FIELDSET
+        }
+    ]
+};
+
 export const getAutopilotContentSubscriptionConfig = (id: Id): SubscriptionConfig<any> => ({
     modelRequest: {
         viewModelCtor: ViewProjection,
@@ -53,54 +76,12 @@ export const getAutopilotContentSubscriptionConfig = (id: Id): SubscriptionConfi
                         idField: `poll_ids`,
                         ...pollModelRequest
                     },
-                    {
-                        idField: `speaker_ids`,
-                        fieldset: FULL_FIELDSET,
-                        follow: [
-                            mergeSubscriptionFollow(
-                                {
-                                    idField: `meeting_user_id`,
-                                    follow: [
-                                        {
-                                            idField: `structure_level_ids`,
-                                            fieldset: [`name`, `color`]
-                                        }
-                                    ]
-                                },
-                                { idField: `meeting_user_id`, ...MeetingUserFieldsets.FullNameSubscription }
-                            ),
-                            {
-                                idField: `structure_level_list_of_speakers_id`,
-                                fieldset: FULL_FIELDSET
-                            }
-                        ]
-                    },
+                    speakersFields,
                     {
                         idField: `list_of_speakers_id`,
                         fieldset: [`closed`, `moderator_notes`, ...MEETING_ROUTING_FIELDS],
                         follow: [
-                            {
-                                idField: `speaker_ids`,
-                                fieldset: FULL_FIELDSET,
-                                follow: [
-                                    mergeSubscriptionFollow(
-                                        {
-                                            idField: `meeting_user_id`,
-                                            follow: [
-                                                {
-                                                    idField: `structure_level_ids`,
-                                                    fieldset: [`name`, `color`]
-                                                }
-                                            ]
-                                        },
-                                        { idField: `meeting_user_id`, ...MeetingUserFieldsets.FullNameSubscription }
-                                    ),
-                                    {
-                                        idField: `structure_level_list_of_speakers_id`,
-                                        fieldset: FULL_FIELDSET
-                                    }
-                                ]
-                            },
+                            speakersFields,
                             {
                                 idField: `structure_level_list_of_speakers_ids`,
                                 fieldset: FULL_FIELDSET

--- a/client/src/app/site/pages/meetings/pages/autopilot/autopilot.subscription.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/autopilot.subscription.ts
@@ -43,7 +43,7 @@ export const getAutopilotContentSubscriptionConfig = (id: Id): SubscriptionConfi
         follow: [
             {
                 idField: `content_object_id`,
-                fieldset: [`title`, `owner_id`, ...MEETING_ROUTING_FIELDS],
+                fieldset: [`title`, `owner_id`, `closed`, `moderator_notes`, ...MEETING_ROUTING_FIELDS],
                 follow: [
                     {
                         idField: `mediafile_id`,
@@ -52,6 +52,28 @@ export const getAutopilotContentSubscriptionConfig = (id: Id): SubscriptionConfi
                     {
                         idField: `poll_ids`,
                         ...pollModelRequest
+                    },
+                    {
+                        idField: `speaker_ids`,
+                        fieldset: FULL_FIELDSET,
+                        follow: [
+                            mergeSubscriptionFollow(
+                                {
+                                    idField: `meeting_user_id`,
+                                    follow: [
+                                        {
+                                            idField: `structure_level_ids`,
+                                            fieldset: [`name`, `color`]
+                                        }
+                                    ]
+                                },
+                                { idField: `meeting_user_id`, ...MeetingUserFieldsets.FullNameSubscription }
+                            ),
+                            {
+                                idField: `structure_level_list_of_speakers_id`,
+                                fieldset: FULL_FIELDSET
+                            }
+                        ]
                     },
                     {
                         idField: `list_of_speakers_id`,

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
@@ -139,10 +139,15 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
                             ? currentProjections[0]
                             : null;
                     this.projectedViewModel = this._currentProjection?.content_object || null;
+                    if (this.projectedViewModel?.collection === `list_of_speakers`) {
+                        this.listOfSpeakers = this.projectedViewModel as ViewListOfSpeakers;
+                    }
                 }
             }),
             closService.currentListOfSpeakersObservable.subscribe(clos => {
-                this.listOfSpeakers = clos;
+                if (this.projectedViewModel?.collection !== `list_of_speakers`) {
+                    this.listOfSpeakers = clos;
+                }
             }),
             this.meetingSettingsService
                 .get(`list_of_speakers_default_structure_level_time`)


### PR DESCRIPTION
Resolve #5172 

The old behaviour is that if a content_object has a los ,it is displayed.
Changed it to: if the content_object is a los, display the los controls outside with this los too.
Needs a change to the subscription to fully work.