### PR TITLE
Hide gender and number for normal users in LoS.

### DIFF
--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-entry/list-of-speakers-entry.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-entry/list-of-speakers-entry.component.html
@@ -84,10 +84,10 @@
                     {{ speaker.getLOSStructureLevels(!structureLevelCountdownEnabled) }}
                 </span>
             }
-            @if (speaker.user_number) {
+            @if (canManage && speaker.user_number) {
                 <span>{{ 'No.' | translate }} {{ speaker.user_number }}</span>
             }
-            @if (speaker.gender) {
+            @if (canManage && speaker.gender) {
                 <span>{{ speaker.gender | translate }}</span>
             }
         </div>


### PR DESCRIPTION
It helps to make list of speakers cleaner for normal users. Gender and number is relevant for managers only.