### PR TITLE
Make the backend action call use the separatly route

### DIFF
--- a/client/src/app/gateways/repositories/polls/poll-repository.service/poll-repository.service.ts
+++ b/client/src/app/gateways/repositories/polls/poll-repository.service/poll-repository.service.ts
@@ -296,11 +296,14 @@ export class PollRepositoryService extends BaseMeetingRelatedRepository<ViewPoll
     public async anonymize(poll: Identifiable, updateState?: PollState): Promise<void> {
         const payload: Identifiable = { id: poll.id };
         if (updateState === PollState.Published) {
-            return this.sendActionsToBackend([
-                { action: PollAction.STOP, data: [payload] },
-                { action: PollAction.ANONYMIZE, data: [payload] },
-                { action: PollAction.PUBLISH, data: [payload] }
-            ]);
+            return this.sendActionsToBackend(
+                [
+                    { action: PollAction.STOP, data: [payload] },
+                    { action: PollAction.ANONYMIZE, data: [payload] },
+                    { action: PollAction.PUBLISH, data: [payload] }
+                ],
+                true
+            );
         }
         return this.sendActionToBackend(PollAction.ANONYMIZE, payload);
     }


### PR DESCRIPTION
The workflow for poll using the combined action of "stop, anonymize, publish" creates corrupt relations. This PR is to call every action sent to the backend as separate "transaction" to the datastore.

The error was triggered by the merge of relations in the relation handling in the backend.
Reproduction:
* Add a user to two meetings
* Create a motion poll (nominal, with live-voting) in one meeting
* Vote with the user
* Use "Stop, anonymize, publish" to finish the vote.
* Delete the meeting, where voted
* An ("Error talking to autoupdate-service...") error should show if the user tries to login.