### PR TITLE
Add filetype icons to attachments

### DIFF
--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.html
@@ -82,7 +82,10 @@
                             <mat-list dense>
                                 @for (file of sortedAttachments; track file) {
                                     <mat-list-item class="attachment-entry">
-                                        <a target="_blank" [routerLink]="file.url">{{ file.getTitle() }}</a>
+                                        <a target="_blank" [routerLink]="file.url">
+                                            <mat-icon class="attachment-icon">{{ file.getIcon() }}</mat-icon>
+                                            {{ file.getTitle() }}
+                                        </a>
                                     </mat-list-item>
                                 }
                             </mat-list>

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.scss
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-detail/components/topic-detail/topic-detail.component.scss
@@ -36,4 +36,8 @@
         max-width: 100%;
         word-break: break-word;
     }
+
+    .attachment-icon {
+        vertical-align: text-bottom;
+    }
 }

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.html
@@ -149,7 +149,10 @@
                         <mat-list class="election-document-list" dense>
                             @for (file of sortedAttachments; track file) {
                                 <mat-list-item class="attachment-entry">
-                                    <a target="_blank" [routerLink]="file.url">{{ file.getTitle() }}</a>
+                                    <a target="_blank" [routerLink]="file.url">
+                                        <mat-icon class="attachment-icon">{{ file.getIcon() }}</mat-icon>
+                                        {{ file.getTitle() }}
+                                    </a>
                                 </mat-list-item>
                             }
                         </mat-list>

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.scss
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.scss
@@ -133,3 +133,7 @@ mat-card mat-card-content h3 {
 :host ::ng-deep .detail-view {
     @include detail-view-appearance.detail-view-appearance;
 }
+
+.attachment-icon {
+    vertical-align: text-bottom;
+}

--- a/client/src/app/site/pages/meetings/pages/mediafiles/view-models/view-meeting-mediafile.ts
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/view-models/view-meeting-mediafile.ts
@@ -25,6 +25,10 @@ export class ViewMeetingMediafile extends BaseProjectableViewModel<MeetingMediaf
         return this.mediafile.title;
     }
 
+    public getIcon(): string {
+        return this.mediafile?.getIcon() ?? `insert_drive_file`;
+    }
+
     /**
      * Determine the downloadURL
      *

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-content/motion-content.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-content/motion-content.component.html
@@ -73,7 +73,10 @@
                     <mat-list dense>
                         @for (file of sortedAttachments$ | async; track file.id) {
                             <mat-list-item class="attachment-entry">
-                                <a target="_blank" [routerLink]="file.url">{{ file.title }}</a>
+                                <a target="_blank" [routerLink]="file.url">
+                                    <mat-icon class="attachment-icon">{{ file.getIcon() }}</mat-icon>
+                                    {{ file.getTitle() }}
+                                </a>
                             </mat-list-item>
                         }
                     </mat-list>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-content/motion-content.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-content/motion-content.component.scss
@@ -20,4 +20,8 @@
         max-width: 100%;
         word-break: break-word;
     }
+
+    .attachment-icon {
+        vertical-align: text-bottom;
+    }
 }


### PR DESCRIPTION
Resolve #5152 

Use getIcon() to get the icon and display the icon in the motion/topic/election detail view.
Add some style fey dust so it looks okay.