### PR TITLE
Disallow attribute interpolation

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -141,7 +141,9 @@ export default tseslint.config({
         "@angular-eslint/template/attributes-order": ["error", {
             alphabetical: true,
         }],
-        "@angular-eslint/template/no-interpolation-in-attributes": ["error"],
+        "@angular-eslint/template/no-interpolation-in-attributes": ["error", {
+            allowSubstringInterpolation: true,
+        }],
         "@angular-eslint/template/prefer-control-flow": ["error"],
     },
 }, {

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -141,7 +141,7 @@ export default tseslint.config({
         "@angular-eslint/template/attributes-order": ["error", {
             alphabetical: true,
         }],
-
+        "@angular-eslint/template/no-interpolation-in-attributes": ["error"],
         "@angular-eslint/template/prefer-control-flow": ["error"],
     },
 }, {

--- a/client/src/app/gateways/export/progress-snack-bar/components/progress-snack-bar/progress-snack-bar.component.html
+++ b/client/src/app/gateways/export/progress-snack-bar/components/progress-snack-bar/progress-snack-bar.component.html
@@ -9,7 +9,7 @@
         <button
             color="warn"
             mat-icon-button
-            matTooltip="{{ 'Cancel' | translate }}"
+            [matTooltip]="'Cancel' | translate"
             (click)="snackBarRef.dismissWithAction()"
         >
             <mat-icon>close</mat-icon>

--- a/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.html
+++ b/client/src/app/site/modules/global-headbar/components/account-button/account-button.component.html
@@ -1,7 +1,7 @@
 <button
-    aria-label="{{ getAriaLabel() }}"
     class="accountButton flex-center"
     data-cy="accountButton"
+    [aria-label]="getAriaLabel()"
     [matMenuTriggerFor]="userMenu"
 >
     @if (isPresent) {
@@ -46,10 +46,8 @@
                 <div>
                     <button
                         mat-icon-button
-                        matTooltip="{{
-                            ((isDarkModeActiveObservable | async) ? 'Light mode' : 'Dark mode') | translate
-                        }}"
                         matTooltipPosition="left"
+                        [matTooltip]="((isDarkModeActiveObservable | async) ? 'Light mode' : 'Dark mode') | translate"
                         (click)="toggleDarkMode($event)"
                     >
                         <mat-icon>
@@ -64,9 +62,9 @@
                     <!-- present toggle -->
                     @if (isAllowedSelfSetPresent && hasActiveMeeting) {
                         <button
-                            aria-checked="{{ isPresent }}"
                             mat-menu-item
                             role="menuitemcheckbox"
+                            [aria-checked]="isPresent"
                             [ngClass]="{ active: isPresent }"
                             (click)="toggleOperatorPresence()"
                         >

--- a/client/src/app/site/modules/global-headbar/components/global-search/global-search.component.html
+++ b/client/src/app/site/modules/global-headbar/components/global-search/global-search.component.html
@@ -5,9 +5,9 @@
     <div class="search-top-form">
         <div class="search-input-container">
             <os-rounded-input
-                placeholder="{{ 'Search' | translate }}"
                 [autofocus]="true"
                 [hasSubmit]="true"
+                [placeholder]="'Search' | translate"
                 [(ngModel)]="searchTerm"
                 (clickSubmit)="searchChange()"
                 (inputCleared)="searchCleared()"
@@ -42,7 +42,7 @@
                 <div class="filter-section">
                     @for (filter of currentlyAvailableFilters; track filter) {
                         @if (hasFilterPermission(filter)) {
-                            <mat-checkbox class="filter" formControlName="{{ filter }}">
+                            <mat-checkbox class="filter" [formControlName]="filter">
                                 {{ availableFilters[filter] | translate }}
                             </mat-checkbox>
                         }

--- a/client/src/app/site/modules/user-components/components/user-delete-dialog/user-delete-dialog.component.html
+++ b/client/src/app/site/modules/user-components/components/user-delete-dialog/user-delete-dialog.component.html
@@ -95,7 +95,7 @@
                 @if (hasRelations(user)) {
                     <mat-icon
                         color="warn"
-                        matTooltip="{{ 'This account has relations to meetings or committees' | translate }}"
+                        [matTooltip]="'This account has relations to meetings or committees' | translate"
                     >
                         warning
                     </mat-icon>

--- a/client/src/app/site/modules/user-components/components/user-detail-view/user-detail-view.component.html
+++ b/client/src/app/site/modules/user-components/components/user-detail-view/user-detail-view.component.html
@@ -85,7 +85,7 @@
             @if (disableGenderField()) {
                 <mat-form-field class="form58 force-min-width">
                     <mat-label>{{ 'Gender' | translate }}</mat-label>
-                    <input matInput readonly value="{{ genderName | translate }}" />
+                    <input matInput readonly [value]="genderName | translate" />
                 </mat-form-field>
             } @else {
                 <mat-form-field class="form58 force-min-width">
@@ -223,15 +223,15 @@
                         <span>({{ user.pronoun }})</span>
                     }
                     @if (!user.is_active && isAllowed('seeSensitiveData')) {
-                        <mat-icon class="red-warning-text" matTooltip="{{ 'Inactive' | translate }}">
+                        <mat-icon class="red-warning-text" [matTooltip]="'Inactive' | translate">
                             do_not_disturb_on
                         </mat-icon>
                     }
                     @if (!user.is_physical_person) {
-                        <mat-icon matTooltip="{{ 'Is no natural person' | translate }}">account_balance</mat-icon>
+                        <mat-icon [matTooltip]="'Is no natural person' | translate">account_balance</mat-icon>
                     }
                     @if (user.hasSamlId && isAllowed('seeSensitiveData')) {
-                        <mat-icon matTooltip="{{ 'Has SSO identification' | translate }}">fingerprint</mat-icon>
+                        <mat-icon [matTooltip]="'Has SSO identification' | translate">fingerprint</mat-icon>
                     }
                 </span>
             </div>

--- a/client/src/app/site/modules/user-components/components/user-password-form/user-password-form.component.html
+++ b/client/src/app/site/modules/user-components/components/user-password-form/user-password-form.component.html
@@ -34,9 +34,7 @@
                             class="pointer"
                             mat-icon-button
                             matSuffix
-                            matTooltip="{{
-                                hidePassword ? ('Show password' | translate) : ('Hide password' | translate)
-                            }}"
+                            [matTooltip]="hidePassword ? ('Show password' | translate) : ('Hide password' | translate)"
                             (click)="hidePassword = !hidePassword"
                         >
                             {{ hidePassword ? 'visibility' : 'visibility_off' }}
@@ -45,7 +43,7 @@
                             class="pointer spacer-left-10"
                             mat-icon-button
                             matSuffix
-                            matTooltip="{{ 'Generate password' | translate }}"
+                            [matTooltip]="'Generate password' | translate"
                             (click)="generatePassword()"
                         >
                             autorenew

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-content/list-of-speakers-content.component.html
@@ -7,8 +7,8 @@
                     <mat-icon
                         append
                         class="primary-accent-by-theme"
-                        matTooltip="{{ 'The list of speakers is closed.' | translate }}"
                         style="margin-top: 8px"
+                        [matTooltip]="'The list of speakers is closed.' | translate"
                     >
                         lock
                     </mat-icon>
@@ -127,8 +127,8 @@
         @if (canManage) {
             <div class="search-new-speaker-form">
                 <os-participant-search-selector
-                    placeholder="{{ 'Select speaker' | translate }}"
                     [nonSelectableUserIds]="nonAvailableUserIds"
+                    [placeholder]="'Select speaker' | translate"
                     (userSelected)="addUserAsNewSpeaker($event)"
                 ></os-participant-search-selector>
             </div>

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-entry/list-of-speakers-entry.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/list-of-speakers-entry/list-of-speakers-entry.component.html
@@ -7,9 +7,9 @@
                     <button
                         class="speaker-control-button"
                         mat-icon-button
-                        matTooltip="{{ (speaker.pause_time ? 'Resume speech' : 'Begin speech') | translate }}"
                         matTooltipPosition="above"
                         [color]="speakerIndex === 0 ? 'accent' : null"
+                        [matTooltip]="(speaker.pause_time ? 'Resume speech' : 'Begin speech') | translate"
                         [ngClass]="{
                             'small-play-icon': (speakerIndex > 0 || speakerIndex !== 0) && !speaker.isCurrentSpeaker
                         }"
@@ -25,8 +25,8 @@
                     <button
                         class="speaker-control-button"
                         mat-icon-button
-                        matTooltip="{{ 'Pause speech' | translate }}"
                         matTooltipPosition="above"
+                        [matTooltip]="'Pause speech' | translate"
                         (click)="onPauseButton()"
                     >
                         <mat-icon>pause_circle_outline</mat-icon>
@@ -127,8 +127,8 @@
                         @if (showStructureLevels()) {
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Structure level' | translate }}"
                                 [matMenuTriggerFor]="structureLevelsMenu"
+                                [matTooltip]="'Structure level' | translate"
                             >
                                 <mat-icon>flag</mat-icon>
                             </button>
@@ -137,7 +137,7 @@
                         @if (enableProContraSpeech && !speaker.point_of_order) {
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Forspeech' | translate }}"
+                                [matTooltip]="'Forspeech' | translate"
                                 (click)="onProContraButtons(true)"
                             >
                                 @if (speaker.speech_state !== SpeechState.PRO) {
@@ -152,7 +152,7 @@
                         @if (enableProContraSpeech && !speaker.point_of_order) {
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Counter speech' | translate }}"
+                                [matTooltip]="'Counter speech' | translate"
                                 (click)="onProContraButtons(false)"
                             >
                                 @if (speaker.speech_state !== SpeechState.CONTRA) {
@@ -165,11 +165,7 @@
                         }
                         <!-- mark -->
                         @if (canMarkSpeaker() && !speaker.point_of_order) {
-                            <button
-                                mat-icon-button
-                                matTooltip="{{ 'Contribution' | translate }}"
-                                (click)="onMarkButton()"
-                            >
+                            <button mat-icon-button [matTooltip]="'Contribution' | translate" (click)="onMarkButton()">
                                 @if (speaker.speech_state === SpeechState.CONTRIBUTION) {
                                     <mat-icon>star</mat-icon>
                                 }
@@ -205,8 +201,8 @@
                 <button
                     class="speaker-stop-button"
                     mat-icon-button
-                    matTooltip="{{ 'End speech' | translate }}"
                     matTooltipPosition="above"
+                    [matTooltip]="'End speech' | translate"
                     (click)="onStopButton()"
                 >
                     <mat-icon>stop_circle</mat-icon>
@@ -244,8 +240,8 @@
                 @if (enableUpdateUserButton()) {
                     <button
                         mat-icon-button
-                        matTooltip="{{ 'Select speaker' | translate }}"
                         matTooltipPosition="left"
+                        [matTooltip]="'Select speaker' | translate"
                         (click)="updateSpeakerMeetingUser()"
                     >
                         <mat-icon>person_add</mat-icon>
@@ -256,8 +252,8 @@
                 <button
                     *osPerms="permission.listOfSpeakersCanManage"
                     mat-icon-button
-                    matTooltip="{{ 'Remove' | translate }}"
                     matTooltipPosition="left"
+                    [matTooltip]="'Remove' | translate"
                     (click)="removeSpeaker()"
                 >
                     <mat-icon>close</mat-icon>
@@ -445,9 +441,7 @@
     ) {
         <span>
             @if (speaker.point_of_order) {
-                <mat-icon class="inline-icon-text-align" color="{{ !!showcolor ? 'warn' : null }}" inline>
-                    warning
-                </mat-icon>
+                <mat-icon class="inline-icon-text-align" inline [color]="!!showcolor ? 'warn' : null">warning</mat-icon>
             }
             @if (speaker.point_of_order_category && ((showSpeakerNoteForEveryoneObservable | async) || canManage)) {
                 <b [class.foreground-warn]="!!showcolor">

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/components/moderation-note/moderation-note.component.html
@@ -11,14 +11,14 @@
                             <button
                                 color="warn"
                                 mat-icon-button
-                                matTooltip="{{ 'Save' | translate }}"
+                                [matTooltip]="'Save' | translate"
                                 (click)="saveChangesModerationNote()"
                             >
                                 <mat-icon>done</mat-icon>
                             </button>
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Cancel edit' | translate }}"
+                                [matTooltip]="'Cancel edit' | translate"
                                 (click)="toggleEditModeratorNote()"
                             >
                                 <mat-icon>close</mat-icon>
@@ -26,7 +26,7 @@
                         } @else {
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Edit moderation note' | translate }}"
+                                [matTooltip]="'Edit moderation note' | translate"
                                 (click)="toggleEditModeratorNote()"
                             >
                                 <mat-icon>edit</mat-icon>
@@ -36,7 +36,7 @@
                     @if (showModerationNotesExport) {
                         <button
                             mat-icon-button
-                            matTooltip="{{ 'Export moderator note as PDF' | translate }}"
+                            [matTooltip]="'Export moderator note as PDF' | translate"
                             (click)="onDownloadPDF()"
                         >
                             <mat-icon>picture_as_pdf</mat-icon>

--- a/client/src/app/site/pages/meetings/modules/list-of-speakers-content/modules/speaker-user-select-dialog/components/speaker-user-select-dialog/speaker-user-select-dialog.component.html
+++ b/client/src/app/site/pages/meetings/modules/list-of-speakers-content/modules/speaker-user-select-dialog/components/speaker-user-select-dialog/speaker-user-select-dialog.component.html
@@ -5,8 +5,8 @@
 <form class="edit-form">
     <mat-dialog-content>
         <os-participant-search-selector
-            placeholder="{{ 'Select speaker' | translate }}"
             [nonSelectableUserIds]="nonAvailableUserIds"
+            [placeholder]="'Select speaker' | translate"
             (userSelected)="setCurrentUser($event)"
         ></os-participant-search-selector>
     </mat-dialog-content>

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/detail-view/components/projectable-title/projectable-title.component.html
@@ -13,7 +13,7 @@
     <div class="suffix">
         @if (isProjectedObservable | async) {
             <mat-icon
-                matTooltip="{{ 'Is being projected' | translate }}"
+                [matTooltip]="'Is being projected' | translate"
                 [ngClass]="{ 'primary-accent-by-theme': titleStyle === 'h1' && !mockH2 }"
             >
                 videocam

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projectable-list/components/projectable-list/projectable-list.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projectable-list/components/projectable-list/projectable-list.component.html
@@ -36,7 +36,7 @@
         <!-- Projector indicator -->
         <div *osPerms="permission.projectorCanManage; complement: true" class="projector-button">
             @if (isProjectedFn(viewModel)) {
-                <mat-icon color="accent" matTooltip="{{ 'Currently projected' | translate }}">videocam</mat-icon>
+                <mat-icon color="accent" [matTooltip]="'Currently projected' | translate">videocam</mat-icon>
             }
         </div>
     </div>

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/components/projection-dialog/projection-dialog.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/projection-dialog/components/projection-dialog/projection-dialog.component.html
@@ -17,7 +17,7 @@
                             {{ projector.name }}
                         </mat-checkbox>
                         @if (isProjectedOn(projector)) {
-                            <mat-icon matTooltip="{{ 'Is already projected' | translate }}" matTooltipPosition="above">
+                            <mat-icon matTooltipPosition="above" [matTooltip]="'Is already projected' | translate">
                                 videocam
                             </mat-icon>
                         }

--- a/client/src/app/site/pages/meetings/modules/meetings-component-collector/speaker-button/components/speaker-button/speaker-button.component.html
+++ b/client/src/app/site/pages/meetings/modules/meetings-component-collector/speaker-button/components/speaker-button/speaker-button.component.html
@@ -5,11 +5,11 @@
                 <button
                     class="anchor-button"
                     mat-icon-button
-                    matTooltip="{{
-                        (listOfSpeakers.closed ? 'The list of speakers is closed.' : 'List of speakers') | translate
-                    }}"
                     type="button"
                     [disabled]="disabled"
+                    [matTooltip]="
+                        (listOfSpeakers.closed ? 'The list of speakers is closed.' : 'List of speakers') | translate
+                    "
                 >
                     @if (canSee) {
                         <mat-icon

--- a/client/src/app/site/pages/meetings/modules/poll/components/base-poll-vote/base-poll-vote.component.html
+++ b/client/src/app/site/pages/meetings/modules/poll/components/base-poll-vote/base-poll-vote.component.html
@@ -290,12 +290,12 @@
                                     <mat-form-field appearance="outline" class="vote-input" role="gridcell">
                                         <input
                                             matInput
-                                            max="{{ poll.max_votes_per_option }}"
                                             min="0"
                                             required
                                             type="number"
                                             value="0"
                                             [formControl]="getFormControl(option.id)"
+                                            [max]="poll.max_votes_per_option"
                                             (change)="saveMultipleVotes(option.id, $event, delegation)"
                                         />
                                         <mat-error>

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/components/list-of-speakers/list-of-speakers.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/list-of-speakers/components/list-of-speakers/list-of-speakers.component.html
@@ -13,9 +13,9 @@
         <ng-container *osPerms="[permission.listOfSpeakersCanManage, permission.projectorCanManage]" class="menu-slot">
             <button
                 mat-icon-button
-                matTooltip="{{ 'Re-add last speaker' | translate }}"
                 type="button"
                 [disabled]="!canReaddLastSpeaker"
+                [matTooltip]="'Re-add last speaker' | translate"
                 (click)="readdLastSpeaker()"
             >
                 <mat-icon>undo</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-dialog/topic-poll-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/modules/topic-poll/components/topic-poll-dialog/topic-poll-dialog.component.html
@@ -30,7 +30,7 @@
                                         <span class="delete-button">
                                             <button
                                                 mat-icon-button
-                                                matTooltip="{{ 'Remove option' | translate }}"
+                                                [matTooltip]="'Remove option' | translate"
                                                 (click)="removeOption(item)"
                                             >
                                                 <mat-icon>clear</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/components/topic-import/topic-import.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/modules/topics/pages/topic-import/components/topic-import/topic-import.component.html
@@ -13,13 +13,13 @@
         @if (finishedSuccessfully || hasErrors) {
             <div style="padding-top: 6px">
                 @if (finishedSuccessfully) {
-                    <mat-icon matTooltip="{{ 'Import successful' | translate }}">done</mat-icon>
+                    <mat-icon [matTooltip]="'Import successful' | translate">done</mat-icon>
                 }
                 @if (finishedWithWarnings) {
-                    <mat-icon matTooltip="{{ 'Import successful with some warnings' | translate }}">done</mat-icon>
+                    <mat-icon [matTooltip]="'Import successful with some warnings' | translate">done</mat-icon>
                 }
                 @if (hasErrors) {
-                    <mat-icon matTooltip="{{ 'Can not import because of errors' | translate }}">block</mat-icon>
+                    <mat-icon [matTooltip]="'Can not import because of errors' | translate">block</mat-icon>
                 }
             </div>
         }

--- a/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-sort/components/agenda-sort/agenda-sort.component.html
+++ b/client/src/app/site/pages/meetings/pages/agenda/pages/agenda-sort/components/agenda-sort/agenda-sort.component.html
@@ -30,7 +30,7 @@
             <mat-selection-list #visibilities (selectionChange)="onFilterChange(visibilities.selectedOptions.selected)">
                 @for (option of filterOptions; track option) {
                     <mat-list-option [selected]="option.state" [value]="option.id">
-                        <mat-icon matListItemIcon matTooltip="{{ option.label | translate }}" matTooltipPosition="left">
+                        <mat-icon matListItemIcon matTooltipPosition="left" [matTooltip]="option.label | translate">
                             {{ getIcon(option.id) }}
                         </mat-icon>
                         <div matListItemTitle>

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-detail/components/assignment-detail/assignment-detail.component.html
@@ -238,7 +238,7 @@
                                                 <span>
                                                     <button
                                                         mat-icon-button
-                                                        matTooltip="{{ 'Remove candidate' | translate }}"
+                                                        [matTooltip]="'Remove candidate' | translate"
                                                         (click)="removeCandidate(item)"
                                                     >
                                                         <mat-icon>clear</mat-icon>
@@ -256,8 +256,8 @@
                             @if (hasPerms('addOthers')) {
                                 <div class="search-new-speaker-form">
                                     <os-participant-search-selector
-                                        placeholder="{{ 'Select participant' | translate }}"
                                         [nonSelectableUserIds]="candidateUserIds"
+                                        [placeholder]="'Select participant' | translate"
                                         (userSelected)="addCandidate($event)"
                                     ></os-participant-search-selector>
                                 </div>

--- a/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-detail/assignment-poll-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/assignments/pages/assignment-polls/components/assignment-poll-detail/assignment-poll-detail.component.html
@@ -54,7 +54,7 @@
                     }
                     @if (showResults && poll.stateHasVotes && poll.isEVoting) {
                         <mat-tab-group (selectedTabChange)="onTabChange()">
-                            <mat-tab label="{{ 'Single votes' | translate }}">
+                            <mat-tab [label]="'Single votes' | translate">
                                 <!-- Single Votes Table -->
                                 <div class="named-result-table">
                                     @if (votesDataObservable) {
@@ -68,7 +68,7 @@
                                     }
                                 </div>
                             </mat-tab>
-                            <mat-tab label="{{ 'Entitled users' | translate }}">
+                            <mat-tab [label]="'Entitled users' | translate">
                                 <os-entitled-users-table
                                     [displayDelegation]="displayDelegation"
                                     [displayVoteWeight]="displayVoteWeight"
@@ -79,10 +79,10 @@
                         </mat-tab-group>
                     } @else if (poll.isEVoting && poll.isStarted) {
                         <mat-tab-group>
-                            <mat-tab label="{{ 'Single votes' | translate }}">
+                            <mat-tab [label]="'Single votes' | translate">
                                 <div class="no-content no-data-margins">{{ 'No data available' | translate }}</div>
                             </mat-tab>
-                            <mat-tab *osPerms="permission.pollCanManage" label="{{ 'Entitled users' | translate }}">
+                            <mat-tab *osPerms="permission.pollCanManage" [label]="'Entitled users' | translate">
                                 <os-entitled-users-table
                                     [displayDelegation]="displayDelegation"
                                     [displayVoteWeight]="displayVoteWeight"

--- a/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
+++ b/client/src/app/site/pages/meetings/pages/autopilot/components/autopilot/autopilot.component.html
@@ -86,8 +86,8 @@
                         <ng-container *osPerms="permission.listOfSpeakersCanManage; complement: true">
                             @if (isLosClosed) {
                                 <mat-icon
-                                    matTooltip="{{ 'The list of speakers is closed.' | translate }}"
                                     matTooltipPosition="above"
+                                    [matTooltip]="'The list of speakers is closed.' | translate"
                                 >
                                     lock
                                 </mat-icon>
@@ -98,16 +98,16 @@
                             <button class="title-action" mat-icon-button (click)="toggleListOfSpeakersOpen()">
                                 @if (isLosClosed) {
                                     <mat-icon
-                                        matTooltip="{{ 'Open list of speakers' | translate }}"
                                         matTooltipPosition="above"
+                                        [matTooltip]="'Open list of speakers' | translate"
                                     >
                                         lock
                                     </mat-icon>
                                 }
                                 @if (!isLosClosed) {
                                     <mat-icon
-                                        matTooltip="{{ 'Close list of speakers' | translate }}"
                                         matTooltipPosition="above"
+                                        [matTooltip]="'Close list of speakers' | translate"
                                     >
                                         lock_open
                                     </mat-icon>
@@ -117,9 +117,9 @@
                             <button
                                 class="title-action"
                                 mat-icon-button
-                                matTooltip="{{ 'Re-add last speaker' | translate }}"
                                 matTooltipPosition="above"
                                 [disabled]="!canReaddLastSpeaker"
+                                [matTooltip]="'Re-add last speaker' | translate"
                                 (click)="readdLastSpeaker()"
                             >
                                 <mat-icon>undo</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-detail/chat-group-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/chat/pages/chat-group-list/components/chat-group-detail/chat-group-detail.component.html
@@ -14,7 +14,7 @@
             <div class="action-row flex-vertical-center padding-left-8 padding-right-8">
                 <div>
                     @if (group.write_groups.length) {
-                        <os-icon-container icon="edit" matTooltip="{{ 'Groups with write permissions' | translate }}">
+                        <os-icon-container icon="edit" [matTooltip]="'Groups with write permissions' | translate">
                             <os-comma-separated-listing [list]="group.write_groups" [showElementsAmount]="3">
                                 <ng-template let-group>{{ group.getTitle() }}</ng-template>
                             </os-comma-separated-listing>
@@ -25,7 +25,7 @@
                     @if (getReadonlyGroups(group).length) {
                         <os-icon-container
                             icon="remove_red_eye"
-                            matTooltip="{{ 'Groups with read permissions' | translate }}"
+                            [matTooltip]="'Groups with read permissions' | translate"
                         >
                             <os-comma-separated-listing [list]="getReadonlyGroups(group)" [showElementsAmount]="3">
                                 <ng-template let-group>{{ group.getTitle() }}</ng-template>

--- a/client/src/app/site/pages/meetings/pages/interaction/modules/action-bar/components/action-bar/action-bar.component.html
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/action-bar/components/action-bar/action-bar.component.html
@@ -8,7 +8,7 @@
                     animate.leave="fade-out"
                     class="action-bar-shadow background-default"
                     mat-mini-fab
-                    matTooltip="{{ 'Show conference room' | translate }}"
+                    [matTooltip]="'Show conference room' | translate"
                     (click)="maximizeCallDialog()"
                 >
                     <mat-icon class="icon-pulse" color="primary">fullscreen</mat-icon>
@@ -21,7 +21,7 @@
                 <button
                     class="action-bar-shadow background-default"
                     mat-mini-fab
-                    matTooltip="{{ canEnterTooltip | translate }}"
+                    [matTooltip]="canEnterTooltip | translate"
                     (click)="enterConferenceRoom()"
                 >
                     <mat-icon color="primary">phone</mat-icon>
@@ -30,7 +30,7 @@
                 <a
                     class="action-bar-shadow fake-disabled"
                     mat-mini-fab
-                    matTooltip="{{ cannotEnterTooltip | translate }}"
+                    [matTooltip]="cannotEnterTooltip | translate"
                     [routerLink]="['/', activeMeetingId, 'autopilot']"
                 >
                     <mat-icon color="primary">phone</mat-icon>
@@ -44,7 +44,7 @@
                 animate.leave="fade-out"
                 class="action-bar-shadow background-default"
                 mat-mini-fab
-                matTooltip="{{ 'Help desk' | translate }}"
+                [matTooltip]="'Help desk' | translate"
                 (click)="enterSupportRoom()"
             >
                 <mat-icon color="primary">help_outline</mat-icon>
@@ -57,12 +57,12 @@
                 animate.leave="fade-out"
                 class="action-bar-shadow background-default"
                 mat-mini-fab
-                matTooltip="{{ 'Give applause' | translate }}"
                 [attr.aria-hidden]="false"
                 [attr.aria-label]="('Amount of applause' | translate) + ': ' + (applauseLevel | async)"
                 [disabled]="sendsApplause | async"
                 [matBadge]="applauseLevel | async"
                 [matBadgeHidden]="(showApplauseLevel | async) === false"
+                [matTooltip]="'Give applause' | translate"
                 (click)="sendApplause()"
             >
                 <mat-icon class="svg-primary" svgIcon="clapping_hands"></mat-icon>

--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call-dialog/call-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call-dialog/call-dialog.component.html
@@ -8,10 +8,10 @@
                         *osPerms="permission.listOfSpeakersCanManage"
                         color="primary"
                         mat-icon-button
-                        matTooltip="{{ 'Open Jitsi in new tab' | translate }}"
                         target="_blank"
                         type="button"
                         [href]="jitsiMeetUrl | async"
+                        [matTooltip]="'Open Jitsi in new tab' | translate"
                         (click)="hangUp()"
                     >
                         <mat-icon>open_in_new</mat-icon>
@@ -21,8 +21,8 @@
                     <button
                         color="primary"
                         mat-icon-button
-                        matTooltip="{{ 'Minimize' | translate }}"
                         type="button"
+                        [matTooltip]="'Minimize' | translate"
                         (click)="hideDialog()"
                     >
                         <mat-icon>minimize</mat-icon>
@@ -42,8 +42,8 @@
                     <button
                         color="primary"
                         mat-icon-button
-                        matTooltip="{{ 'Exit conference room' | translate }}"
                         type="button"
+                        [matTooltip]="'Exit conference room' | translate"
                         (click)="hangUp()"
                     >
                         <mat-icon>close</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call/call.component.html
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/call/call.component.html
@@ -51,7 +51,7 @@
             <div class="control-buttons">
                 <!-- Hangup -->
                 @if (showHangUp) {
-                    <button color="warn" mat-mini-fab matTooltip="{{ 'Leave' | translate }}" (click)="hangUp()">
+                    <button color="warn" mat-mini-fab [matTooltip]="'Leave' | translate" (click)="hangUp()">
                         <mat-icon>call_end</mat-icon>
                     </button>
                 }
@@ -61,8 +61,8 @@
                     <button
                         color="accent"
                         mat-mini-fab
-                        matTooltip="{{ 'Enter conference room' | translate }}"
                         [disabled]="(canEnterCall | async) === false || isConnecting"
+                        [matTooltip]="'Enter conference room' | translate"
                         (click)="callRoom()"
                     >
                         <mat-icon>call</mat-icon>
@@ -76,7 +76,7 @@
                         <button
                             color="primary"
                             mat-icon-button
-                            matTooltip="{{ 'Continue livestream' | translate }}"
+                            [matTooltip]="'Continue livestream' | translate"
                             (click)="viewStream()"
                         >
                             <mat-icon>live_tv</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/video-player/video-player.component.html
+++ b/client/src/app/site/pages/meetings/pages/interaction/modules/interaction-container/components/video-player/video-player.component.html
@@ -40,7 +40,7 @@
                             <button
                                 color="accent"
                                 mat-mini-fab
-                                matTooltip="{{ 'Refresh' | translate }}"
+                                [matTooltip]="'Refresh' | translate"
                                 (click)="onRefreshVideo()"
                             >
                                 <mat-icon>refresh</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/mediafiles/modules/mediafile-list/components/mediafile-list/mediafile-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/mediafiles/modules/mediafile-list/components/mediafile-list/mediafile-list.component.html
@@ -60,10 +60,7 @@
     @if (canEdit && directory && directory.has_inherited_access_groups) {
         <span class="visibility">
             <button class="visible-for" mat-button (click)="onEditFile(directory)">
-                <os-icon-container
-                    icon="group"
-                    matTooltip="{{ 'Allowed access groups for this directory' | translate }}"
-                >
+                <os-icon-container icon="group" [matTooltip]="'Allowed access groups for this directory' | translate">
                     <os-comma-separated-listing [list]="directory.inherited_access_groups" [showElementsAmount]="3">
                         <ng-template let-group>{{ group.getTitle() }}</ng-template>
                     </os-comma-separated-listing>

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/allocation-list/allocation-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/allocation-list/allocation-list.component.html
@@ -21,10 +21,10 @@
                 <button
                     class="delete-button"
                     mat-icon-button
-                    matTooltip="{{ 'Cancel' | translate }}"
                     matTooltipPosition="left"
                     type="button"
                     [disabled]="disabled"
+                    [matTooltip]="'Cancel' | translate"
                     (click)="onRemoveAllocation(i)"
                 >
                     <mat-icon>close</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/meeting-settings/pages/meeting-settings-group-detail/components/meeting-settings-group-detail/meeting-settings-group-detail.component.html
@@ -10,8 +10,8 @@
     <ng-container class="menu-slot">
         <button
             mat-button
-            matTooltip="{{ 'Save all changes' | translate }}"
             [disabled]="!hasChanges() || hasErrors()"
+            [matTooltip]="'Save all changes' | translate"
             (click)="saveAll()"
         >
             <strong class="upper">{{ 'Save' | translate }}</strong>

--- a/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll/motion-poll.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/modules/motion-poll/components/motion-poll/motion-poll.component.html
@@ -91,7 +91,7 @@
             <!-- Detail link -->
             @if (poll.isPublished && isSameMeeting) {
                 <div class="poll-detail-button-wrapper">
-                    <a mat-icon-button matTooltip="{{ 'More' | translate }}" [routerLink]="getDetailLink()">
+                    <a mat-icon-button [matTooltip]="'More' | translate" [routerLink]="getDetailLink()">
                         <mat-icon class="icon-18">visibility</mat-icon>
                     </a>
                 </div>
@@ -110,7 +110,7 @@
 
 <ng-template #emptyTemplate>
     <span *osPerms="permission.motionCanManagePolls; and: poll.type === 'analog'">
-        <button mat-stroked-button matTooltip="{{ 'Edit' | translate }}" (click)="dialogOpened.emit()">
+        <button mat-stroked-button [matTooltip]="'Edit' | translate" (click)="dialogOpened.emit()">
             <mat-icon>edit</mat-icon>
         </button>
         <div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail-sort/category-detail-sort.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-detail-sort/category-detail-sort.component.html
@@ -29,8 +29,8 @@
                             <mat-basic-chip
                                 class="bluegrey"
                                 disableRipple
-                                matTooltip="{{ 'Sequential number' | translate }}"
                                 matTooltipPosition="left"
+                                [matTooltip]="'Sequential number' | translate"
                             >
                                 {{ motion.sequential_number }}
                             </mat-basic-chip>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-list/category-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/categories/components/category-list/category-list.component.html
@@ -33,7 +33,7 @@
 
     <!-- Amount -->
     <div *osScrollingTableCell="'amount'; row as category; config: { width: 45 }" class="cell-slot fill">
-        <span class="os-amount-chip" matTooltip="{{ 'Motions' | translate }}" matTooltipPosition="left">
+        <span class="os-amount-chip" matTooltipPosition="left" [matTooltip]="'Motions' | translate">
             {{ getMotionAmount(category) }}
         </span>
     </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-blocks/components/motion-block-detail/motion-block-detail.component.html
@@ -144,8 +144,8 @@
             <button
                 color="warn"
                 mat-icon-button
-                matTooltip="{{ 'Remove from motion block' | translate }}"
                 type="button"
+                [matTooltip]="'Remove from motion block' | translate"
                 (click)="onRemoveMotionButton(motion)"
             >
                 <mat-icon>close</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-comment/motion-comment.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-comment/motion-comment.component.html
@@ -33,21 +33,21 @@
 
     <ng-container class="meta-text-block-action-row">
         @if (isEditing) {
-            <button color="warn" mat-icon-button matTooltip="{{ 'Save' | translate }}" (click)="saveComment()">
+            <button color="warn" mat-icon-button [matTooltip]="'Save' | translate" (click)="saveComment()">
                 <mat-icon>done</mat-icon>
             </button>
 
-            <button mat-icon-button matTooltip="{{ 'Cancel edit' | translate }}" (click)="leaveEditMode()">
+            <button mat-icon-button [matTooltip]="'Cancel edit' | translate" (click)="leaveEditMode()">
                 <mat-icon>close</mat-icon>
             </button>
         } @else {
             @if (canBeEdited || hasSubmitterEditRights) {
-                <button mat-icon-button matTooltip="{{ 'Edit' | translate }}" (click)="editComment()">
+                <button mat-icon-button [matTooltip]="'Edit' | translate" (click)="editComment()">
                     <mat-icon>edit</mat-icon>
                 </button>
             }
             @if (hasComment()) {
-                <button mat-icon-button matTooltip="{{ 'Export comment' | translate }}" (click)="exportCommentAsPDf()">
+                <button mat-icon-button [matTooltip]="'Export comment' | translate" (click)="exportCommentAsPDf()">
                     <mat-icon>picture_as_pdf</mat-icon>
                 </button>
             }

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-detail-diff/motion-detail-diff.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-detail-diff/motion-detail-diff.component.html
@@ -91,7 +91,7 @@
                     <div class="status-row">
                         <div class="collission-hint">
                             @if (hasCollissions(change, workingTextChangingObjects)) {
-                                <mat-icon matTooltip="{{ 'This change collides with another one.' | translate }}">
+                                <mat-icon [matTooltip]="'This change collides with another one.' | translate">
                                     warning
                                 </mat-icon>
                             }
@@ -152,7 +152,7 @@
                         isAmendment(change) && showAllAmendments && change.amendment.change_recommendation_ids?.length
                     ) {
                         <div class="amendment-cr-hint">
-                            <mat-icon matTooltip="{{ 'This amendment has change recommendations.' | translate }}">
+                            <mat-icon [matTooltip]="'This amendment has change recommendations.' | translate">
                                 info
                             </mat-icon>
                         </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-extension-field/motion-extension-field.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-extension-field/motion-extension-field.component.html
@@ -8,7 +8,7 @@
     </mat-menu>
     <os-icon-container
         icon="create"
-        iconTooltip="{{ 'Edit' | translate }}"
+        [iconTooltip]="'Edit' | translate"
         [noFill]="true"
         [showIcon]="!editMode && canBeEdited && hasExtension"
         [swap]="true"
@@ -47,8 +47,8 @@
             <mat-form-field [formGroup]="extensionFieldForm">
                 <mat-label>{{ list.label ?? '' | translate }}</mat-label>
                 <os-list-search-selector
-                    formControlName="{{ 'list' + i + '' }}"
                     [disableOptionWhenFn]="getIsDisabled(i)"
+                    [formControlName]="'list' + i + ''"
                     [inputListValues]="list.observable"
                     [keepOpen]="list.keepOpen"
                     [wider]="list.wider"

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-highlight-form/motion-highlight-form.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-highlight-form/motion-highlight-form.component.html
@@ -64,8 +64,8 @@
             @if (showCreateFinalVersionButton) {
                 <button
                     mat-icon-button
-                    matTooltip="{{ 'Create editorial final version' | translate }}"
                     type="button"
+                    [matTooltip]="'Create editorial final version' | translate"
                     (click)="createModifiedFinalVersion()"
                 >
                     <mat-icon>file_copy</mat-icon>
@@ -76,8 +76,8 @@
                 @if (!isEditingFinalVersion) {
                     <button
                         mat-icon-button
-                        matTooltip="{{ 'Edit editorial final version' | translate }}"
                         type="button"
+                        [matTooltip]="'Edit editorial final version' | translate"
                         (click)="editModifiedFinalVersion()"
                     >
                         <mat-icon>edit</mat-icon>
@@ -86,8 +86,8 @@
                     <!-- save final version -->
                     <button
                         mat-icon-button
-                        matTooltip="{{ 'Save editorial final version' | translate }}"
                         type="button"
+                        [matTooltip]="'Save editorial final version' | translate"
                         (click)="saveModifiedFinalVersion()"
                     >
                         <mat-icon>done</mat-icon>
@@ -96,8 +96,8 @@
                     <!-- cancel final version edit -->
                     <button
                         mat-icon-button
-                        matTooltip="{{ 'Cancel editing without saving' | translate }}"
                         type="button"
+                        [matTooltip]="'Cancel editing without saving' | translate"
                         (click)="cancelEditingModifiedFinalVersion()"
                     >
                         <mat-icon>close</mat-icon>
@@ -107,8 +107,8 @@
                     <button
                         class="red-warning-text"
                         mat-icon-button
-                        matTooltip="{{ 'Delete editorial final version' | translate }}"
                         type="button"
+                        [matTooltip]="'Delete editorial final version' | translate"
                         (click)="deleteModifiedFinalVersion()"
                     >
                         <mat-icon>delete</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-motion-meeting-users/motion-manage-motion-meeting-users.component.html
@@ -42,8 +42,8 @@
                     <span>
                         <button
                             mat-icon-button
-                            matTooltip="{{ 'Remove' | translate }}"
                             type="button"
+                            [matTooltip]="'Remove' | translate"
                             (click)="onRemove(user)"
                         >
                             <mat-icon>close</mat-icon>
@@ -54,8 +54,8 @@
         </os-sorting-list>
         <div class="text-field-container">
             <os-participant-search-selector
-                placeholder="{{ 'Select participant' | translate }}"
                 [nonSelectableUserIds]="nonSelectableUserIds"
+                [placeholder]="'Select participant' | translate"
                 (userSelected)="addUser($event)"
             ></os-participant-search-selector>
         </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-supporters/motion-manage-supporters.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-supporters/motion-manage-supporters.component.html
@@ -45,8 +45,8 @@
                             <span>
                                 <button
                                     mat-icon-button
-                                    matTooltip="{{ 'Remove' | translate }}"
                                     type="button"
+                                    [matTooltip]="'Remove' | translate"
                                     (click)="onRemove(user)"
                                 >
                                     <mat-icon>close</mat-icon>
@@ -57,8 +57,8 @@
                 </os-sorting-list>
                 <div class="text-field-container">
                     <os-participant-search-selector
-                        placeholder="{{ 'Select participant' | translate }}"
                         [nonSelectableUserIds]="nonSelectableUserIds"
+                        [placeholder]="'Select participant' | translate"
                         (userSelected)="addUser($event)"
                     ></os-participant-search-selector>
                 </div>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-title/motion-manage-title.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-manage-title/motion-manage-title.component.html
@@ -25,9 +25,9 @@
                 append
                 class="primary-accent-by-theme"
                 mat-icon-button
-                matTooltip="{{ 'Mark as personal favorite' | translate }}"
                 matTooltipPosition="right"
                 [hidden]="publicAccess || isnotPartOfMeeting"
+                [matTooltip]="'Mark as personal favorite' | translate"
                 (click)="setFavorite(!isFavorite)"
             >
                 <mat-icon>{{ isFavorite ? 'star' : 'star_border' }}</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-meta-data/motion-meta-data.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-meta-data/motion-meta-data.component.html
@@ -4,14 +4,14 @@
         <div class="remove-top-margin">
             <os-motion-manage-motion-meeting-users
                 additionalInputField="additional_submitter"
-                additionalInputLabel="{{ 'Extension' | translate }}"
                 field="submitters"
-                secondSelectorLabel="{{ 'Committees' | translate }}"
-                title="{{ 'Submitters' | translate }}"
+                [additionalInputLabel]="'Extension' | translate"
                 [additionalInputValue]="$safeNavigationMigration(motion?.additional_submitter)"
                 [loadSecondSelectorValues]="loadForwardingCommittees"
                 [motion]="motion"
                 [repo]="motionSubmitterRepo"
+                [secondSelectorLabel]="'Committees' | translate"
+                [title]="'Submitters' | translate"
                 [useAdditionalInput]="true"
             ></os-motion-manage-motion-meeting-users>
         </div>
@@ -24,18 +24,18 @@
 <div *osMeetingSetting="'motions_enable_editor'; and: perms.isAllowed('change_metadata')">
     <os-motion-manage-motion-meeting-users
         field="editors"
-        title="{{ 'Motion editor' | translate }}"
         [motion]="motion"
         [repo]="motionEditorRepo"
+        [title]="'Motion editor' | translate"
     ></os-motion-manage-motion-meeting-users>
 </div>
 
 <div *osMeetingSetting="'motions_enable_working_group_speaker'; and: perms.isAllowed('change_metadata')">
     <os-motion-manage-motion-meeting-users
         field="working_group_speakers"
-        title="{{ 'Spokesperson' | translate }}"
         [motion]="motion"
         [repo]="motionWorkingGroupSpeakerRepo"
+        [title]="'Spokesperson' | translate"
     ></os-motion-manage-motion-meeting-users>
 </div>
 
@@ -43,16 +43,16 @@
 @if (motion.state$ | async; as motionState) {
     <div>
         <os-motion-extension-field
-            extensionLabel="{{ 'Extension' | translate }}"
-            title="{{ 'State' | translate }}"
             [canBeEdited]="
                 perms.isAllowed('change_state', motion) ||
                 (!!motionState.submitter_withdraw_state && operatorIsSubmitter)
             "
             [chipValue]="stateLabel"
             [classes]="motion.stateCssColor"
+            [extensionLabel]="'Extension' | translate"
             [hasExtension]="!!motionState && motionState.show_state_extension_field"
             [searchFieldInput]="$safeNavigationMigration(motion?.state_extension)"
+            [title]="'State' | translate"
             (succeeded)="setStateExtension($event)"
         >
             <span class="trigger-menu">
@@ -139,15 +139,15 @@
 @if (isRecommendationEnabled) {
     <div>
         <os-motion-extension-field
-            extensionLabel="{{ 'Extension' | translate }}"
-            title="{{ recommender }}"
             [canBeEdited]="perms.isAllowed('change_metadata', motion)"
             [chipValue]="recommendationLabel"
+            [extensionLabel]="'Extension' | translate"
             [hasExtension]="!!motion.recommendation && motion.recommendation.show_recommendation_extension_field"
             [internal]="$safeNavigationMigration(motion?.state?.is_internal)"
             [listValueTransformFns]="[motionTransformFn]"
             [searchFieldInput]="$safeNavigationMigration(motion?.recommendation_extension)"
             [searchLists]="searchLists"
+            [title]="recommender"
             (succeeded)="setRecommendationExtension($event)"
         >
             <span class="trigger-menu">
@@ -303,7 +303,7 @@
 }
 
 <!-- Workflow timestamp -->
-<os-motion-manage-timestamp field="workflow_timestamp" title="{{ 'Submission date' | translate }}" [motion]="motion" />
+<os-motion-manage-timestamp field="workflow_timestamp" [motion]="motion" [title]="'Submission date' | translate" />
 
 <!-- Created timestamp -->
 @if (motion?.created && perms.isAllowed('change_metadata', motion)) {

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-personal-note/motion-personal-note.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/motion-personal-note/motion-personal-note.component.html
@@ -7,20 +7,20 @@
     <!-- Actions -->
     <ng-container class="meta-text-block-action-row">
         @if (isEditing) {
-            <button color="warn" mat-icon-button matTooltip="{{ 'Save' | translate }}" (click)="savePersonalNote()">
+            <button color="warn" mat-icon-button [matTooltip]="'Save' | translate" (click)="savePersonalNote()">
                 <mat-icon>done</mat-icon>
             </button>
-            <button mat-icon-button matTooltip="{{ 'Cancel edit' | translate }}" (click)="leaveEditMode()">
+            <button mat-icon-button [matTooltip]="'Cancel edit' | translate" (click)="leaveEditMode()">
                 <mat-icon>close</mat-icon>
             </button>
         } @else {
-            <button mat-icon-button matTooltip="{{ 'Edit' | translate }}" (click)="editPersonalNote()">
+            <button mat-icon-button [matTooltip]="'Edit' | translate" (click)="editPersonalNote()">
                 <mat-icon>edit</mat-icon>
             </button>
             @if (personalNoteObservable | async) {
                 <button
                     mat-icon-button
-                    matTooltip="{{ 'Export personal note only' | translate }}"
+                    [matTooltip]="'Export personal note only' | translate"
                     (click)="printPersonalNote()"
                 >
                     <mat-icon>picture_as_pdf</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/origin-motion-meta-data/origin-motion-meta-data.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-detail/pages/motion-view/components/origin-motion-meta-data/origin-motion-meta-data.component.html
@@ -23,15 +23,15 @@
             <div class="remove-top-margin">
                 <os-motion-manage-motion-meeting-users
                     additionalInputField="additional_submitter"
-                    additionalInputLabel="{{ 'Extension' | translate }}"
                     field="submitters"
-                    secondSelectorLabel="{{ 'Committees' | translate }}"
-                    title="{{ 'Submitters' | translate }}"
+                    [additionalInputLabel]="'Extension' | translate"
                     [additionalInputValue]="motion.additional_submitter"
                     [disableEdit]="true"
                     [loadSecondSelectorValues]="loadForwardingCommittees"
                     [motion]="motion"
                     [repo]="motionSubmitterRepo"
+                    [secondSelectorLabel]="'Committees' | translate"
+                    [title]="'Submitters' | translate"
                     [useAdditionalInput]="true"
                 ></os-motion-manage-motion-meeting-users>
             </div>
@@ -42,13 +42,13 @@
     @if (motion.state$ | async; as motionState) {
         <div>
             <os-motion-extension-field
-                extensionLabel="{{ 'Extension' | translate }}"
-                title="{{ 'State' | translate }}"
                 [canBeEdited]="false"
                 [chipValue]="stateLabel"
                 [classes]="motion.stateCssColor"
+                [extensionLabel]="'Extension' | translate"
                 [hasExtension]="!!motionState && motionState.show_state_extension_field"
                 [searchFieldInput]="motion.state_extension"
+                [title]="'State' | translate"
             ></os-motion-extension-field>
         </div>
     }
@@ -57,9 +57,9 @@
     @if (isRecommendationEnabled) {
         <div>
             <os-motion-extension-field
-                extensionLabel="{{ 'Extension' | translate }}"
                 [canBeEdited]="false"
                 [chipValue]="recommendationLabel"
+                [extensionLabel]="'Extension' | translate"
                 [hasExtension]="!!motion.recommendation && motion.recommendation.show_recommendation_extension_field"
                 [internal]="$safeNavigationMigration(motion?.state?.is_internal)"
                 [listValueTransformFns]="[motionTransformFn]"

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-list/components/motion-list/motion-list.component.html
@@ -28,7 +28,7 @@
                 @if (selectedView === 'list') {
                     <button
                         mat-button
-                        matTooltip="{{ 'Tile view' | translate }}"
+                        [matTooltip]="'Tile view' | translate"
                         [matTooltipShowDelay]="500"
                         (click)="onChangeView('tiles')"
                     >
@@ -38,7 +38,7 @@
                 @if (selectedView === 'tiles') {
                     <button
                         mat-button
-                        matTooltip="{{ 'List view' | translate }}"
+                        [matTooltip]="'List view' | translate"
                         [matTooltipShowDelay]="500"
                         (click)="onChangeView('list')"
                     >

--- a/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-detail/motion-poll-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/motion-polls/components/motion-poll-detail/motion-poll-detail.component.html
@@ -57,7 +57,7 @@
 
         @if (showResults && poll.stateHasVotes && poll.isEVoting) {
             <mat-tab-group (selectedTabChange)="onTabChange()">
-                <mat-tab label="{{ 'Single votes' | translate }}">
+                <mat-tab [label]="'Single votes' | translate">
                     <div class="named-result-table">
                         <os-votes-table
                             [filterProps]="filterPropsSingleVotesTable"
@@ -67,7 +67,7 @@
                         ></os-votes-table>
                     </div>
                 </mat-tab>
-                <mat-tab label="{{ 'Entitled users' | translate }}">
+                <mat-tab [label]="'Entitled users' | translate">
                     <os-entitled-users-table
                         [displayDelegation]="displayDelegation"
                         [displayVoteWeight]="displayVoteWeight"
@@ -78,12 +78,12 @@
             </mat-tab-group>
         } @else if (poll.isEVoting && poll.isStarted) {
             <mat-tab-group>
-                <mat-tab label="{{ 'Single votes' | translate }}">
+                <mat-tab [label]="'Single votes' | translate">
                     <div class="no-content no-data-margins">
                         {{ 'No data available' | translate }}
                     </div>
                 </mat-tab>
-                <mat-tab *osPerms="permission.motionCanManagePolls" label="{{ 'Entitled users' | translate }}">
+                <mat-tab *osPerms="permission.motionCanManagePolls" [label]="'Entitled users' | translate">
                     <os-entitled-users-table
                         [displayDelegation]="displayDelegation"
                         [displayVoteWeight]="displayVoteWeight"

--- a/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-list/workflow-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/motions/pages/workflows/components/workflow-list/workflow-list.component.html
@@ -51,8 +51,8 @@
         @if (!isMultiSelect) {
             <button
                 mat-icon-button
-                matTooltip="{{ 'Delete' | translate }}"
                 type="button"
+                [matTooltip]="'Delete' | translate"
                 (click)="onDeleteWorkflow(workflow)"
             >
                 <mat-icon color="warn">delete</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-edit/participant-detail-edit.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/components/participant-detail-edit/participant-detail-edit.component.html
@@ -37,8 +37,8 @@
                 <div [formGroup]="form">
                     <mat-checkbox
                         formControlName="is_present"
-                        matTooltip="{{ 'Designates whether this user is in the room.' | translate }}"
                         matTooltipPosition="right"
+                        [matTooltip]="'Designates whether this user is in the room.' | translate"
                     >
                         <span>{{ 'present' | translate }}</span>
                     </mat-checkbox>
@@ -47,8 +47,8 @@
                     <!-- Locked out? -->
                     <mat-checkbox
                         formControlName="locked_out"
-                        matTooltip="{{ 'Lock out user from this meeting.' | translate }}"
                         matTooltipPosition="right"
+                        [matTooltip]="'Lock out user from this meeting.' | translate"
                     >
                         <span>{{ 'locked out' | translate }}</span>
                     </mat-checkbox>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-detail/pages/participant-detail-manage/components/participant-create-wizard/participant-create-wizard.component.html
@@ -145,16 +145,16 @@
                             <div [formGroup]="form">
                                 <mat-checkbox
                                     formControlName="is_present"
-                                    matTooltip="{{ 'Designates whether this user is in the room.' | translate }}"
                                     matTooltipPosition="right"
+                                    [matTooltip]="'Designates whether this user is in the room.' | translate"
                                 >
                                     <span>{{ 'present' | translate }}</span>
                                 </mat-checkbox>
                                 <!-- Locked out? -->
                                 <mat-checkbox
                                     formControlName="locked_out"
-                                    matTooltip="{{ 'Lock out user from this meeting.' | translate }}"
                                     matTooltipPosition="right"
+                                    [matTooltip]="'Lock out user from this meeting.' | translate"
                                 >
                                     <span>{{ 'locked out' | translate }}</span>
                                 </mat-checkbox>

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-import/components/participant-import-list/participant-import-list.component.html
@@ -14,11 +14,11 @@
 </os-head-bar>
 
 <os-backend-import-list
-    additionalInfo="{{
+    modelName="Participant"
+    [additionalInfo]="
         'Existing accounts can be reused or updated by using: <ul><li>Membership number <i>(recommended)</i><li>Username<li>Email address AND first name AND last name'
             | translate
-    }}"
-    modelName="Participant"
+    "
     [defaultColumns]="columns"
     [importer]="importer"
     [possibleFields]="possibleFields"

--- a/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/participants/pages/participant-list/components/participant-list/participant-list.component.html
@@ -108,10 +108,10 @@
             </div>
             <div class="icon-group">
                 @if (!user.is_physical_person) {
-                    <mat-icon matTooltip="{{ 'Is no natural person' | translate }}">account_balance</mat-icon>
+                    <mat-icon [matTooltip]="'Is no natural person' | translate">account_balance</mat-icon>
                 }
                 @if (user.hasSamlId && canSeeSensitiveData) {
-                    <mat-icon matTooltip="{{ 'Has SSO identification' | translate }}">fingerprint</mat-icon>
+                    <mat-icon [matTooltip]="'Has SSO identification' | translate">fingerprint</mat-icon>
                 }
             </div>
         </div>
@@ -163,8 +163,8 @@
             @if (user.vote_delegated_to() && voteDelegationEnabled) {
                 <div
                     class="spacer-top-5"
-                    matTooltip="{{ 'Voting right delegated to (proxy)' | translate }}"
                     matTooltipPosition="left"
+                    [matTooltip]="'Voting right delegated to (proxy)' | translate"
                 >
                     <os-icon-container
                         icon="forward"
@@ -180,8 +180,8 @@
             @if (user.vote_delegations_from_ids()?.length && voteDelegationEnabled) {
                 <div
                     class="spacer-top-5"
-                    matTooltip="{{ 'Voting right received from (principals)' | translate }}"
                     matTooltipPosition="left"
+                    [matTooltip]="'Voting right received from (principals)' | translate"
                 >
                     <os-icon-container
                         icon="work"
@@ -215,7 +215,7 @@
             <!-- Has comment indicator -->
             <div *osPerms="permission.userCanUpdate">
                 @if (!!user.comment()) {
-                    <mat-icon inline matTooltip="{{ user.comment() }}">comment</mat-icon>
+                    <mat-icon inline [matTooltip]="user.comment()">comment</mat-icon>
                 }
             </div>
         </div>

--- a/client/src/app/site/pages/meetings/pages/polls/modules/poll-list/components/poll-list/poll-list.component.html
+++ b/client/src/app/site/pages/meetings/pages/polls/modules/poll-list/components/poll-list/poll-list.component.html
@@ -44,9 +44,9 @@
         class="cell-slot fill"
     >
         @if (canBeVoteFor(poll)) {
-            <mat-icon color="warn" matTooltip="{{ 'Voting is currently in progress.' | translate }}">warning</mat-icon>
+            <mat-icon color="warn" [matTooltip]="'Voting is currently in progress.' | translate">warning</mat-icon>
         } @else {
-            <mat-icon color="accent" matTooltip="{{ 'You have already voted.' | translate }}">check_circle</mat-icon>
+            <mat-icon color="accent" [matTooltip]="'You have already voted.' | translate">check_circle</mat-icon>
         }
     </div>
 </os-projectable-list>

--- a/client/src/app/site/pages/meetings/pages/projectors/components/projector-edit-dialog/components/projector-edit-dialog/projector-edit-dialog.component.html
+++ b/client/src/app/site/pages/meetings/pages/projectors/components/projector-edit-dialog/components/projector-edit-dialog/projector-edit-dialog.component.html
@@ -117,8 +117,8 @@
                             <button
                                 mat-icon-button
                                 matSuffix
-                                matTooltip="{{ 'Reset' | translate }}"
                                 type="button"
+                                [matTooltip]="'Reset' | translate"
                                 (click)="resetField(form)"
                             >
                                 <mat-icon>replay</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/countdown-controls/countdown-controls.component.html
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/countdown-controls/countdown-controls.component.html
@@ -14,8 +14,8 @@
                     <button
                         class="small-mat-icon-button"
                         mat-icon-button
-                        matTooltip="{{ 'Open projection dialog' | translate }}"
                         type="button"
+                        [matTooltip]="'Open projection dialog' | translate"
                         (click)="onBringDialog()"
                     >
                         <mat-icon>open_in_new</mat-icon>
@@ -43,8 +43,8 @@
                         <button
                             class="small-mat-icon-button"
                             mat-icon-button
-                            matTooltip="{{ 'Delete' | translate }}"
                             type="button"
+                            [matTooltip]="'Delete' | translate"
                             (click)="onDelete()"
                         >
                             <mat-icon>close</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/message-controls/message-controls.component.html
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/message-controls/message-controls.component.html
@@ -10,9 +10,9 @@
                     <button
                         class="small-mat-icon-button"
                         mat-icon-button
-                        matTooltip="{{ 'Open projection dialog' | translate }}"
                         matTooltipPosition="left"
                         type="button"
+                        [matTooltip]="'Open projection dialog' | translate"
                         (click)="onBringDialog()"
                     >
                         <mat-icon>open_in_new</mat-icon>
@@ -20,9 +20,9 @@
                     <button
                         class="small-mat-icon-button"
                         mat-icon-button
-                        matTooltip="{{ 'Edit' | translate }}"
                         matTooltipPosition="left"
                         type="button"
+                        [matTooltip]="'Edit' | translate"
                         (click)="onEdit()"
                     >
                         <mat-icon>edit</mat-icon>
@@ -30,9 +30,9 @@
                     <button
                         class="small-mat-icon-button"
                         mat-icon-button
-                        matTooltip="{{ 'Delete' | translate }}"
                         matTooltipPosition="left"
                         type="button"
+                        [matTooltip]="'Delete' | translate"
                         (click)="onDelete()"
                     >
                         <mat-icon>close</mat-icon>

--- a/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/projector-detail/projector-detail.component.html
+++ b/client/src/app/site/pages/meetings/pages/projectors/modules/projector-detail/components/projector-detail/projector-detail.component.html
@@ -74,8 +74,8 @@
                             <!-- scale down -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Zoom out' | translate }}"
                                 type="button"
+                                [matTooltip]="'Zoom out' | translate"
                                 (click)="scale(scrollScaleDirection.Down)"
                             >
                                 <mat-icon>zoom_out</mat-icon>
@@ -83,8 +83,8 @@
                             <!-- scale up -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Zoom in' | translate }}"
                                 type="button"
+                                [matTooltip]="'Zoom in' | translate"
                                 (click)="scale(scrollScaleDirection.Up)"
                             >
                                 <mat-icon>zoom_in</mat-icon>
@@ -92,8 +92,8 @@
                             <!-- reset button -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Reset' | translate }}"
                                 type="button"
+                                [matTooltip]="'Reset' | translate"
                                 (click)="scale(scrollScaleDirection.Reset)"
                             >
                                 <mat-icon>refresh</mat-icon>
@@ -105,9 +105,9 @@
                             <!-- scroll viewport up (fast), decrease scroll counter -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Scroll up (big step)' | translate }}"
                                 type="button"
                                 [disabled]="projector.scroll <= 4"
+                                [matTooltip]="'Scroll up (big step)' | translate"
                                 (click)="scroll(scrollScaleDirection.Down, 5)"
                             >
                                 <mat-icon>arrow_upward</mat-icon>
@@ -115,9 +115,9 @@
                             <!-- scroll viewport up (slow), decrease scroll counter -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Scroll up' | translate }}"
                                 type="button"
                                 [disabled]="projector.scroll <= 0"
+                                [matTooltip]="'Scroll up' | translate"
                                 (click)="scroll(scrollScaleDirection.Down)"
                             >
                                 <mat-icon>arrow_drop_up</mat-icon>
@@ -125,8 +125,8 @@
                             <!-- scroll viewport down (slow), increase scroll counter -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Scroll down' | translate }}"
                                 type="button"
+                                [matTooltip]="'Scroll down' | translate"
                                 (click)="scroll(scrollScaleDirection.Up)"
                             >
                                 <mat-icon>arrow_drop_down</mat-icon>
@@ -134,8 +134,8 @@
                             <!-- scroll viewport down (fast), increase scroll counter -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Scroll down (big step)' | translate }}"
                                 type="button"
+                                [matTooltip]="'Scroll down (big step)' | translate"
                                 (click)="scroll(scrollScaleDirection.Up, 5)"
                             >
                                 <mat-icon>arrow_downward</mat-icon>
@@ -143,8 +143,8 @@
                             <!-- reset button -->
                             <button
                                 mat-icon-button
-                                matTooltip="{{ 'Reset' | translate }}"
                                 type="button"
+                                [matTooltip]="'Reset' | translate"
                                 (click)="scroll(scrollScaleDirection.Reset)"
                             >
                                 <mat-icon>refresh</mat-icon>
@@ -203,8 +203,8 @@
                                             </span>
                                             <button
                                                 mat-icon-button
-                                                matTooltip="{{ 'Clear current projection' | translate }}"
                                                 type="button"
+                                                [matTooltip]="'Clear current projection' | translate"
                                                 (click)="deleteProjection(projection)"
                                             >
                                                 <mat-icon>close</mat-icon>
@@ -270,8 +270,8 @@
                                                     <div>
                                                         <button
                                                             mat-icon-button
-                                                            matTooltip="{{ 'Delete' | translate }}"
                                                             type="button"
+                                                            [matTooltip]="'Delete' | translate"
                                                             (click)="deleteProjection(projection)"
                                                         >
                                                             <mat-icon>delete</mat-icon>
@@ -286,8 +286,8 @@
                                     @if (!editQueue) {
                                         <button
                                             mat-icon-button
-                                            matTooltip="{{ 'Edit queue' | translate }}"
                                             type="button"
+                                            [matTooltip]="'Edit queue' | translate"
                                             (click)="editQueue = !editQueue"
                                         >
                                             <mat-icon>edit</mat-icon>
@@ -296,8 +296,8 @@
                                     @if (editQueue) {
                                         <button
                                             mat-icon-button
-                                            matTooltip="{{ 'Close edit mode' | translate }}"
                                             type="button"
+                                            [matTooltip]="'Close edit mode' | translate"
                                             (click)="editQueue = !editQueue"
                                         >
                                             <mat-icon>close</mat-icon>

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail/account-detail.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-detail/components/account-detail/account-detail.component.html
@@ -197,7 +197,7 @@
                                     <td class="admin-column">
                                         @if (row.value.is_manager) {
                                             <mat-icon
-                                                matTooltip="{{ 'Committee admin' | translate }}"
+                                                [matTooltip]="'Committee admin' | translate"
                                                 [matTooltipPosition]="'left'"
                                             >
                                                 engineering
@@ -227,7 +227,7 @@
                                     <td class="admin-column" [attr.rowspan]="getNumberOfKeys(row.value.meetings)">
                                         @if (row.value.is_manager) {
                                             <mat-icon
-                                                matTooltip="{{ 'Committee admin' | translate }}"
+                                                [matTooltip]="'Committee admin' | translate"
                                                 [matTooltipPosition]="'left'"
                                             >
                                                 engineering

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-import/components/account-import-list/account-import-list.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-import/components/account-import-list/account-import-list.component.html
@@ -14,11 +14,11 @@
 </os-head-bar>
 
 <os-backend-import-list
-    additionalInfo="{{
+    modelName="Account"
+    [additionalInfo]="
         'Existing accounts can be reused or updated by using: <ul><li>Membership number <i>(recommended)</i><li>Username<li>Email address AND first name AND last name'
             | translate
-    }}"
-    modelName="Account"
+    "
     [defaultColumns]="columns"
     [importer]="importer"
     [possibleFields]="possibleFields"

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-list/account-list.component.html
@@ -53,20 +53,20 @@
                         @if (!user.is_physical_person) {
                             <os-icon-container
                                 icon="account_balance"
-                                matTooltip="{{ 'Is no natural person' | translate }}"
+                                [matTooltip]="'Is no natural person' | translate"
                             ></os-icon-container>
                         }
                         @if (!user.is_active) {
                             <os-icon-container
                                 class="red-warning-text"
                                 icon="do_not_disturb_on"
-                                matTooltip="{{ 'Inactive' | translate }}"
+                                [matTooltip]="'Inactive' | translate"
                             ></os-icon-container>
                         }
                         @if (user.hasSamlId) {
                             <os-icon-container
                                 icon="fingerprint"
-                                matTooltip="{{ 'Has SSO identification' | translate }}"
+                                [matTooltip]="'Has SSO identification' | translate"
                             ></os-icon-container>
                         }
                     </div>
@@ -94,8 +94,8 @@
             @if (!!user.meetings?.length) {
                 <os-icon-container
                     icon="event_available"
-                    matTooltip="{{ 'Meetings' | translate }}"
                     matTooltipPosition="left"
+                    [matTooltip]="'Meetings' | translate"
                     [noWrap]="true"
                     [showIcon]="true"
                 >
@@ -116,8 +116,8 @@
             <os-icon-container
                 *osOmlPerms="OML.can_manage_users; allowCommitteeAdmin: true; and: !!getOmlByUser(user)"
                 icon="engineering"
-                matTooltip="{{ getOmlByUser(user) | translate }}"
                 matTooltipPosition="left"
+                [matTooltip]="getOmlByUser(user) | translate"
                 [matTooltipDisabled]="!isMobile"
             >
                 @if (!isMobile) {

--- a/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-merge-dialog/account-merge-dialog.component.html
+++ b/client/src/app/site/pages/organization/pages/accounts/pages/account-list/components/account-merge-dialog/account-merge-dialog.component.html
@@ -40,19 +40,19 @@
                                 @if (!user.is_physical_person) {
                                     <os-icon-container
                                         icon="account_balance"
-                                        matTooltip="{{ 'Is no natural person' | translate }}"
+                                        [matTooltip]="'Is no natural person' | translate"
                                     ></os-icon-container>
                                 }
                                 @if (!user.is_active) {
                                     <os-icon-container
                                         icon="block"
-                                        matTooltip="{{ 'Inactive' | translate }}"
+                                        [matTooltip]="'Inactive' | translate"
                                     ></os-icon-container>
                                 }
                                 @if (user.hasSamlId) {
                                     <os-icon-container
                                         icon="fingerprint"
-                                        matTooltip="{{ 'Has SSO identification' | translate }}"
+                                        [matTooltip]="'Has SSO identification' | translate"
                                     ></os-icon-container>
                                 }
                             </div>

--- a/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/modules/committee-meeting-preview/committee-meeting-preview.component.html
@@ -72,11 +72,7 @@
             </a>
         }
         @if (!canEnter) {
-            <span
-                matTooltip="{{
-                    'You cannot enter this meeting because you are not assigned to any group.' | translate
-                }}"
-            >
+            <span [matTooltip]="'You cannot enter this meeting because you are not assigned to any group.' | translate">
                 <button color="accent" mat-stroked-button [disabled]="true">
                     {{ 'Open meeting' | translate }}
                 </button>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-meeting/components/meeting-edit/meeting-edit.component.html
@@ -83,7 +83,7 @@
                 </mat-autocomplete>
             </mat-form-field>
 
-            <os-daterangepicker formControlName="daterange" title="{{ 'Meeting date' }}"></os-daterangepicker>
+            <os-daterangepicker formControlName="daterange" [title]="'Meeting date'"></os-daterangepicker>
 
             <mat-form-field>
                 <mat-label>{{ 'Administrators' | translate }}</mat-label>

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-detail/modules/committee-detail-view/components/committee-detail-view/committee-detail-view.component.html
@@ -63,7 +63,7 @@
             </div>
             <!-- forward motions to -->
             @if (committee.forward_to_committee_ids?.length > 0 && isOrgaAdmin()) {
-                <os-committee-meta-info icon="file_upload" title="{{ 'Forward motions to' | translate }}">
+                <os-committee-meta-info icon="file_upload" [title]="'Forward motions to' | translate">
                     <ul class="content-list expandable-list" [class.expanded]="forwardingExpanded">
                         @for (
                             forwarding of sortCommitteesByName(committee.forward_to_committee_ids);
@@ -99,7 +99,7 @@
             }
             <!-- receive motions from -->
             @if (committee.receive_forwardings_from_committee_ids?.length > 0 && isOrgaAdmin()) {
-                <os-committee-meta-info icon="file_download" title="{{ 'Receive motions from' | translate }}">
+                <os-committee-meta-info icon="file_download" [title]="'Receive motions from' | translate">
                     <ul class="content-list expandable-list" [class.expanded]="receiveExpanded">
                         @for (
                             receive of sortCommitteesByName(committee.receive_forwardings_from_committee_ids);
@@ -135,7 +135,7 @@
             }
             <!-- Member amount -->
             @if (canManageCommittee) {
-                <os-committee-meta-info icon="engineering" title="{{ 'Committee admin' | translate }}">
+                <os-committee-meta-info icon="engineering" [title]="'Committee admin' | translate">
                     @if (committee.getManagers(); as managers) {
                         <os-comma-separated-listing [list]="managers">
                             <ng-template let-manager>
@@ -157,7 +157,7 @@
                     }
                 </os-committee-meta-info>
                 <!-- Numbers of accounts -->
-                <os-committee-meta-info icon="person" title="{{ 'Accounts' | translate }}">
+                <os-committee-meta-info icon="person" [title]="'Accounts' | translate">
                     <div>
                         <b>{{ accountNumber }}</b>
                         @if ((childCommitteesObservable | async).length > 0) {

--- a/client/src/app/site/pages/organization/pages/committees/pages/committee-list/components/committee-list/committee-list.component.html
+++ b/client/src/app/site/pages/organization/pages/committees/pages/committee-list/components/committee-list/committee-list.component.html
@@ -65,8 +65,8 @@
                 <div>
                     <os-icon-container
                         icon="file_upload"
-                        iconTooltip="{{ 'Can forward motions to committee' | translate }}"
                         iconTooltipPosition="left"
+                        [iconTooltip]="'Can forward motions to committee' | translate"
                         [noWrap]="true"
                     >
                         <span>
@@ -82,8 +82,8 @@
                 <div>
                     <os-icon-container
                         icon="file_download"
-                        iconTooltip="{{ 'Can receive motions from committee' | translate }}"
                         iconTooltipPosition="left"
+                        [iconTooltip]="'Can receive motions from committee' | translate"
                         [noWrap]="true"
                     >
                         <span>
@@ -102,8 +102,8 @@
                     <div>
                         <os-icon-container
                             icon="event_available"
-                            iconTooltip="{{ 'Meetings' | translate }}"
                             iconTooltipPosition="right"
+                            [iconTooltip]="'Meetings' | translate"
                         >
                             {{ committee.meetingAmount }}
                         </os-icon-container>
@@ -113,8 +113,8 @@
                     <div>
                         <os-icon-container
                             icon="layers"
-                            iconTooltip="{{ 'Subcommittees' | translate }}"
                             iconTooltipPosition="right"
+                            [iconTooltip]="'Subcommittees' | translate"
                         >
                             {{ getCommitteeChildrenNumber(committee) }}
                         </os-icon-container>
@@ -126,8 +126,8 @@
                     <div>
                         <os-icon-container
                             icon="group"
-                            iconTooltip="{{ 'Accounts' | translate }}"
                             iconTooltipPosition="right"
+                            [iconTooltip]="'Accounts' | translate"
                         >
                             {{ committee.memberAmount }}
                         </os-icon-container>
@@ -137,8 +137,8 @@
                     <div>
                         <os-icon-container
                             icon="engineering"
-                            iconTooltip="{{ 'Committee management' | translate }}"
                             iconTooltipPosition="right"
+                            [iconTooltip]="'Committee management' | translate"
                         >
                             {{ committee.managerAmount }}
                         </os-icon-container>

--- a/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
+++ b/client/src/app/site/pages/organization/pages/dashboard/pages/dashboard-detail/components/dashboard/dashboard.component.html
@@ -177,16 +177,16 @@
             </div>
         }
         @if (meeting.isArchived) {
-            <mat-icon matTooltip="{{ 'This meeting is archived' | translate }}">archive</mat-icon>
+            <mat-icon [matTooltip]="'This meeting is archived' | translate">archive</mat-icon>
         }
         @if (meeting.publicAccessPossible() && !operator.isAnonymous) {
-            <mat-icon matTooltip="{{ 'This meeting is public' | translate }}">public</mat-icon>
+            <mat-icon [matTooltip]="'This meeting is public' | translate">public</mat-icon>
         }
         @if (meeting.committee_id) {
             <a
                 class="show-committee-link"
                 mat-icon-button
-                matTooltip="{{ 'Show committee' | translate }}"
+                [matTooltip]="'Show committee' | translate"
                 [routerLink]="['/', 'committees', meeting.committee_id]"
             >
                 <mat-icon class="show-committee-icon">layers</mat-icon>

--- a/client/src/app/site/pages/organization/pages/designs/modules/theme-builder-dialog/components/theme-builder-dialog.component.html
+++ b/client/src/app/site/pages/organization/pages/designs/modules/theme-builder-dialog/components/theme-builder-dialog.component.html
@@ -20,8 +20,8 @@
                     <div>
                         <div>
                             <os-color-form-field
-                                title="{{ title | translate }}"
                                 [formControlName]="createFormControlName(palette, '500')"
+                                [title]="title | translate"
                                 (resetted)="resetField(palette)"
                             ></os-color-form-field>
                         </div>
@@ -45,8 +45,8 @@
                     <div>
                         <os-color-form-field
                             formControlName="headbar"
-                            title="{{ 'Global headbar color' | translate }}"
                             [defaultDisplayColor]="getDefaultColor('headbar')"
+                            [title]="'Global headbar color' | translate"
                             (resetted)="resetField('headbar')"
                         ></os-color-form-field>
                     </div>
@@ -59,9 +59,9 @@
                     <div>
                         <div>
                             <os-color-form-field
-                                title="{{ title | translate }}"
                                 [defaultDisplayColor]="getDefaultColor(place)"
                                 [formControlName]="place"
+                                [title]="title | translate"
                                 (resetted)="resetField(place)"
                             ></os-color-form-field>
                         </div>

--- a/client/src/app/site/pages/organization/pages/orga-meetings/pages/meeting-list/components/meeting-list/meeting-list.component.html
+++ b/client/src/app/site/pages/organization/pages/orga-meetings/pages/meeting-list/components/meeting-list/meeting-list.component.html
@@ -153,8 +153,8 @@
                 <div>
                     <os-icon-container
                         icon="group"
-                        iconTooltip="{{ 'Participants' | translate }}"
                         iconTooltipPosition="right"
+                        [iconTooltip]="'Participants' | translate"
                     >
                         {{ meeting.userAmount }}
                     </os-icon-container>
@@ -164,8 +164,8 @@
                 <div>
                     <os-icon-container
                         icon="assignment"
-                        iconTooltip="{{ 'Motions' | translate }}"
                         iconTooltipPosition="right"
+                        [iconTooltip]="'Motions' | translate"
                     >
                         {{ meeting.motionsAmount }}
                     </os-icon-container>

--- a/client/src/app/site/pages/organization/pages/organization-tags/modules/organization-tag-dialog/components/organization-tag-dialog.component.html
+++ b/client/src/app/site/pages/organization/pages/organization-tags/modules/organization-tag-dialog/components/organization-tag-dialog.component.html
@@ -8,12 +8,7 @@
         <mat-form-field appearance="fill">
             <mat-label>{{ 'Color' | translate }}</mat-label>
             <input formControlName="color" matInput type="color" [required]="isCreateView" />
-            <button
-                mat-icon-button
-                matSuffix
-                matTooltip="{{ 'Generate new color' | translate }}"
-                (click)="generateColor()"
-            >
+            <button mat-icon-button matSuffix [matTooltip]="'Generate new color' | translate" (click)="generateColor()">
                 <mat-icon>autorenew</mat-icon>
             </button>
             @if (hasColorFormError('pattern')) {

--- a/client/src/app/ui/modules/color-form-field/color-form-field.component.html
+++ b/client/src/app/ui/modules/color-form-field/color-form-field.component.html
@@ -1,7 +1,7 @@
 <mat-form-field class="color-picker-form">
     <mat-label>{{ title | translate }}</mat-label>
     <input matInput type="color" [formControl]="formControl" />
-    <button mat-icon-button matSuffix matTooltip="{{ 'Reset' | translate }}" type="button" (click)="onReset()">
+    <button mat-icon-button matSuffix type="button" [matTooltip]="'Reset' | translate" (click)="onReset()">
         <mat-icon>replay</mat-icon>
     </button>
 </mat-form-field>

--- a/client/src/app/ui/modules/file-list/file-list.component.html
+++ b/client/src/app/ui/modules/file-list/file-list.component.html
@@ -263,9 +263,9 @@
             <mat-label>{{ 'Upload to' | translate }}</mat-label>
             <os-list-search-selector
                 formControlName="directory_id"
-                noneTitle="{{ 'Base folder' | translate }}"
                 [includeNone]="true"
                 [inputListValues]="filteredDirectoryBehaviorSubject"
+                [noneTitle]="'Base folder' | translate"
             />
         </mat-form-field>
 

--- a/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.html
+++ b/client/src/app/ui/modules/file-upload/components/file-upload/file-upload.component.html
@@ -6,7 +6,7 @@
             <ngx-file-drop
                 contentClassName="file-drop-content-style"
                 dropZoneClassName="file-drop-zone-style"
-                dropZoneLabel="{{ 'Drop files into this area OR click here to select files' | translate }}"
+                [dropZoneLabel]="'Drop files into this area OR click here to select files' | translate"
                 (click)="fileInput.click()"
                 (onFileDrop)="onDropFile($event)"
             ></ngx-file-drop>
@@ -45,7 +45,7 @@
 <ng-template #tableTemplate>
     <os-scrolling-table vScrollFixed="50" [dataSource]="dataSource" [showHeader]="true" [tableHeight]="tableHeight">
         <div *osScrollingTableCell="'remove'; row as file; config: { width: 24 }">
-            <button mat-icon-button matTooltip="{{ 'Remove file' | translate }}" (click)="onRemoveButton(file)">
+            <button mat-icon-button [matTooltip]="'Remove file' | translate" (click)="onRemoveButton(file)">
                 <mat-icon>close</mat-icon>
             </button>
         </div>

--- a/client/src/app/ui/modules/head-bar/components/head-bar/head-bar.component.html
+++ b/client/src/app/ui/modules/head-bar/components/head-bar/head-bar.component.html
@@ -56,8 +56,8 @@
                 <button
                     data-cy="headbarMainButton"
                     mat-icon-button
-                    matTooltip="{{ mainActionTooltip | translate }}"
                     [disabled]="!isMainButtonEnabled"
+                    [matTooltip]="mainActionTooltip | translate"
                     [matTooltipShowDelay]="500"
                     (click)="sendMainEvent()"
                 >
@@ -91,8 +91,8 @@
         <button
             class="head-button"
             mat-fab
-            matTooltip="{{ mainActionTooltip | translate }}"
             [disabled]="!isMainButtonEnabled"
+            [matTooltip]="mainActionTooltip | translate"
             (click)="sendMainEvent()"
         >
             @if (mainButtonIcon === 'add_circle') {

--- a/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.html
+++ b/client/src/app/ui/modules/import-list/components/via-backend-import-list/backend-import-list.component.html
@@ -10,7 +10,7 @@
                     </mat-tab>
                 }
                 <!-- CSV import tab -->
-                <mat-tab label="{{ 'CSV import' | translate }}">
+                <mat-tab [label]="'CSV import' | translate">
                     <ng-template matTabContent>
                         <ng-container *ngTemplateOutlet="defaultTabContent" />
                     </ng-template>
@@ -152,7 +152,7 @@
                 <h2 class="no-margin">{{ 'Summary' | translate }}</h2>
                 <button
                     mat-icon-button
-                    matTooltip="{{ 'Fullscreen' | translate }}"
+                    [matTooltip]="'Fullscreen' | translate"
                     (click)="enterFullscreen(fullscreenDialog)"
                 >
                     <mat-icon>fullscreen</mat-icon>
@@ -403,12 +403,12 @@
                 class="flex-vertical-center"
             >
                 @if (row.state === 'error') {
-                    <mat-icon class="red-warning-text" matTooltip="{{ getRowTooltip(row) }}" matTooltipPosition="right">
+                    <mat-icon class="red-warning-text" matTooltipPosition="right" [matTooltip]="getRowTooltip(row)">
                         {{ getActionIcon(row) }}
                     </mat-icon>
                 }
                 @if (row.state !== 'error' && row.messages.length) {
-                    <mat-icon class="warn" matTooltip="{{ getWarningRowTooltip(row) }}" matTooltipPosition="right">
+                    <mat-icon class="warn" matTooltipPosition="right" [matTooltip]="getWarningRowTooltip(row)">
                         warning
                     </mat-icon>
                 }
@@ -418,7 +418,7 @@
                 class="flex-vertical-center"
             >
                 @if (row.state !== 'error') {
-                    <mat-icon matTooltip="{{ getRowTooltip(row) }}" matTooltipPosition="right">
+                    <mat-icon matTooltipPosition="right" [matTooltip]="getRowTooltip(row)">
                         {{ getActionIcon(row) }}
                     </mat-icon>
                 }
@@ -453,7 +453,7 @@
 <ng-template #fullscreenDialog>
     <div class="action-title" mat-dialog-title>
         <h1 class="dialog-title">{{ 'Preview' | translate }}</h1>
-        <button mat-icon-button matTooltip="{{ 'Exit fullscreen' | translate }}" [mat-dialog-close]="null">
+        <button mat-icon-button [mat-dialog-close]="null" [matTooltip]="'Exit fullscreen' | translate">
             <mat-icon>close</mat-icon>
         </button>
     </div>

--- a/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.html
+++ b/client/src/app/ui/modules/list/components/sort-filter-bar/sort-filter-bar.component.html
@@ -129,8 +129,8 @@
             <os-rounded-input
                 #searchField
                 iconName="manage_search"
-                placeholder="{{ 'Search' | translate }}"
                 [fullWidth]="false"
+                [placeholder]="'Search' | translate"
                 [size]="'small'"
                 [(ngModel)]="searchFieldInput"
                 (clickIcon)="toggleSearchEdit()"

--- a/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.html
+++ b/client/src/app/ui/modules/search-selector/components/base-search-selector/base-search-selector.component.html
@@ -27,8 +27,8 @@
             <input
                 class="background-card"
                 osAutofocus
-                placeholder="{{ 'Search' | translate }}"
                 [formControl]="searchValueForm"
+                [placeholder]="'Search' | translate"
                 (keydown)="onSearchKeydown($event)"
             />
         </div>


### PR DESCRIPTION
Long term substring interpolation should also be forbidden. Instead proper parametrized translation strings should be used. Right now I am too lazy to do that as this needs manual work. 
All usages of this are currently problematic. Therefore a new issue should be opened. 