### PR TITLE
Support meta (Command) key for macOS compatibility

### DIFF
--- a/client/src/app/ui/directives/only-number/only-number.directive.ts
+++ b/client/src/app/ui/directives/only-number/only-number.directive.ts
@@ -73,14 +73,14 @@ export class OnlyNumberDirective implements OnInit {
         if (this.osOnlyNumber) {
             if (
                 this.allowedKeys.includes(event.key) ||
-                // Allow: Ctrl+A
-                (event.key === `a` && event.ctrlKey) ||
-                // Allow: Ctrl+C
-                (event.key === `c` && event.ctrlKey) ||
-                // Allow: Ctrl+V
-                (event.key === `v` && event.ctrlKey) ||
-                // Allow: Ctrl+X
-                (event.key === `x` && event.ctrlKey) ||
+                // Allow: Ctrl+A and command+A
+                (event.key === `a` && (event.ctrlKey || event.metaKey)) ||
+                // Allow: Ctrl+C and command+C
+                (event.key === `c` && (event.ctrlKey || event.metaKey)) ||
+                // Allow: Ctrl+V and command+V
+                (event.key === `v` && (event.ctrlKey || event.metaKey)) ||
+                // Allow: Ctrl+X and command+X
+                (event.key === `x` && (event.ctrlKey || event.metaKey)) ||
                 this.regExp.test(nextValue)
             ) {
                 return;

--- a/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.ts
+++ b/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.ts
@@ -304,7 +304,7 @@ export class SortFilterBarComponent<V extends Identifiable> implements OnDestroy
     }
 
     @HostListener(`document:keydown`, [`$event`]) public onKeyDown(event: KeyboardEvent): void {
-        if (event.ctrlKey && event.key === `f`) {
+        if ((event.ctrlKey || event.metaKey) && event.key === `f`) {
             event.preventDefault();
             event.stopPropagation();
             this._searchFieldComponent.focus();

--- a/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
+++ b/client/src/app/ui/modules/sorting/modules/sorting-list/components/sorting-list/sorting-list.component.ts
@@ -205,7 +205,7 @@ export class SortingListComponent<T extends Selectable = Selectable> implements 
     public onItemClick(event: MouseEvent | Event, indx: number): void {
         if (event.type === `click` || (event as KeyboardEvent).key === ` `) {
             event.preventDefault();
-            if ((event as MouseEvent).ctrlKey) {
+            if ((event as MouseEvent).ctrlKey || (event as MouseEvent).metaKey) {
                 const ind = this.multiSelectedIndex.findIndex(i => i === indx);
                 if (ind === -1) {
                     this.multiSelectedIndex.push(indx);

--- a/client/src/app/ui/modules/sorting/modules/sorting-tree/components/sorting-tree/sorting-tree.component.ts
+++ b/client/src/app/ui/modules/sorting/modules/sorting-tree/components/sorting-tree/sorting-tree.component.ts
@@ -600,7 +600,7 @@ export class SortingTreeComponent<T extends Identifiable & Displayable> implemen
         if (event.type === `click` || (event as KeyboardEvent).key === ` `) {
             document.getSelection().removeAllRanges();
             event.preventDefault();
-            if ((event as MouseEvent).ctrlKey) {
+            if ((event as MouseEvent).ctrlKey || (event as MouseEvent).metaKey) {
                 const index = this.multiSelectedIndex.findIndex(i => i === clickIndex);
                 if (index === -1) {
                     this.multiSelectedIndex.push(clickIndex);


### PR DESCRIPTION
Added metaKey checks alongside ctrlKey across various components to ensure compatibility with Command key on macOS. This update enables consistent user interactions for keyboard shortcuts on both Windows and macOS platforms.

Related to Issue Support for Cmd key (macOS) in keyboard/mouse interactions #5233