### PR TITLE
Set timezone after initTimezones in meeting-edit

### DIFF
--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.ts
@@ -170,7 +170,18 @@ export class MeetingEditComponent extends BaseComponent implements OnInit {
     }
 
     private async initTimezones(): Promise<void> {
-        this.timeZone.getTZForSearchSelector().then(values => this.time_zones.next(values));
+        this.timeZone.getTZForSearchSelector().then(values => {
+            this.time_zones.next(values);
+            this.patchTimezoneInForm();
+        });
+    }
+
+    private patchTimezoneInForm(): void {
+        if (!this.meetingForm?.get('time_zone').value) {
+            this.meetingForm
+                .get('time_zone')
+                .setValue(this.timeZone.getTimezoneIdByName(this.timeZone.getOrganizationTimeZone()));
+        }
     }
 
     public getAdditionallySearchedValuesFn(item: Selectable): string[] {


### PR DESCRIPTION
Resolve #6204 

To set the initial timezone the timezone service needs to be fully initialized, because of the use of get the tz id by name.
(`getTimezoneIdByName`). So wait until the data is there and then set the value. 