### PR TITLE
Downgrade nginx back to stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN [ -n "$VERSION" ] && echo "$VERSION ($(date +%Y-%m-%d))" >src/assets/version
 RUN npm run build
 
 # Prod wants nginx as base image for some reason
-FROM nginx:1.29.5 AS prod
+FROM nginx:1.28.2 AS prod
 
 ## Setup
 ARG CONTEXT


### PR DESCRIPTION
1.29.x is a mainline version. We want to use stable instead. 