### PR TITLE
Add missing titles to chat and meeting settings

### DIFF
--- a/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-list/chat-group-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-list/chat-group-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { firstValueFrom, Observable } from 'rxjs';
 import { Id } from 'src/app/domain/definitions/key-types';
@@ -19,7 +19,7 @@ import { ChatGroupControllerService, ChatNotificationService } from '../../../..
     encapsulation: ViewEncapsulation.None,
     standalone: false
 })
-export class ChatGroupListComponent extends BaseMeetingComponent {
+export class ChatGroupListComponent extends BaseMeetingComponent implements OnInit {
     public get chatGroupsObservable(): Observable<ViewChatGroup[]> {
         return this.chatGroupRepo.getViewModelListObservable();
     }
@@ -43,6 +43,10 @@ export class ChatGroupListComponent extends BaseMeetingComponent {
         private operator: OperatorService
     ) {
         super();
+    }
+
+    public ngOnInit(): void {
+        super.setTitle(`Chat`);
     }
 
     public getNotificationsObservableForChatId(chatGroupId: Id): Observable<number> {

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.ts
@@ -193,6 +193,7 @@ export class MeetingSettingsGroupDetailFieldComponent extends BaseComponent impl
      * Sets up the form for this settings field.
      */
     public ngOnInit(): void {
+        super.setTitle(`Settings`);
         // filter out empty results in group observable. We never have no groups and it messes up
         // the settings change detection
         this.groupObservable = this.groupRepo.getViewModelListWithoutSystemGroupsObservable().pipe(

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.ts
@@ -76,6 +76,7 @@ export class MeetingSettingsGroupDetailComponent
      * Sets the title, inits the table and calls the repo
      */
     public ngOnInit(): void {
+        super.setTitle(`Settings`);
         const settings = this.translate.instant(`Settings`);
 
         this.subscriptions.push(

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-list/components/meeting-settings-group-list/meeting-settings-group-list.component.ts
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-list/components/meeting-settings-group-list/meeting-settings-group-list.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { BaseMeetingComponent } from 'src/app/site/pages/meetings/base/base-meeting.component';
 import { MeetingControllerService } from 'src/app/site/pages/meetings/services/meeting-controller.service';
@@ -15,7 +15,7 @@ import { PromptService } from 'src/app/ui/modules/prompt-dialog';
     styleUrls: [`./meeting-settings-group-list.component.scss`],
     standalone: false
 })
-export class MeetingSettingsGroupListComponent extends BaseMeetingComponent {
+export class MeetingSettingsGroupListComponent extends BaseMeetingComponent implements OnInit {
     public groups: SettingsGroup[] = [];
 
     public constructor(
@@ -27,6 +27,10 @@ export class MeetingSettingsGroupListComponent extends BaseMeetingComponent {
         super();
 
         this.groups = this.meetingSettingsDefinitionProvider.settings;
+    }
+
+    public ngOnInit(): void {
+        super.setTitle(`Settings`);
     }
 
     /**


### PR DESCRIPTION
Resolve #5045

Use the setTitle() method to set the missing titles.