### PR TITLE
Disable correct committees in edit mask

### DIFF
--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
@@ -53,7 +53,7 @@
                     <mat-label>{{ 'Can forward motions to committee' | translate }}</mat-label>
                     <os-repo-search-selector
                         formControlName="forward_to_committee_ids"
-                        [disableOptionWhenFn]="getDisableOptionWhenNotComAdmin()"
+                        [disableOptionWhenFn]="isNotCommitteeAdminFor()"
                         [multiple]="true"
                         [repo]="committeeRepo"
                         [showChips]="false"

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
@@ -53,6 +53,7 @@
                     <mat-label>{{ 'Can forward motions to committee' | translate }}</mat-label>
                     <os-repo-search-selector
                         formControlName="forward_to_committee_ids"
+                        [disableOptionWhenFn]="getDisableOptionWhenNotComAdmin()"
                         [multiple]="true"
                         [repo]="committeeRepo"
                         [showChips]="false"

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.html
@@ -53,7 +53,7 @@
                     <mat-label>{{ 'Can forward motions to committee' | translate }}</mat-label>
                     <os-repo-search-selector
                         formControlName="forward_to_committee_ids"
-                        [disableOptionWhenFn]="isNotCommitteeAdminFor()"
+                        [disableOptionWhenFn]="isNotCommitteeAdminFor"
                         [multiple]="true"
                         [repo]="committeeRepo"
                         [showChips]="false"
@@ -65,7 +65,7 @@
                     <mat-label>{{ 'Can receive motions from committee' | translate }}</mat-label>
                     <os-repo-search-selector
                         formControlName="receive_forwardings_from_committee_ids"
-                        [disableOptionWhenFn]="getDisableOptionWhenFn()"
+                        [disableOptionWhenFn]="getDisableOptionWhenFn"
                         [multiple]="true"
                         [repo]="committeeRepo"
                         [showChips]="false"

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
@@ -88,13 +88,14 @@ export class CommitteeDetailEditComponent extends BaseComponent implements OnIni
      *
      * @returns A function that will return a boolean
      */
-    public getDisableOptionWhenFn(): (value: Selectable) => boolean {
-        return value => (value.id === this.committeeId || this.isNotCommitteeAdminFor()(value));
-    }
+    public getDisableOptionWhenFn: (value: Selectable) => boolean = value => (
+        value.id === this.committeeId || this.isNotCommitteeAdminFor(value)
+    );
 
