### PR TITLE
Show polls on projected agenda-item-list

### DIFF
--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
@@ -45,9 +45,7 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
     }
 
     public get showPollCollection(): boolean {
-        return (
-            this._currentProjection?.type !== `agenda_item_list` && this._currentProjection?.type !== `wifi_access_data`
-        );
+        return this._currentProjection?.type !== `wifi_access_data`;
     }
 
     public get projectorTitle(): string {


### PR DESCRIPTION
Resolve #5193 

There was a hook, which disallowed to see the polls on the agenda item list. I think, this was done with propose.
I have commented it out. 