### PR TITLE
Cleanup of the account dialog main component

### DIFF
--- a/client/src/app/site/modules/global-headbar/components/account-dialog-main/account-dialog-main.component.ts
+++ b/client/src/app/site/modules/global-headbar/components/account-dialog-main/account-dialog-main.component.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
-import { Id } from 'src/app/domain/definitions/key-types';
-import { SubscriptionConfig } from 'src/app/domain/interfaces/subscription-config';
-import { BaseMeetingModelRequestHandler } from 'src/app/site/pages/meetings/base/base-meeting-model-request-handler.component';
+import { BaseModelRequestHandlerComponent } from 'src/app/site/base/base-model-request-handler.component';
 import { getDashboardMeetingListSubscriptionConfig } from 'src/app/site/pages/organization/pages/dashboard/dashboard.subscription';
 
 @Component({
@@ -10,8 +8,8 @@ import { getDashboardMeetingListSubscriptionConfig } from 'src/app/site/pages/or
     styleUrls: [`./account-dialog-main.component.scss`],
     standalone: false
 })
-export class AccountDialogMainComponent extends BaseMeetingModelRequestHandler {
-    protected getSubscriptions(_id: Id): SubscriptionConfig<any>[] {
-        return [getDashboardMeetingListSubscriptionConfig()];
+export class AccountDialogMainComponent extends BaseModelRequestHandlerComponent {
+    protected override onShouldCreateModelRequests(): void {
+        this.subscribeTo(getDashboardMeetingListSubscriptionConfig(), { hideWhenDestroyed: true });
     }
 }


### PR DESCRIPTION
Resolve part of #6114

Use a different method to get the Subscription with hideWhenDestroyed also use a more general handler.

It doesn't include the standalone removal. This would lead to dependencies import /export problems with a broken mix of standalone and module components.