### PR TITLE
Change default config of the motion export

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-export/components/motion-export/motion-export.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-export/components/motion-export/motion-export.component.ts
@@ -327,6 +327,16 @@ export class MotionExportComponent extends BaseComponent implements AfterViewIni
         this.storeService.get<SavedSelections>(`motion-export-selection`).then(savedDefaults => {
             if (savedDefaults?.tab_index !== undefined) {
                 this.savedSelections = savedDefaults;
+            } else {
+                const defaultLineNumbering = this.meetingSettingsService.instant(`motions_default_line_numbering`);
+                const defaultTextVersion = this.meetingSettingsService.instant(`motions_recommendation_text_mode`);
+                if ([this.lnMode.None, this.lnMode.Outside].includes(defaultLineNumbering)) {
+                    (this.savedSelections.tab_selections[0] as any).lnMode = defaultLineNumbering;
+                }
+                (this.savedSelections.tab_selections[0] as any).crMode = defaultTextVersion;
+                if ([this.crMode.Original, this.crMode.Final].includes(defaultTextVersion)) {
+                    (this.savedSelections.tab_selections[1] as any).crMode = defaultTextVersion;
+                }
             }
             this.tabGroup.selectedIndex = this.savedSelections.tab_index;
             this.dialogForm.patchValue(this.savedSelections.tab_selections[this.savedSelections.tab_index]);


### PR DESCRIPTION
Resolve #5294 

When the defaults in the motion export are used (first time), also get the meeting settings for lnMode and crMode and use these for the defaults if possible.