### PR TITLE
Show polls without finished or published in agenda list projection

### DIFF
--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -155,7 +155,7 @@
             ) {
                 <os-poll-collection
                     [currentProjection]="projectedViewModel"
-                    [disableFinished]="disabledContentElements['poll-finished'] === true"
+                    [disableFinished]="disabledContentElements['poll-finished'] === true || isAgendaListProjection"
                     [disableRunning]="disabledContentElements['poll-running'] === true"
                     [displayInAutopilot]="true"
                 ></os-poll-collection>

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.ts
@@ -46,7 +46,7 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
 
     public get showPollCollection(): boolean {
         return (
-            this._currentProjection?.type !== `agenda_item_list` && this._currentProjection?.type !== `wifi_access_data`
+            this._currentProjection?.type !== `wifi_access_data`
         );
     }
 
@@ -104,6 +104,10 @@ export class AutopilotComponent extends BaseMeetingComponent implements OnInit {
 
     public get numDisabledElements(): number {
         return Object.values(this.disabledContentElements).filter(v => v).length;
+    }
+
+    public get isAgendaListProjection(): boolean {
+        return this._currentProjection?.type === `agenda_item_list`;
     }
 
     public structureLevelCountdownEnabled = false;

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/poll-collection/poll-collection.component.ts
@@ -142,7 +142,7 @@ export class PollCollectionComponent<C extends PollContentObject> extends BaseCo
      * Helper function to detect new latest published polls and set them.
      */
     private updateLastPublished(): void {
-        const lastPublished = this.getLastfinshedPoll(this.currentProjection!);
+        const lastPublished = this.getLastFinishedOrPublishedPoll(this.currentProjection!);
         if (lastPublished !== this.lastPublishedPoll) {
             if (
                 (this.currentProjection as BaseViewModel)?.collection === `meeting` &&
@@ -173,15 +173,11 @@ export class PollCollectionComponent<C extends PollContentObject> extends BaseCo
      *
      * @param viewModel
      */
-    private getLastfinshedPoll(viewModel: Partial<HasPolls<C>>): ViewPoll | null {
+    private getLastFinishedOrPublishedPoll(viewModel: Partial<HasPolls<C>>): ViewPoll | null {
         if (isHavingViewPolls(viewModel)) {
             let currPolls: ViewPoll[] = viewModel.polls;
-            /**
-             * Although it should, since the union type could use `.filter
-             * without any problem, without an any cast it will not work
-             */
-            currPolls = (currPolls as any[]).filter((p: ViewPoll) => p.stateHasVotes).reverse();
-            return currPolls[0];
+            currPolls = currPolls.filter((p: ViewPoll) => p.stateHasVotes).reverse();
+            return currPolls.length ? currPolls[0] : null;
         }
         return null;
     }


### PR DESCRIPTION
Resolve #5193 

This pr shows the polls in a projected agenda list.
I tried to cleanup the code a bit and disabled to display of the last position (finished or published) poll for
agenda list. See the issue for my comments.

The os-poll-collection component needs some more cleanup (naming, moving of methods,...).