### PR TITLE
Change location of reco buttons in action-row

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-detail-diff/motion-detail-diff.component.scss
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-detail-diff/motion-detail-diff.component.scss
@@ -50,6 +50,10 @@
             opacity: 0.5;
             overflow: hidden;
 
+            button {
+                margin-top: -12px;
+            }
+
             .btn-delete {
                 margin-left: 5px;
                 color: red;


### PR DESCRIPTION
Resolve #5911 

Small fix, use margin-top to move the 48px sized buttons in the line.