### PR TITLE
Remove color while pasting text

### DIFF
--- a/client/src/app/ui/modules/editor/components/editor/extensions/clear-textcolor.ts
+++ b/client/src/app/ui/modules/editor/components/editor/extensions/clear-textcolor.ts
@@ -23,7 +23,9 @@ const ClearTextcolorPastePlugin = new Plugin({
 
                 const isTextBlack = !el.style.color || tinycolor(el.style.color).toHex() === `000000`;
                 const isBgWhite = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex() === `ffffff`;
-                if (isTextBlack && isBgWhite) {
+                const IsTextWhite = !el.style.color || tinycolor(el.style.color).toHex() === `ffffff`;
+                const IsBgDark = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex() === `424242`;
+                if ((isTextBlack && isBgWhite) || (IsTextWhite && IsBgDark)) {
                     el.style.color = ``;
                     el.style.backgroundColor = ``;
                 }

--- a/client/src/app/ui/modules/editor/components/editor/extensions/clear-textcolor.ts
+++ b/client/src/app/ui/modules/editor/components/editor/extensions/clear-textcolor.ts
@@ -21,11 +21,13 @@ const ClearTextcolorPastePlugin = new Plugin({
                     continue;
                 }
 
-                const isTextBlack = !el.style.color || tinycolor(el.style.color).toHex() === `000000`;
-                const isBgWhite = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex() === `ffffff`;
-                const isTextWhite = !el.style.color || tinycolor(el.style.color).toHex() === `ffffff`;
-                const isBgDark = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex() === `424242`;
-                if ((isTextBlack && isBgWhite) || (isTextWhite && isBgDark)) {
+                const textColor = !el.style.color || tinycolor(el.style.color).toHex();
+                const bgColor = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex();
+
+                if (
+                    (textColor === `000000` && bgColor === `ffffff`) ||
+                    (textColor === `ffffff` && bgColor === `424242`)
+                ) {
                     el.style.color = ``;
                     el.style.backgroundColor = ``;
                 }

--- a/client/src/app/ui/modules/editor/components/editor/extensions/clear-textcolor.ts
+++ b/client/src/app/ui/modules/editor/components/editor/extensions/clear-textcolor.ts
@@ -23,9 +23,9 @@ const ClearTextcolorPastePlugin = new Plugin({
 
                 const isTextBlack = !el.style.color || tinycolor(el.style.color).toHex() === `000000`;
                 const isBgWhite = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex() === `ffffff`;
-                const IsTextWhite = !el.style.color || tinycolor(el.style.color).toHex() === `ffffff`;
-                const IsBgDark = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex() === `424242`;
-                if ((isTextBlack && isBgWhite) || (IsTextWhite && IsBgDark)) {
+                const isTextWhite = !el.style.color || tinycolor(el.style.color).toHex() === `ffffff`;
+                const isBgDark = !el.style.backgroundColor || tinycolor(el.style.backgroundColor).toHex() === `424242`;
+                if ((isTextBlack && isBgWhite) || (isTextWhite && isBgDark)) {
                     el.style.color = ``;
                     el.style.backgroundColor = ``;
                 }


### PR DESCRIPTION
Resolves: #5961
I'm not really happy with hard coding a background color,
so I think it might be best if all formatting in general (or just color information) were removed from pasted text,
since it mostly causes annoyances
(even tough that could also remove wanted formatting).