### PR TITLE
Cleanup: Use inject() for dep inj and getTimezoneXY methods

### DIFF
--- a/client/src/app/site/pages/organization/pages/settings/modules/settings-detail/components/organization-settings/organization-settings.component.ts
+++ b/client/src/app/site/pages/organization/pages/settings/modules/settings-detail/components/organization-settings/organization-settings.component.ts
@@ -161,20 +161,9 @@ export class OrganizationSettingsComponent extends BaseComponent {
         return [item.getTitle()];
     }
 
-    private mapTZIdToTZ(TZId: number): string {
-        return this.time_zones
-            .getValue()
-            .find(item => item.id === TZId)
-            ?.getTitle();
-    }
-
-    private getTZIdbyTZ(TZname: string): number {
-        return this.time_zones.getValue().find(item => item.getTitle() === TZname)?.id;
-    }
-
     public onSubmit(): void {
         const { time_zone, ...payload }: any = this.orgaSettingsForm!.value;
-        payload.time_zone = this.mapTZIdToTZ(time_zone);
+        payload.time_zone = this.timeZone.getTimezoneNameById(time_zone);
         if (this.operator.isSuperAdmin) {
             payload.saml_attr_mapping = payload.saml_attr_mapping
                 ? JSON.stringify(JSON.parse(payload.saml_attr_mapping as string))

--- a/client/src/app/site/services/time-zone.service.ts
+++ b/client/src/app/site/services/time-zone.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { TZDate } from '@date-fns/tz';
 import { Id } from 'src/app/domain/definitions/key-types';
 import { Selectable } from 'src/app/domain/interfaces';
@@ -30,11 +30,9 @@ class SearchSelectorHelper implements Selectable {
     providedIn: `root`
 })
 export class TimeZoneService {
-    public constructor(
-        private activeMeetingRepo: ActiveMeetingService,
-        private organizationRepo: OrganizationControllerService,
-        private presenter: GetValidTimezonesPresenterService
-    ) {}
+    private activeMeetingRepo = inject(ActiveMeetingService);
+    private organizationRepo = inject(OrganizationControllerService);
+    private presenter = inject(GetValidTimezonesPresenterService);
 
     private timezonesCache: Selectable[] | null = null;
 

--- a/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.ts
+++ b/client/src/app/ui/pipes/localized-date-range/localized-date-range.pipe.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Pipe, PipeTransform } from '@angular/core';
+import { ChangeDetectorRef, inject, Pipe, PipeTransform } from '@angular/core';
 import { tzName } from '@date-fns/tz';
 import { Locale } from 'date-fns';
 import { DateFnsConfigurationService, DateFnsInputDate, FormatPipe } from 'ngx-date-fns';
@@ -10,13 +10,10 @@ import { TimeZoneService } from 'src/app/site/services/time-zone.service';
     standalone: false
 })
 export class LocalizedDateRangePipe implements PipeTransform {
+    private inputDate = inject(DateFnsConfigurationService);
+    private timeZone = inject(TimeZoneService);
+    private cd = inject(ChangeDetectorRef);
     public formatter = new FormatPipe(this.inputDate, this.cd);
-
-    public constructor(
-        private timeZone: TimeZoneService,
-        private inputDate: DateFnsConfigurationService,
-        private cd: ChangeDetectorRef
-    ) {}
 
     public transform(value: any, dateFormat = `PPp`, timezone = ``): any {
         if (!value) {

--- a/client/src/app/ui/pipes/localized-date/localized-date.pipe.ts
+++ b/client/src/app/ui/pipes/localized-date/localized-date.pipe.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Pipe, PipeTransform } from '@angular/core';
+import { ChangeDetectorRef, inject, Pipe, PipeTransform } from '@angular/core';
 import { TZDate, tzName } from '@date-fns/tz';
 import { DateFnsConfigurationService, FormatPipe } from 'ngx-date-fns';
 import { TimeZoneService } from 'src/app/site/services/time-zone.service';
@@ -9,13 +9,10 @@ import { TimeZoneService } from 'src/app/site/services/time-zone.service';
     standalone: false
 })
 export class LocalizedDatePipe implements PipeTransform {
+    private inputDate = inject(DateFnsConfigurationService);
+    private timeZone = inject(TimeZoneService);
+    private cd = inject(ChangeDetectorRef);
     private formatter = new FormatPipe(this.inputDate, this.cd);
-
-    public constructor(
-        private inputDate: DateFnsConfigurationService,
-        private cd: ChangeDetectorRef,
-        private timeZone: TimeZoneService
-    ) {}
 
     public transform(value: any, dateFormat = `PPp`): any {
         if (!value && value !== 0) {


### PR DESCRIPTION
Resolve #6099 

Use inject() to inject the dependencies and small cleanup of methods.