### PR TITLE
Fix show entire motion text

### DIFF
--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-detail-original-change-recommendations/motion-detail-original-change-recommendations.component.ts
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-detail-original-change-recommendations/motion-detail-original-change-recommendations.component.ts
@@ -212,9 +212,11 @@ export class MotionDetailOriginalChangeRecommendationsComponent implements OnIni
 
         if (to) {
             return (to.offsetHeight + to.offsetTop - from.offsetTop).toString() + `px`;
-        } else {
+        } else if (from) {
             return from.offsetHeight.toString() + `px`;
         }
+
+        return `0px`;
     }
 
     /**

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/paragraph-based-amendment/paragraph-based-amendment.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/paragraph-based-amendment/paragraph-based-amendment.component.html
@@ -124,7 +124,11 @@
 @if (changeRecoMode === ChangeRecoMode.Original || changeRecoMode === ChangeRecoMode.Changed) {
     <div>
         @if (motion && motion.isParagraphBasedAmendment() && motion.lead_motion) {
-            <mat-checkbox class="show-entire-text-check" (change)="showAmendmentContext = !showAmendmentContext">
+            <mat-checkbox
+                class="show-entire-text-check"
+                [checked]="showAmendmentContext"
+                (change)="showAmendmentContext = !showAmendmentContext"
+            >
                 <span>{{ 'Show entire motion text' | translate }}</span>
             </mat-checkbox>
         }


### PR DESCRIPTION
resolves #6531

Also fixes an issue where the "Show entire motion text" checkbox displays the wrong value when switching between original/changed version.