### PR TITLE
Change the padding of structure levels in Live-voting

### DIFF
--- a/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/poll-slide/components/poll-slide.component.scss
+++ b/client/src/app/site/pages/meetings/modules/projector/modules/slides/components/poll-slide/components/poll-slide.component.scss
@@ -141,7 +141,8 @@
             align-items: end;
             border-bottom: 0 !important;
             h3 {
-                padding-bottom: 3px;
+                padding-top: 1.5px;
+                padding-bottom: 1.5px;
                 margin-top: 0;
                 margin-bottom: 0 !important;
                 line-height: 1;


### PR DESCRIPTION
Resolve #5362 

This is the result of experimenting with the structure level header. In my test it doesn't cut ÄÜÖ or jgy.
A test with some more delegates and structure levels is needed. 

If the 1.5/1.5 split doesn't work, I would recommend 1/2 split.
