### PR TITLE
Colors changed

### DIFF
--- a/client/src/app/site/modules/global-headbar/components/global-headbar/global-headbar.component.scss
+++ b/client/src/app/site/modules/global-headbar/components/global-headbar/global-headbar.component.scss
@@ -11,6 +11,11 @@
     display: flex;
     flex-direction: row;
     padding-left: 26px;
+    .mat-icon,
+    os-account-button,
+    .display-name {
+        color: var(--theme-primary-contrast-500);
+    }
 }
 
 .background-headbar {


### PR DESCRIPTION
Resolves #5521


I found another issue while fixing this one:

As the button "save" shares the same colour as primary, if the theme is set to light and the primary color is also white, the button becomes invisible. I propose to change the color to "accent"
<img width="805" height="535" alt="Screenshot_20251205_115332" src="https://github.com/user-attachments/assets/1ee6ff47-0624-4fa5-aa0d-41c0325f3505" />

Change with accent (not implemented).
<img width="805" height="535" alt="Screenshot_20251205_115701" src="https://github.com/user-attachments/assets/bdd27057-48f8-4fe1-9cbf-02bd8ded0051" />

