### PR TITLE
Make present status available for screenreader

### DIFF
--- a/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.html
+++ b/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.html
@@ -1,4 +1,9 @@
-<button class="accountButton flex-center" data-cy="accountButton" [matMenuTriggerFor]="userMenu">
+<button
+    aria-label="{{ getAriaLabel() }}"
+    class="accountButton flex-center"
+    data-cy="accountButton"
+    [matMenuTriggerFor]="userMenu"
+>
     @if (isPresent) {
         <div class="fake-fab-button flex-center">
             <mat-icon class="icon-16">done</mat-icon>

--- a/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.scss
+++ b/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.scss
@@ -51,6 +51,12 @@ a {
     cursor: pointer;
 }
 
+.accountButton {
+    background: var(--theme-headbar);
+    color: var(--theme-headbar-contrast);
+    border: none;
+}
+
 .width-16 {
     margin: 4px;
     width: 20px;

--- a/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.ts
+++ b/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.ts
@@ -204,4 +204,22 @@ export class AccountButtonComponent extends BaseUiComponent implements OnInit {
         this.isLoggedIn = !this.operator.isAnonymous;
         this.username = this.operator.shortName;
     }
+
+    public getAriaLabel(): string {
+        let stringForUserPresent: string;
+        if (!this.hasActiveMeeting) {
+            stringForUserPresent = this.translate.instant(`Account of {} is not in Meeting`);
+        } else if (this.user.isPresentInMeeting()) {
+            stringForUserPresent = this.translate.instant(
+                `Account of {} is present. If status just changed focus this element again to get accurate present status.`
+            );
+        } else if (this.user.isInActiveMeeting) {
+            stringForUserPresent = this.translate.instant(
+                `Account of {} is not present. If status just changed focus this element again to get accurate present status.`
+            );
+        } else {
+            stringForUserPresent = this.translate.instant(`Account of {} is not in this Meeting`);
+        }
+        return stringForUserPresent.replace(`{}`, this.user.short_name);
+    }
 }


### PR DESCRIPTION
resolves #5571 
That the button aira-label is not updated seems to be an error of the component. 
The string is correctly updated and (as far as I see) immediately updated.

I could change aria-label to title, then the string is called twice, if just changed first wrong and then correct. 
That the title is readout loud twice is also an error of the component, but known. 

I currently just changed the string to inform the user that the info could be wrong, test/read code for more details.
If the changed/informative string is okay as is then I would prefer this solution over working around the wrong working component.

