### PR TITLE
Added frontent for maximum available yes votes

### DIFF
--- a/client/src/app/domain/models/poll/poll-config-rating-approval.ts
+++ b/client/src/app/domain/models/poll/poll-config-rating-approval.ts
@@ -9,6 +9,7 @@ export class PollConfigRatingApproval extends BasePollConfigModel<PollConfigRati
 
     public max_options_amount!: number;
     public min_options_amount!: number;
+    public max_yes_amount!: number;
     public allow_abstain!: boolean;
     public onehundred_percent_base!: RatingApprovalOnehundredPercentBase;
 
@@ -29,6 +30,7 @@ export class PollConfigRatingApproval extends BasePollConfigModel<PollConfigRati
         `poll_id`,
         `max_options_amount`,
         `min_options_amount`,
+        `max_yes_amount`,
         `allow_abstain`,
         `onehundred_percent_base`
     ];

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-form-rating-approval/poll-form-rating-approval.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-form-rating-approval/poll-form-rating-approval.component.html
@@ -1,14 +1,13 @@
 <form [formGroup]="form">
     <div class="poll-preview-meta-info-form">
+        <mat-form-field>
+            <mat-label>{{ 'Election method' | translate }}</mat-label>
+            <mat-select formControlName="allow_abstain">
+                <mat-option [value]="false">{{ 'Yes/No' | translate }}</mat-option>
+                <mat-option [value]="true">{{ 'Yes/No/Abstain' | translate }}</mat-option>
+            </mat-select>
+        </mat-form-field>
         <div class="margin-bottom-15 info-grid">
-            <mat-form-field>
-                <mat-label>{{ 'Election method' | translate }}</mat-label>
-                <mat-select formControlName="allow_abstain">
-                    <mat-option [value]="false">{{ 'Yes/No' | translate }}</mat-option>
-                    <mat-option [value]="true">{{ 'Yes/No/Abstain' | translate }}</mat-option>
-                </mat-select>
-            </mat-form-field>
-
             <mat-form-field>
                 <mat-label>{{ 'Min amount of votes' | translate }}</mat-label>
                 <input formControlName="min_options_amount" matInput required type="number" />
@@ -17,6 +16,11 @@
             <mat-form-field>
                 <mat-label>{{ 'Max amount of votes' | translate }}</mat-label>
                 <input formControlName="max_options_amount" matInput required type="number" />
