### PR TITLE
Fix meeting setting text: ignore help text entries

### DIFF
--- a/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definition.service.spec.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definition.service.spec.ts
@@ -191,14 +191,14 @@ describe(`MeetingSettingsDefinitionService`, () => {
         for (let i = 1; i < 4; i++) {
             if (Array.isArray(values[i - 1][properties[i - 1]])) {
                 indices[i] = indices[i] % values[i - 1][properties[i - 1]].length;
+                values.push(values[i - 1][properties[i - 1]][indices[i]]);
+            } else {
+                values.push(values[i - 1][properties[i - 1]]);
             }
-            values.push(
-                Array.isArray(values[i - 1][properties[i - 1]])
-                    ? values[i - 1][properties[i - 1]][indices[i]]
-                    : values[i - 1][properties[i - 1]]
-            );
         }
-        expect(service.settingsMap[values[3]]).toBe(values[2]);
+        if (!values[2]?.text) {
+            expect(service.settingsMap[values[3]]).toBe(values[2]);
+        }
     });
 
     it(`test normal get methods`, () => {


### PR DESCRIPTION
Resolve #5444 

Still use the random stuff, but ignore help text entries while testing. 