### PR TITLE
motion forward: filter target meetings with end_time

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/services/motion-forward-dialog.service.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/components/motion-forward-dialog/services/motion-forward-dialog.service.ts
@@ -186,7 +186,7 @@ export class MotionForwardDialogService extends BaseDialogService<
 
     private endAndActiveMeetingFilter(meetingData: GetForwardingMeetingsPresenterMeeting): boolean {
         return (
-            Number(meetingData.id) !== this.activeMeeting.meetingId &&
+            +meetingData.id !== this.activeMeeting.meetingId &&
             meetingData.end_time &&
             new Date() <= endOfDay(fromUnixTime(meetingData.end_time))
         );


### PR DESCRIPTION
Resolve #5148

Add a filter method to the target meetings.
Exclude meetings with current time  > end_of_day(end_time ).