### PR TITLE
Use isListEmpty for disable list-search-selectors

### DIFF
--- a/client/src/app/ui/base/base-form-field-control.ts
+++ b/client/src/app/ui/base/base-form-field-control.ts
@@ -104,7 +104,7 @@ export abstract class BaseFormFieldControlComponent<T>
 
     private _required = false;
 
-    private _disabled = false;
+    protected _disabled = false;
 
     protected subscriptions: Subscription[] = [];
 

--- a/client/src/app/ui/base/base-form-field-control.ts
+++ b/client/src/app/ui/base/base-form-field-control.ts
@@ -104,7 +104,7 @@ export abstract class BaseFormFieldControlComponent<T>
 
     private _required = false;
 
-    protected _disabled = false;
+    private _disabled = false;
 
     protected subscriptions: Subscription[] = [];
 

--- a/client/src/app/ui/modules/search-selector/components/list-search-selector/list-search-selector.component.ts
+++ b/client/src/app/ui/modules/search-selector/components/list-search-selector/list-search-selector.component.ts
@@ -50,7 +50,7 @@ export class ListSearchSelectorComponent extends BaseSearchSelectorComponent {
     }
 
     public override get disabled(): boolean {
-        return this.isListEmpty() || this._disabled;
+        return super.disabled || (this.isListEmpty() && !this.clickNotFound.observed);
     }
 
     @Input()

--- a/client/src/app/ui/modules/search-selector/components/list-search-selector/list-search-selector.component.ts
+++ b/client/src/app/ui/modules/search-selector/components/list-search-selector/list-search-selector.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, Optional, Self, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, Optional, Self, signal, ViewEncapsulation } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { MatFormFieldControl } from '@angular/material/form-field';
 import { auditTime, distinctUntilChanged, Observable, Subscription } from 'rxjs';
@@ -18,6 +18,8 @@ import { BaseSearchSelectorComponent } from '../base-search-selector/base-search
 export class ListSearchSelectorComponent extends BaseSearchSelectorComponent {
     private _inputListValuesSubscription: Subscription;
 
+    private isListEmpty = signal(true);
+
     /**
      * The inputlist subject. Subscribes to it and updates the selector, if the subject
      * changes its values.
@@ -35,10 +37,7 @@ export class ListSearchSelectorComponent extends BaseSearchSelectorComponent {
         } else {
             this._inputListValuesSubscription = value.pipe(auditTime(10), distinctUntilChanged()).subscribe(items => {
                 this.selectableItems = items;
-                if (this.contentForm) {
-                    this.disabled =
-                        (this.disabled || !items || (!!items && !items.length)) && !this.clickNotFound.observed;
-                }
+                this.isListEmpty.set(!items || (!!items && !items.length));
             });
             this.subscriptions.push(this._inputListValuesSubscription);
         }
@@ -48,5 +47,14 @@ export class ListSearchSelectorComponent extends BaseSearchSelectorComponent {
 
     public constructor(@Optional() @Self() ngControl: NgControl) {
         super(ngControl);
+    }
+
+    public override get disabled(): boolean {
+        return this.isListEmpty() || this._disabled;
+    }
+
+    @Input()
+    public override set disabled(value: boolean) {
+        super.disabled = value;
     }
 }


### PR DESCRIPTION
Resolve #6327 #6273 

As described in #6363  I have used an `isListEmpty` property and override the get (and set) of disabled.

Tested with:
- meeting-edit (duplicate from)
- participant-list-info (Str lvl)
- history (id field)
