### PR TITLE
Set meeting settings non default integer values to `null`

### DIFF
--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.html
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail-field/meeting-settings-group-detail-field.component.html
@@ -71,8 +71,7 @@
                                 [type]="formType(setting.type!)"
                                 [value]="internalValue"
                             />
-                        }
-                        @if (setting.type !== 'email') {
+                        } @else {
                             <input
                                 formControlName="value"
                                 matInput

--- a/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definition.service.spec.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definition.service.spec.ts
@@ -138,7 +138,7 @@ const fakeBrokenSettingsDefaults: Record<string, any> = {
 };
 
 const typeToDefault: Record<SettingsType, any> = {
-    integer: 0,
+    integer: null,
     boolean: false,
     groups: [],
     translations: {},

--- a/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definition.service.ts
+++ b/client/src/app/site/pages/meetings/services/meeting-settings-definition.service/meeting-settings-definition.service.ts
@@ -42,7 +42,7 @@ export class MeetingSettingsDefinitionService {
     public getDefaultValueForType(setting: SettingsInput): any {
         switch (setting.type) {
             case `integer`:
-                return 0;
+                return null;
             case `boolean`:
                 return false;
             case `translations`:


### PR DESCRIPTION
resolves #6523 

Not completely fulfilling the expected behavior. For that https://github.com/OpenSlides/openslides-meta/issues/574 is needed which requires a migration. I adjusted the default value in the new issue to use the default that is used in the projector when nothing is set. 