### PR TITLE
Fix editing of motion submitters with deleted users

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.ts
@@ -183,7 +183,7 @@ export class MotionManageMotionMeetingUsersComponent<V extends BaseHasMeetingUse
                                           return model.user_id === val.id;
                                       }
                                       // else is (val instanceof ViewMotionSubmitter/ViewMotionEditor/ViewMotionWorkingGroupSpeaker)
-                                      return model.user_id === val.id;
+                                      return model.id === val.id;
                                   })
                               ),
                               filter(model => !!model)


### PR DESCRIPTION
Resolve #5588 

I found a problem with the  'MotionManageMotionMeetingUsersComponent'. Val is in this situation a internmedia model and it is compared to intermedia objects, so the `id` should be used. 
If this model is not found the result will be empty and firstValueFrom lets the promise wait, this leads to the broken
behavior.
