### PR TITLE
Motion export: sanitize filename

### DIFF
--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -570,7 +570,7 @@ export class PdfDocumentService {
                 landscape: false,
                 imageUrls: imageUrls
             }),
-            filename: `${filetitle}.pdf`,
+            filename: `${this.sanitizeFilename(filetitle)}.pdf`,
             settings: this.settings,
             loadImages: (): Promise<PdfImageDescription> => this.loadImages(),
             progressService: null,
@@ -590,7 +590,7 @@ export class PdfDocumentService {
             progressService: this.progressService
         });
         if (file) {
-            saveAs(file, config.filename, { autoBom: true });
+            saveAs(file, this.sanitizeFilename(config.filename), { autoBom: true });
         }
     }
 
@@ -607,7 +607,7 @@ export class PdfDocumentService {
                 pageMargins: [50, 80, 50, 75],
                 landscape: true
             }),
-            filename: `${filetitle}.pdf`,
+            filename: `${this.sanitizeFilename(filetitle)}.pdf`,
             settings: this.settings,
             loadImages: (): Promise<PdfImageDescription> => this.loadImages(),
             progressService: this.progressService,
@@ -1077,5 +1077,9 @@ export class PdfDocumentService {
                 .filter((_, index) => downloads[index].type === `image/svg+xml`)
                 .mapToObject((url, index) => ({ [url]: atob(svgs[index].data) }))
         };
+    }
+
+    private sanitizeFilename(value: string): string {
+        return value.replace(/[^a-zA-Z0-9_-]/g, '_');
     }
 }

--- a/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
+++ b/client/src/app/gateways/export/pdf-document.service/pdf-document.service.ts
@@ -1080,6 +1080,6 @@ export class PdfDocumentService {
     }
 
     private sanitizeFilename(value: string): string {
-        return value.replace(/[^a-zA-Z0-9_-]/g, '_');
+        return value.replace(/[^a-zA-Z0-9_-üöäÜÖÄ§\s]/g, '_');
     }
 }


### PR DESCRIPTION
Resolve #6271 

Sanitize filenames to allow a working export. Dots and another special characters can lead to problems on different
systems. 