### PR TITLE
Change identifier style in motion export toc

### DIFF
--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -481,14 +481,14 @@ export class PdfDocumentService {
      * @returns A line for the toc
      */
     public createTocLine(
-        { identifier, title, pageReference, style = StyleType.DEFAULT, fillColor = `` }: TocLineDefinition,
+        { identifier, title, pageReference, fillColor = `` }: TocLineDefinition,
         ...subTitle: Content[]
     ): Content[] {
         return [
             {
                 text: identifier,
-                fillColor,
-                style
+                style: `tocEntry`,
+                fillColor
             },
             {
                 text: [title, ...subTitle],


### PR DESCRIPTION
Resolves #5916 

It seems to be a small issue, the identifier style in the toc was different, changed it. 