+            </mat-form-field>
+
+            <mat-form-field>
+                <mat-label>{{ 'Max amount of yes votes' | translate }}</mat-label>
+                <input formControlName="max_yes_amount" matInput required type="number" />
             </mat-form-field>
         </div>
 

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-form-rating-approval/poll-form-rating-approval.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-form-rating-approval/poll-form-rating-approval.component.ts
@@ -53,6 +53,7 @@ export class PollFormRatingApprovalComponent {
         this.form = this.fb.group({
             onehundred_percent_base: [`valid`],
             allow_abstain: [false],
+            max_yes_amount: [1, [Validators.required, Validators.min(1)]],
             max_options_amount: [1, [Validators.required, Validators.min(1)]],
             min_options_amount: [1, [Validators.required, Validators.min(0), this.minOptionsAmountValidator()]]
         });
@@ -78,12 +79,19 @@ export class PollFormRatingApprovalComponent {
     }
 
     private onOptionAmountUpdate(): void {
+        const option_amount = this.optionAmount();
         const maxCtrl = this.form.get('max_options_amount');
-        if (this.optionAmount()) {
-            maxCtrl?.setValidators([Validators.required, Validators.min(1), Validators.max(this.optionAmount())]);
+        const maxYesCtrl = this.form.get('max_yes_amount');
+        if (option_amount) {
+            maxCtrl?.setValidators([Validators.required, Validators.min(1), Validators.max(option_amount)]);
+            maxYesCtrl?.setValidators([Validators.required, Validators.min(1), Validators.max(option_amount)]);
+            maxCtrl?.setValue(option_amount, { emitEvent: false });
+            maxYesCtrl.setValue(option_amount, { emitEvent: false });
         } else {
             maxCtrl?.setValidators([Validators.required, Validators.min(1)]);
+            maxYesCtrl?.setValidators([Validators.required, Validators.min(1)]);
         }
         maxCtrl?.updateValueAndValidity({ emitEvent: false });
+        maxYesCtrl?.updateValueAndValidity({ emitEvent: false });
     }
 }

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-form-rating-approval/poll-form-rating-approval.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-form-rating-approval/poll-form-rating-approval.component.ts
@@ -79,14 +79,14 @@ export class PollFormRatingApprovalComponent {
     }
 
     private onOptionAmountUpdate(): void {
-        const option_amount = this.optionAmount();
+        const optionAmount = this.optionAmount();
         const maxCtrl = this.form.get('max_options_amount');
         const maxYesCtrl = this.form.get('max_yes_amount');
-        if (option_amount) {
-            maxCtrl?.setValidators([Validators.required, Validators.min(1), Validators.max(option_amount)]);
-            maxYesCtrl?.setValidators([Validators.required, Validators.min(1), Validators.max(option_amount)]);
-            maxCtrl?.setValue(option_amount, { emitEvent: false });
-            maxYesCtrl.setValue(option_amount, { emitEvent: false });
+        if (optionAmount) {
+            maxCtrl?.setValidators([Validators.required, Validators.min(1), Validators.max(optionAmount)]);
+            maxYesCtrl?.setValidators([Validators.required, Validators.min(1), Validators.max(optionAmount)]);
+            maxCtrl?.setValue(optionAmount, { emitEvent: false });
+            maxYesCtrl.setValue(optionAmount, { emitEvent: false });
         } else {
             maxCtrl?.setValidators([Validators.required, Validators.min(1)]);
             maxYesCtrl?.setValidators([Validators.required, Validators.min(1)]);

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-meta/poll-meta.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-meta/poll-meta.component.html
@@ -80,32 +80,30 @@
         </div>
     }
 
-    @if (
-        config().COLLECTION === `poll_config_selection`
-    ) {
-        @if(config().min_options_amount > 1 || config().max_options_amount > 1){
+    @if (config().COLLECTION === `poll_config_selection`) {
+        @if (config().min_options_amount > 1 || config().max_options_amount > 1) {
             @if (config().min_options_amount === config().max_options_amount) {
-            <div>
-                {{ 'Votes on different options' | translate }}:
-                <span>{{ config().min_options_amount }}</span>
-            </div>
-        } @else {
-            @if (config().min_options_amount > 1) {
                 <div>
-                    {{ 'Minimum amount of options selected' | translate }}:
+                    {{ 'Votes on different options' | translate }}:
                     <span>{{ config().min_options_amount }}</span>
                 </div>
-            }
+            } @else {
+                @if (config().min_options_amount > 1) {
+                    <div>
+                        {{ 'Minimum amount of options selected' | translate }}:
+                        <span>{{ config().min_options_amount }}</span>
+                    </div>
+                }
 
-            @if (config().max_options_amount > 1) {
-                <div>
-                    {{ 'Maximum amount options selected' | translate }}:
-                    <span>{{ config().max_options_amount }}</span>
-                </div>
+                @if (config().max_options_amount > 1) {
+                    <div>
+                        {{ 'Maximum amount options selected' | translate }}:
+                        <span>{{ config().max_options_amount }}</span>
+                    </div>
+                }
             }
         }
-        }
-    }@else {
+    } @else {
         @if (config().min_vote_sum > 1 || config().max_vote_sum > 1) {
             @if (config().min_vote_sum === config().max_vote_sum) {
                 <div>

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-meta/poll-meta.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-meta/poll-meta.component.html
@@ -80,34 +80,11 @@
         </div>
     }
 
-    @if (config().min_vote_sum > 1 || config().max_vote_sum > 1) {
-        @if (config().min_vote_sum === config().max_vote_sum) {
-            <div>
-                {{ 'Votes' | translate }}:
-                <span>{{ config().min_vote_sum }}</span>
-            </div>
-        } @else {
-            @if (config().min_vote_sum > 1) {
-                <div>
-                    {{ 'Minimum amount of votes' | translate }}:
-                    <span>{{ config().min_vote_sum }}</span>
-                </div>
-            }
-
-            @if (config().max_vote_sum > 1) {
-                <div>
-                    {{ 'Maximum amount of votes' | translate }}:
-                    <span>{{ config().max_vote_sum }}</span>
-                </div>
-            }
-        }
-    }
-
     @if (
-        config().COLLECTION !== `poll_config_selection` &&
-        (config().min_options_amount > 1 || config().max_options_amount > 1)
+        config().COLLECTION === `poll_config_selection`
     ) {
-        @if (config().min_options_amount === config().max_options_amount) {
+        @if(config().min_options_amount > 1 || config().max_options_amount > 1){
+            @if (config().min_options_amount === config().max_options_amount) {
             <div>
                 {{ 'Votes on different options' | translate }}:
                 <span>{{ config().min_options_amount }}</span>
@@ -126,6 +103,37 @@
                     <span>{{ config().max_options_amount }}</span>
                 </div>
             }
+        }
+        }
+    }@else {
+        @if (config().min_vote_sum > 1 || config().max_vote_sum > 1) {
+            @if (config().min_vote_sum === config().max_vote_sum) {
+                <div>
+                    {{ 'Votes' | translate }}:
+                    <span>{{ config().min_vote_sum }}</span>
+                </div>
+            } @else {
+                @if (config().min_vote_sum > 1) {
+                    <div>
+                        {{ 'Minimum amount of votes' | translate }}:
+                        <span>{{ config().min_vote_sum }}</span>
+                    </div>
+                }
+
+                @if (config().max_vote_sum > 1) {
+                    <div>
+                        {{ 'Maximum amount of votes' | translate }}:
+                        <span>{{ config().max_vote_sum }}</span>
+                    </div>
+                }
+            }
+        }
+
+        @if (config().max_yes_amount > 1 && config().max_yes_amount < config().max_vote_sum) {
+            <div>
+                {{ 'Maximum amount of yes votes' | translate }}:
+                <span>{{ config().max_yes_amount }}</span>
+            </div>
         }
     }
 

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-approval/poll-vote-approval.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-approval/poll-vote-approval.component.html
@@ -2,8 +2,8 @@
     @for (action of voteActions(); track action.vote) {
         <div class="vote-button-area" role="gridcell">
             <os-poll-vote-button
+                [disabled]="loading()"
                 [isSelected]="isOptionSelected(action.vote)"
-                [loading]="loading()"
                 [optionTitle]="action.label | translate"
                 [optionType]="action.vote"
                 (toggleOption)="submitVote(action.vote)"

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.html
@@ -4,7 +4,7 @@
     role="radio"
     [ariaLabel]="optionTitle()"
     [attr.aria-checked]="isSelected() ? 'true' : 'false'"
-    [disabled]="loading()"
+    [disabled]="loading() || disabled()"
     (click)="toggleOption.emit(!isSelected())"
 >
     <div class="vote-button-content" [class.button-content-opaque]="!isSelected()">

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.html
@@ -4,7 +4,7 @@
     role="radio"
     [ariaLabel]="optionTitle()"
     [attr.aria-checked]="isSelected() ? 'true' : 'false'"
-    [disabled]="loading() || disabled()"
+    [disabled]="disabled()"
     (click)="toggleOption.emit(!isSelected())"
 >
     <div class="vote-button-content" [class.button-content-opaque]="!isSelected()">

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.ts
@@ -21,6 +21,7 @@ export class PollVoteButtonComponent {
 
     public optionType = input<OptionType>(`yes`);
     public loading = input<boolean>(false);
+    public disabled = input<boolean>(false);
 
     public votedClass = computed<string>(() => {
         return this.isSelected() ? `voted-${this.optionType()}` : ``;

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-button/poll-vote-button.component.ts
@@ -20,7 +20,6 @@ export class PollVoteButtonComponent {
     public optionTitle = input.required<string>();
 
     public optionType = input<OptionType>(`yes`);
-    public loading = input<boolean>(false);
     public disabled = input<boolean>(false);
 
     public votedClass = computed<string>(() => {

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.html
@@ -29,7 +29,7 @@
                         {{ 'Votes' | translate }}
                     </div>
                 }
-                @if (config()?.max_yes_amount<config()?.max_vote_sum) {
+                @if (config()?.max_yes_amount < config()?.max_vote_sum) {
                     <div>
                         {{ 'Available yes votes' | translate }}:
                         <b>{{ config()?.max_yes_amount - yesVotesUsed() }}/{{ config()?.max_yes_amount }}</b>

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.html
@@ -29,6 +29,12 @@
                         {{ 'Votes' | translate }}
                     </div>
                 }
+                @if (config()?.max_yes_amount<config()?.max_vote_sum) {
+                    <div>
+                        {{ 'Available yes votes' | translate }}:
+                        <b>{{ config()?.max_yes_amount - yesVotesUsed() }}/{{ config()?.max_yes_amount }}</b>
+                    </div>
+                }
             </div>
         </div>
     </div>
@@ -62,6 +68,7 @@
             <div class="vote-button-area" role="gridcell">
                 <os-poll-vote-button
                     optionType="yes"
+                    [disabled]="isYesDisabled(option.id)"
                     [isSelected]="isSelected(option.id, 'yes')"
                     [loading]="loading()"
                     [optionTitle]="'Yes' | translate"

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.html
@@ -68,9 +68,8 @@
             <div class="vote-button-area" role="gridcell">
                 <os-poll-vote-button
                     optionType="yes"
-                    [disabled]="isYesDisabled(option.id)"
+                    [disabled]="loading() || isYesDisabled(option.id)"
                     [isSelected]="isSelected(option.id, 'yes')"
-                    [loading]="loading()"
                     [optionTitle]="'Yes' | translate"
                     (toggleOption)="toggleOption(option.id, 'yes')"
                 />
@@ -78,8 +77,8 @@
             <div class="vote-button-area" role="gridcell">
                 <os-poll-vote-button
                     optionType="no"
+                    [disabled]="loading()"
                     [isSelected]="isSelected(option.id, 'no')"
-                    [loading]="loading()"
                     [optionTitle]="'No' | translate"
                     (toggleOption)="toggleOption(option.id, 'no')"
                 />
@@ -88,8 +87,8 @@
                 <div class="vote-button-area" role="gridcell">
                     <os-poll-vote-button
                         optionType="abstain"
+                        [disabled]="loading()"
                         [isSelected]="isSelected(option.id, 'abstain')"
-                        [loading]="loading()"
                         [optionTitle]="'Abstain' | translate"
                         (toggleOption)="toggleOption(option.id, 'abstain')"
                     />
@@ -115,8 +114,8 @@
                 <div class="vote-button-area" role="gridcell">
                     <os-poll-vote-button
                         optionType="abstain"
+                        [disabled]="loading()"
                         [isSelected]="isSelected(0)"
-                        [loading]="loading()"
                         [optionTitle]="'General abstain' | translate"
                         (toggleOption)="toggleOption(0)"
                     />

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.ts
@@ -30,6 +30,23 @@ export class PollVoteRatingApprovalComponent extends PollVoteBaseComponent<ViewP
 
     public selectedOptions = signal<Map<number, string>>(new Map());
 
+    public yesVotesUsed = computed<number>(() => {
+        let count = 0;
+        for (const value of this.selectedOptions().values()) {
+            if (value === 'yes') count++;
+        }
+        return count;
+    });
+
+    public maxYesReached = computed<boolean>(() => {
+        const max = this.config()?.max_yes_amount;
+        return max != null && this.yesVotesUsed() >= max;
+    });
+
+    public isYesDisabled(optionId: number): boolean {
+        return this.maxYesReached() && !this.isSelected(optionId, 'yes');
+    }
+
     public availableVotes = computed<number>(() => {
         if (this.selectedOptions().has(0)) {
             return 0;
@@ -60,6 +77,9 @@ export class PollVoteRatingApprovalComponent extends PollVoteBaseComponent<ViewP
             selected.set(optionId, null);
         } else {
             selected.delete(0);
+            if (value === 'yes' && this.maxYesReached()) {
+                return;
+            }
             if ((this.config()?.max_options_amount ?? 1) === 1) {
                 selected.clear();
             } else {

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-approval/poll-vote-rating-approval.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@a
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { YES_KEY } from 'src/app/domain/models/poll';
 import { PromptService } from 'src/app/ui/modules/prompt-dialog';
 
 import { ViewPollConfigRatingApproval } from '../../../../pages/polls';
@@ -33,7 +34,7 @@ export class PollVoteRatingApprovalComponent extends PollVoteBaseComponent<ViewP
     public yesVotesUsed = computed<number>(() => {
         let count = 0;
         for (const value of this.selectedOptions().values()) {
-            if (value === 'yes') count++;
+            if (value === YES_KEY) count++;
         }
         return count;
     });
@@ -44,7 +45,7 @@ export class PollVoteRatingApprovalComponent extends PollVoteBaseComponent<ViewP
     });
 
     public isYesDisabled(optionId: number): boolean {
-        return this.maxYesReached() && !this.isSelected(optionId, 'yes');
+        return this.maxYesReached() && !this.isSelected(optionId, YES_KEY);
     }
 
     public availableVotes = computed<number>(() => {
@@ -77,7 +78,7 @@ export class PollVoteRatingApprovalComponent extends PollVoteBaseComponent<ViewP
             selected.set(optionId, null);
         } else {
             selected.delete(0);
-            if (value === 'yes' && this.maxYesReached()) {
+            if (value === YES_KEY && this.maxYesReached()) {
                 return;
             }
             if ((this.config()?.max_options_amount ?? 1) === 1) {

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-score/poll-vote-rating-score.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-rating-score/poll-vote-rating-score.component.html
@@ -107,8 +107,8 @@
             <div class="vote-button-area" role="gridcell">
                 <os-poll-vote-button
                     optionType="abstain"
+                    [disabled]="loading()"
                     [isSelected]="+getOptionVote(0) > 0"
-                    [loading]="loading()"
                     [optionTitle]="'General abstain' | translate"
                     (toggleOption)="setOptionVote(0, '1')"
                 />

--- a/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-selection/poll-vote-selection.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/poll-vote-selection/poll-vote-selection.component.html
@@ -67,8 +67,8 @@
             </div>
             <div class="vote-button-area" role="gridcell">
                 <os-poll-vote-button
+                    [disabled]="loading()"
                     [isSelected]="isSelected(option.id)"
-                    [loading]="loading()"
                     [optionTitle]="option.text || option.meeting_user?.user?.getName()"
                     [optionType]="config().strike_out ? 'no' : 'yes'"
                     (toggleOption)="toggleOption(option.id)"
@@ -95,8 +95,8 @@
                 </div>
                 <div class="vote-button-area" role="gridcell">
                     <os-poll-vote-button
+                        [disabled]="loading()"
                         [isSelected]="isSelected(-1)"
-                        [loading]="loading()"
                         [optionTitle]="optionName"
                         [optionType]="config().strike_out ? 'yes' : 'no'"
                         (toggleOption)="toggleOption(-1)"
@@ -113,8 +113,8 @@
                 <div class="vote-button-area" role="gridcell">
                     <os-poll-vote-button
                         optionType="abstain"
+                        [disabled]="loading()"
                         [isSelected]="isSelected(0)"
-                        [loading]="loading()"
                         [optionTitle]="'General abstain' | translate"
                         (toggleOption)="toggleOption(0)"
                     />

--- a/client/src/app/site/pages/meetings/modules/poll/services/voting.service/voting.service.ts
+++ b/client/src/app/site/pages/meetings/modules/poll/services/voting.service/voting.service.ts
@@ -75,6 +75,7 @@ export class VotingService {
      * checks whether the operator can vote on the given poll
      */
     public votingProhibited(poll: ViewPoll, user?: ViewUser): Observable<VotingProhibition | null> {
+        // TODO: [potatojuicemachine::10.07.2026] user being undefined will throw here. Not sure what the correct fix would be.
         return combineLatest([
             this.userRepo.getViewModelObservable(user.id),
             this.pollRepo.getViewModelObservable(poll.id),


### PR DESCRIPTION
This PR adds the frontend for the maximum available yes votes that has been implemented recently in the backend. It is a response (and hopefully closes) to this issue: https://github.com/OpenSlides/openslides-client/issues/6351 .

Creating a new approval poll will looks like this:
<img width="1050" height="757" alt="image" src="https://github.com/user-attachments/assets/9f8a21bf-2be9-4fc4-a083-43499c6281d8" />

I added the information to the meta component so it looks like this:
<img width="970" height="318" alt="image" src="https://github.com/user-attachments/assets/e522347d-90a1-41a7-8579-85a71f84a3dc" />

I added the information to the top of the vote form:
<img width="963" height="555" alt="image" src="https://github.com/user-attachments/assets/a6f49ac3-3401-476c-a0d8-4ae6a549a6d5" />

When enough yes votes are selected the inputs will be disabled so they look like this:
<img width="960" height="542" alt="image" src="https://github.com/user-attachments/assets/8dc1d2a7-4fb8-4cda-b473-bcb704934b9d" />

Looking forward to your feedback. 

Have a nice day.