### PR TITLE
Fonts in projector and motion detail view now match

### DIFF
--- a/client/src/assets/styles/projector.scss
+++ b/client/src/assets/styles/projector.scss
@@ -1,8 +1,9 @@
 @use 'font-variables';
+@use 'src/assets/styles/themes/typography.scss';
 
 #projector {
     * {
-        font-family: customProjectorFont;
+        font-family: typography.$font-family;
     }
     .material-icons {
         font-family: 'Material Icons';


### PR DESCRIPTION
Resolves [#54](https://github.com/OpenSlides/openslides-projector-service/issues/54)