-    public isNotCommitteeAdminFor(): (value: Selectable) => boolean {
-        return value => !(this.isOrgaManager || this.operator.committeeCanManageNoOrgaCheck(value.id));
-    }
+
+    public isNotCommitteeAdminFor: (value: Selectable) => boolean = value => !(
+       this.isOrgaManager || this.operator.committeeCanManageNoOrgaCheck(value.id)
+    );
 
     public getDisableOptionForCommitteeParentFn(): (value: Selectable) => boolean {
         return value => {

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
@@ -89,7 +89,11 @@ export class CommitteeDetailEditComponent extends BaseComponent implements OnIni
      * @returns A function that will return a boolean
      */
     public getDisableOptionWhenFn(): (value: Selectable) => boolean {
-        return value => value.id === this.committeeId;
+        return value => value.id === this.committeeId || !(this.operator.isSuperAdmin || this.operator.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
+    }
+
+    public getDisableOptionWhenNotComAdmin(): (value: Selectable) => boolean {
+        return value => !(this.operator.isSuperAdmin || this.operator.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
     }
 
     public getDisableOptionForCommitteeParentFn(): (value: Selectable) => boolean {

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
@@ -89,11 +89,11 @@ export class CommitteeDetailEditComponent extends BaseComponent implements OnIni
      * @returns A function that will return a boolean
      */
     public getDisableOptionWhenFn(): (value: Selectable) => boolean {
-        return value => value.id === this.committeeId || !(this.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
+        return value => (value.id === this.committeeId || this.isNotCommitteeAdminFor()(value));
     }
 
-    public getDisableOptionWhenNotComAdmin(): (value: Selectable) => boolean {
-        return value => !(this.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
+    public isNotCommitteeAdminFor(): (value: Selectable) => boolean {
+        return value => !(this.isOrgaManager || this.operator.committeeCanManageNoOrgaCheck(value.id));
     }
 
     public getDisableOptionForCommitteeParentFn(): (value: Selectable) => boolean {

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
@@ -89,11 +89,11 @@ export class CommitteeDetailEditComponent extends BaseComponent implements OnIni
      * @returns A function that will return a boolean
      */
     public getDisableOptionWhenFn(): (value: Selectable) => boolean {
-        return value => value.id === this.committeeId || !(this.operator.isSuperAdmin || this.operator.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
+        return value => value.id === this.committeeId || !(this.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
     }
 
     public getDisableOptionWhenNotComAdmin(): (value: Selectable) => boolean {
-        return value => !(this.operator.isSuperAdmin || this.operator.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
+        return value => !(this.isOrgaManager || this.committeeRepo.getViewModel(value.id).manager_ids?.includes(this.operator.user.id));
     }
 
     public getDisableOptionForCommitteeParentFn(): (value: Selectable) => boolean {

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-edit/components/committee-detail-edit/committee-detail-edit.component.ts
@@ -92,9 +92,8 @@ export class CommitteeDetailEditComponent extends BaseComponent implements OnIni
         value.id === this.committeeId || this.isNotCommitteeAdminFor(value)
     );
 
-
     public isNotCommitteeAdminFor: (value: Selectable) => boolean = value => !(
-       this.isOrgaManager || this.operator.committeeCanManageNoOrgaCheck(value.id)
+        this.isOrgaManager || this.operator.committeeCanManageNoOrgaCheck(value.id)
     );
 
     public getDisableOptionForCommitteeParentFn(): (value: Selectable) => boolean {

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
@@ -81,16 +81,12 @@
                     @if (committee.forward_to_committees.length > 1) {
                         <button mat-button (click)="toggleForwardingList()">
                             @if (!forwardingExpanded) {
-                                {{ 'More' | translate }}
-                            }
-                            @if (!forwardingExpanded) {
-                                <mat-icon>expand_more</mat-icon>
+                                <mat-icon class="icon-text">expand_more</mat-icon>
+                                <span>{{ 'More' | translate }}</span>
                             }
                             @if (forwardingExpanded) {
+                                <mat-icon class="icon-text">expand_less</mat-icon>
                                 {{ 'Less' | translate }}
-                            }
-                            @if (forwardingExpanded) {
-                                <mat-icon>expand_less</mat-icon>
                             }
                         </button>
                     }
@@ -118,17 +114,15 @@
                     </ul>
                     @if (committee.receive_forwardings_from_committees.length > 1) {
                         <button mat-button (click)="toggleReceiveList()">
+                            @if (!receiveExpanded) {}
+                            @if (receiveExpanded) {}
                             @if (!receiveExpanded) {
-                                {{ 'More' | translate }}
+                                <mat-icon class="icon-text">expand_more</mat-icon>
+                                <span>{{ 'More' | translate }}</span>
                             }
                             @if (receiveExpanded) {
-                                {{ 'Less' | translate }}
-                            }
-                            @if (!receiveExpanded) {
-                                <mat-icon>expand_more</mat-icon>
-                            }
-                            @if (receiveExpanded) {
-                                <mat-icon>expand_less</mat-icon>
+                                <mat-icon class="icon-text">expand_less</mat-icon>
+                                <span>{{ 'Less' | translate }}</span>
                             }
                         </button>
                     }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
@@ -86,7 +86,7 @@
                             }
                             @if (forwardingExpanded) {
                                 <mat-icon class="icon-text">expand_less</mat-icon>
-                                {{ 'Less' | translate }}
+                                <span>{{ 'Less' | translate }}</span>
                             }
                         </button>
                     }
@@ -114,8 +114,6 @@
                     </ul>
                     @if (committee.receive_forwardings_from_committees.length > 1) {
                         <button mat-button (click)="toggleReceiveList()">
-                            @if (!receiveExpanded) {}
-                            @if (receiveExpanded) {}
                             @if (!receiveExpanded) {
                                 <mat-icon class="icon-text">expand_more</mat-icon>
                                 <span>{{ 'More' | translate }}</span>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.scss
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.scss
@@ -83,6 +83,5 @@ $navbar-size: 40px;
 }
 
 .icon-text {
-    display: inline-block;
     vertical-align: middle;
 }

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.scss
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.scss
@@ -81,3 +81,8 @@ $navbar-size: 40px;
     margin: auto 0px;
     overflow: hidden;
 }
+
+.icon-text {
+    display: inline-block;
+    vertical-align: middle;
+}

--- a/client/src/app/site/services/operator.service.ts
+++ b/client/src/app/site/services/operator.service.ts
@@ -83,6 +83,10 @@ export class OperatorService {
         return this.isSuperAdmin || this.isOrgaManager || this.isCommitteeManager;
     }
 
+    public committeeCanManageNoOrgaCheck(committeeId: number): boolean {
+        return this._CML[committeeId] === CML.can_manage;
+    }
+
     public get isAccountAdmin(): boolean {
         return this.hasOrganizationPermissions(OML.can_manage_users);
     }


### PR DESCRIPTION
closes #5075 

This PR fixes the not disabled committees in the list (while edit) 

The issue with teh missing committees in the list will be continued in it's own issue

This Issue is still testable if you have a committee admin (one committee) and this committee admin is just anormal user in anoter committee. They will be able to this committee in the list (that's also a bug hence the bug label)